### PR TITLE
docs: initial design spec for job-aggregator v1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+*.egg
+dist/
+build/
+wheels/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+htmlcov/
+.coverage
+.coverage.*
+coverage.xml
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+
+# uv
+# (uv.lock is committed intentionally for reproducibility)
+
+# Claude Code local settings
+.claude/settings.local.json
+
+# Git worktrees (local-only by convention)
+.worktrees/
+
+# IDE / editor
+.vscode/
+.idea/
+*.swp
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/docs/superpowers/plans/2026-04-23-job-aggregator-v1-execution-plan.md
+++ b/docs/superpowers/plans/2026-04-23-job-aggregator-v1-execution-plan.md
@@ -1,0 +1,393 @@
+# job-aggregator v1.0 — Phase 1 Execution Plan
+
+**Date:** 2026-04-23
+**Status:** Revised — all 7 open questions resolved by user; CI/tooling and public-package audits folded in
+**Author:** Christopher Beaulieu (with Claude Code, project-planner)
+**Source spec:** `docs/superpowers/specs/2026-04-23-job-aggregator-design.md` (v3-patched)
+**Scope:** Phase 1 only — standalone `job-aggregator` package v1.0. Phase 2 (`job-matcher-pr` migration; spec §12, Issues H-K) is explicitly **deferred** and acknowledged here only as the gated next phase.
+
+---
+
+## 1. Executive summary
+
+- **Critical path is dominated by the 10 per-plugin migration/audit issues (B1-B10).** Issue B (the new ABC + schemas) blocks them, but once B lands, B1-B10 can run in parallel — the long pole is whichever single plugin takes longest, not the sum.
+- **Three true serial gates:** Issue A (skeleton + full CI + public-package metadata) blocks everything; Issue B (ABC contract + exception hierarchy) blocks B1-B10, C, D, E, F; the new **Preflight** live-API smoke test (Q7) blocks B1-B10 from opening at all.
+- **Phase 1 is now split into two exit gates:** a **Code-complete gate** that can finish on its own schedule (green CI, deptry clean, all cassettes recorded, docs published, `v1.0.0-rc1` tag) and a **Ship gate** that depends on the external consumer's own readiness and produces the final `v1.0.0` PyPI release.
+- **Public-package readiness is now explicit.** `LICENSE`, `CHANGELOG.md`, full `pyproject.toml` metadata, `py.typed`, `__version__`, library-logger pattern, PyPI trusted publishing workflow, issue/PR templates, `CONTRIBUTING.md`, `SECURITY.md`, exception hierarchy, and README badges are all in Phase 1 scope — not deferred.
+- **Custom AST import-fence is dropped.** Replaced with `deptry` as a CI job — the invariant ("every import in `src/` must be declared or stdlib") maps more naturally to deptry's whitelist model than to a custom blacklist scanner.
+- **Biggest hidden risk** is the §11.5 metadata catalog — each row must carry all 7 attributes + code-citation justifications + rate-limit notes grounded in actual behavior. The plan below pins down what "done" means for one row and flags that rows with `?` values are not shippable.
+- **Milestone scaffolding:** one milestone (`job-aggregator v1`) with **19 issues** — Preflight, A, B, B1-B10, C, D, E, F, G, M — all created up front so the dependency graph is visible from day one.
+
+---
+
+## 2. Spec clarifications applied by this plan
+
+These reconcile inconsistencies noticed while planning. They are planning-layer decisions, not spec rewrites.
+
+### 2.1 PyPI publishing is Phase 1, not Phase 2
+
+Spec §12.3 implies PyPI publishing is Phase 2, but the v1.0 primary user story (§4 story #1) is `pip install job-aggregator`. These contradict. Resolution: **PyPI publishing infrastructure (trusted-publishing workflow, TestPyPI rehearsal) and the first publish both happen in Phase 1.** Phase 2's scope is narrowed to "`job-matcher-pr` switches its install source from editable-sibling to pinned PyPI version" — it is the *consumer migration*, not the *package publication*.
+
+### 2.2 Import-fence implementation: deptry instead of custom AST
+
+Spec §14.1 proposes a grep/AST scan of `src/job_aggregator/` for a blacklist of forbidden imports (`db`, `flask`, `psycopg2`, LLM clients, etc.). We replace this with **`deptry` as a CI job**. Rationale: the real invariant is "every import in `src/` must be declared in `pyproject.toml` dependencies or be in the Python stdlib." Deptry checks this directly via whitelist (declared deps) rather than blacklist (forbidden list). The no-DB / no-framework / no-LLM goal falls out for free because `psycopg2`, `flask`, `anthropic`, `openai`, `google.*` are never declared as dependencies. Zero custom test code to maintain. Post-Phase-2, augment with a clean-venv install smoke test in CI (Issue A's acceptance).
+
+### 2.3 N3 `--query` mixed-mode handling: both warning and envelope metadata
+
+User decided to implement both approaches (B + C) rather than pick one:
+
+- **B (stderr warning):** At `jobs` startup, if `--query` is passed and any enabled source has `accepts_query` in `{"never", "partial"}`, emit `WARNING: --query "<value>" will not apply to: <source_keys> (accepts_query=never)` to stderr.
+- **C (envelope metadata):** Add `query_applied: {source_key: bool}` to the envelope's `sources_used` section (or a sibling field). Programmatic consumers can assert on this.
+
+Both land in Issue D. Update §9.2 envelope example and §8.1 docstring accordingly.
+
+### 2.4 Deprecation policy anchor: PEP 387
+
+Any removal or breaking change to Identity / Always-present schema fields or the Python API must be preceded by at least one minor release that emits a `DeprecationWarning` and documents the coming change in `CHANGELOG.md`. Pure field renames may use dual-emit (both old and new keys present during the deprecation window) where feasible. This lives in `docs/output_schema.md` §9.5 (Issue G).
+
+### 2.5 §11.5 catalog row acceptance is tightened
+
+Each row must carry all 7 attributes + code-citation justifications (line ranges in the plugin's `fetch_page()`) + rate-limit notes grounded in actual behavior (quoted from official docs or explicitly marked "Unknown — not documented by source"). **No row may ship with a `?` value.** This is enforced in the B1-B10 issue template.
+
+---
+
+## 3. Pre-work checklist
+
+Resolve before Issue A is opened.
+
+- [x] **Confirm Python 3.11+** — uv will manage the interpreter via `.python-version = 3.11` (installs automatically on both dev and CI via `astral-sh/setup-uv`).
+- [x] **Confirm PyPI package name `job-aggregator` is unclaimed** — verified 2026-04-23: `https://pypi.org/pypi/job-aggregator/json` returns 404 (available).
+- [x] **Adopt uv for Python tooling** — all venv management, installs, and tool invocation use `uv` (not `pip` / `venv` / `virtualenv`). Lock file `uv.lock` committed; `.python-version` committed; CI uses `astral-sh/setup-uv@v3`.
+- [x] **Decide LICENSE** — **Resolved: MIT.** `pyproject.toml` sets `license = "MIT"` (SPDX); `LICENSE` file holds standard MIT text (© 2026 Christopher Beaulieu).
+- [ ] **Decide GitHub repo visibility** (affects PyPI trusted-publishing OIDC trust setup and whether external consumers can `pip install git+…`).
+- [ ] **Configure PyPI trusted publishing** (pending LICENSE/name decisions above) — register the project on PyPI and TestPyPI with the `cbeaulieu-gt/job-aggregator` repo + `publish.yml` workflow as the trusted publisher. No API tokens stored anywhere.
+- [ ] **Reserve the GitHub Milestone** `job-aggregator v1` before opening any issues.
+- [ ] **All 10 plugins' credentials are on hand.** (User confirmed: yes.) Cassettes will be recorded for all 10 plugins — including those with no credential requirement, to capture real HTTP shape.
+
+Resolved (documented here for traceability):
+
+- Q1 — §11.5 row acceptance: **confirmed as in §2.5 above.**
+- Q2 — Cassette coverage: **all 10 plugins get cassettes. No skip-cassette fallback.**
+- Q3 — Import enforcement: **deptry, per §2.2 above.** No custom AST scanner.
+- Q4 — `--query` mixed-mode: **both warning + envelope metadata, per §2.3.**
+- Q5 — Deprecation policy: **PEP 387 one-minor-release window, per §2.4.**
+- Q6 — External consumer: **not yet ready.** User will update consumer separately. Phase 1 exit is split into Code-complete gate + Ship gate (see §6).
+- Q7 — Pre-flight smoke test: **new Preflight issue added**, runs after B lands but before B1-B10 open. Classifies each plugin `green` / `needs-fixing` / `broken-defer-to-v1.1`.
+
+---
+
+## 4. Sequenced issue list with dependency graph
+
+```
+                         ┌─────────────────────────────┐
+                         │  A: Skeleton + full CI +    │
+                         │  public-package metadata    │
+                         │  (deptry, ruff, mypy,       │
+                         │  pytest, pip-audit, publish)│
+                         └──────────────┬──────────────┘
+                                        │
+                    ┌───────────────────┼──────────────────────┐
+                    │                   │                      │
+                    ▼                   ▼                      ▼
+        ┌──────────────────┐   ┌─────────────────┐   ┌─────────────────┐
+        │ B: ABC v3 +      │   │ M: Community    │   │ (G: docs —      │
+        │ PluginInfo/Field │   │ meta            │   │  draft only     │
+        │ + exception      │   │ (CONTRIBUTING,  │   │  until C/D/E/F) │
+        │ hierarchy        │   │  SECURITY, tpl) │   └─────────────────┘
+        └────────┬─────────┘   └─────────────────┘
+                 │
+                 ▼
+        ┌──────────────────────┐
+        │ Preflight: live-API  │
+        │ smoke test, 10 srcs  │
+        │ → green / needs-fix  │
+        │   / defer-to-v1.1    │
+        └────────┬─────────────┘
+                 │ Preflight + B both gate B1-B10
+    ┌────────────┼─────────────────────────────────┐
+    │            │                                 │
+    ▼            ▼                                 ▼
+┌───────────────────┐              ┌────────────────────────┐
+│ B1-B10 (parallel) │              │ C: JobRecord schema    │
+│ per-plugin audit  │              │    + record normalizer │
+│ + cassettes +     │              └───────────┬────────────┘
+│ §11.5 rows        │                          │ C blocks D, E
+└────────┬──────────┘                          ▼
+         │                       ┌──────────────────────────┐
+         │                       │ D: jobs orchestrator +   │
+         │                       │   formatters + dedup +   │
+         │                       │   --query warning +      │
+         │                       │   query_applied envelope │
+         │                       └──────────┬───────────────┘
+         │                                  ▼
+         │                       ┌──────────────────────────┐
+         │                       │ E: hydrate + move        │
+         │                       │   scrape_description +   │
+         │                       │   §8.2.1 input handling  │
+         │                       └──────────┬───────────────┘
+         │                                  │
+         │                                  ▼
+         │                       ┌──────────────────────────┐
+         │                       │ F: sources + list_plugins│
+         │                       │   / get_plugin API       │
+         │                       └──────────┬───────────────┘
+         │                                  │
+         └──────────┬───────────────────────┘
+                    ▼
+        ┌──────────────────────────────────────┐
+        │ G: docs final pass (README,          │
+        │ output_schema.md inc. PEP 387 policy,│
+        │ plugin_authoring.md, sample fixture) │
+        └────────────┬─────────────────────────┘
+                     │
+                     ▼
+        ┌──────────────────────────────────────┐
+        │ CODE-COMPLETE GATE:                  │
+        │  • all 5 CI jobs green on main       │
+        │  • deptry clean                      │
+        │  • 10 cassettes recorded             │
+        │  • §11.5 catalog full, no ?          │
+        │  • docs published                    │
+        │  • pip install . in clean venv OK    │
+        │  • v1.0.0-rc1 tag + draft Release    │
+        └────────────┬─────────────────────────┘
+                     │
+                     ▼
+        ┌──────────────────────────────────────┐
+        │ SHIP GATE (blocks v1.0 + Phase 2):   │
+        │  • external consumer integrates +    │
+        │    signs off against v1.0.0-rc1      │
+        │  • v1.0.0 tag → trusted-publish PyPI │
+        │  • job-matcher-pr Phase 2 unlocked   │
+        └──────────────────────────────────────┘
+```
+
+**Graph notes:**
+
+- **B1-B10 now depend on Preflight + B.** Preflight classifies each plugin before its migration issue opens for work; broken plugins either get scope amended or are deferred out of v1.0.
+- **M runs in parallel with B and the whole core arm** — it only touches meta files, no code dependency.
+- **C still blocks D and E** — D emits `JobRecord`, E reads/modifies them.
+- **F depends on B** (reads `PluginInfo` + exception hierarchy), independent of D/E.
+- **G can begin as a draft after B; substantive sections wait on C/D/E/F.**
+
+---
+
+## 5. Critical path analysis
+
+Minimum wall-clock path:
+
+```
+A → B → Preflight → max( slowest single B-N , C → D → E → F ) → G → Code-complete gate → Ship gate
+```
+
+- The per-plugin arm (B1-B10) remains the long pole. 10 plugins × 1-3h each is 10-30h serial; parallelism for a solo developer is attention-bounded.
+- Preflight adds a small serial segment (~30 min of runtime + triage) but **shrinks the critical-path risk** by pulling "broken upstream" discovery to the front.
+- The C→D→E→F arm is roughly: small → medium → medium → small — probably 1-3 days if sequential.
+- Code-complete gate is independent of external consumer readiness; the Ship gate waits on external work that this plan does not schedule.
+
+---
+
+## 6. Phase 1 exit criteria (split into two gates)
+
+### 6.1 Code-complete gate — package is technically done
+
+This gate unblocks the RC release and lets the external consumer begin integration testing. It does NOT require the external consumer to be ready.
+
+1. **All 5 CI jobs green on `main`:**
+   - `lint` — ruff check + ruff format --check
+   - `typecheck` — mypy strict on `src/`
+   - `deps` — deptry on `src/` (catches undeclared / forbidden imports per §2.2)
+   - `test` — pytest (unit + VCR-replay + schema round-trip + orchestrator integration + CLI smoke)
+   - `audit` — pip-audit on resolved lockfile
+2. **All 10 §11.5 metadata catalog rows complete** with no `?` / `TBD` values; every value code-cited; rate-limit notes grounded (quoted source doc, or explicit "Unknown — not documented").
+3. **All 10 plugins have VCR cassettes** recorded against their real endpoints (credentials used where required).
+4. **`docs/output_schema.md` published**: §9 record categories, envelope (with Q4 `query_applied` field), `description_source` truth table, `extra.*` policy, schema-version semantics, PEP 387 deprecation policy (per §2.4).
+5. **`docs/plugin_authoring.md` published**, covering all 7 metadata attributes + how to record a VCR cassette + exception hierarchy.
+6. **`docs/examples/sample-output.jsonl`** is committed, produced from a real `job-aggregator jobs` run.
+7. **`pip install .` in a clean venv passes a smoke test** (the CI workflow runs this; verifies the wheel + declared deps resolve).
+8. **`v1.0.0-rc1` tag pushed** + **GitHub Release drafted** (not published) pointing at TestPyPI.
+9. **Preflight-deferred plugins (if any) are documented** in `docs/preflight-report.md` with clear v1.1 deferral scope.
+
+### 6.2 Ship gate — unblocks v1.0 and Phase 2
+
+10. **External consumer integrates with `v1.0.0-rc1`** (installed from TestPyPI) and produces non-zero scored output end-to-end. User signs off.
+11. **`v1.0.0` tag pushed** → `publish.yml` publishes to production PyPI via trusted publishing.
+12. **Phase 2 milestone created in `job-matcher-pr`** and ready for H-K issues.
+13. **No open issues on `job-aggregator v1` milestone.**
+
+Gates 6.1 (items 1-9) and 6.2 (items 10-13) collectively define "v1.0 shipped."
+
+---
+
+## 7. CI and tooling stack (consolidated into Issue A)
+
+Issue A is no longer just "skeleton" — it stands up the full CI/tooling stack so that every subsequent issue lands against an opinionated, enforced baseline.
+
+### 7.1 `pyproject.toml` tool configuration
+
+- `[tool.ruff]` — select rules `E, F, W, I, N, UP, B, SIM, RUF`; `line-length = 100`; `target-version = "py311"`.
+- `[tool.ruff.format]` — standard formatter config.
+- `[tool.mypy]` — `strict = true`, `python_version = "3.11"`, `packages = ["job_aggregator"]`.
+- `[dependency-groups] dev` — `ruff`, `mypy`, `deptry`, `pytest`, `pytest-recording` (VCR), `pip-audit`, `pre-commit`.
+
+### 7.2 `.github/workflows/ci.yml` — 5 parallel jobs
+
+Per user's `feedback_ci_split_lint_and_test.md`, split rather than chained:
+
+| Job | Command | Fails on |
+|---|---|---|
+| `lint` | `ruff check . && ruff format --check .` | style / lint violations |
+| `typecheck` | `mypy src/` | any type error under strict |
+| `deps` | `deptry src/` | undeclared import, unused dep, dev-dep in src |
+| `test` | `pytest` | any test failure (cassettes replayed; no live HTTP in CI) |
+| `audit` | `pip-audit` | known CVE in resolved tree |
+
+Matrix: **Python 3.11 only for v1.0.** (3.12 is a v1.1 candidate once all 10 plugin cassettes confirm 3.12 compatibility.)
+
+### 7.3 `.pre-commit-config.yaml`
+
+Mirrors the `lint` CI job (ruff check + ruff format) for local-dev parity. Optional: `deptry` hook on commit.
+
+### 7.4 `.github/workflows/publish.yml`
+
+PyPI trusted publishing via OIDC — no stored API tokens. Trigger on tag push:
+
+- `v*.*.*-rc*` → TestPyPI
+- `v*.*.*` (final) → production PyPI
+
+### 7.5 Initial CI smoke commit
+
+Issue A's final commit must produce an all-green CI run on an empty skeleton (no plugins yet). This proves the pipeline before any real code lands.
+
+---
+
+## 8. Public-package readiness (folded into Issue A, Issue B, and new Issue M)
+
+### 8.1 Into Issue A
+
+- **LICENSE** file (MIT / Apache-2.0 / BSD-3-Clause — pre-work decision).
+- **CHANGELOG.md** skeleton, Keep-a-Changelog format, starting with `## [Unreleased]`.
+- **Full `pyproject.toml` metadata** beyond spec §6: `description`, `readme = "README.md"`, `authors`, `license` (SPDX identifier), `classifiers` (Development Status, Python versions, OS, Topic, License), `keywords`, `urls` (Homepage, Repository, Issues, Changelog, Documentation).
+- **`src/job_aggregator/py.typed`** — empty marker file, PEP 561, required for mypy to pick up the package's types when installed.
+- **`__version__`** in `job_aggregator/__init__.py` via `importlib.metadata.version("job-aggregator")`.
+- **Library logger pattern** — `logging.getLogger("job_aggregator")` with `logging.NullHandler()` attached at package init, PEP 282 convention. **Never** configure the root logger.
+- **README badges** — PyPI version, CI status, Python versions, license.
+- **`.github/workflows/publish.yml`** — trusted publishing per §7.4.
+
+### 8.2 Into Issue B
+
+- **Exception hierarchy** — all rooted at `JobAggregatorError`:
+  - `JobAggregatorError` (base)
+  - `PluginConflictError` (spec §6 — duplicate `source_key` at entry-point load)
+  - `ScrapeError`
+  - `CredentialsError`
+  - `SchemaVersionError`
+- Documented in `docs/output_schema.md` and re-exported via `job_aggregator.__init__` for a clean public API surface.
+
+### 8.3 New Issue M — "Meta / community" (parallel to B1-B10)
+
+- **CONTRIBUTING.md** — dev setup (editable install + venv + pre-commit), how to run tests, how to record a VCR cassette, PR process.
+- **SECURITY.md** — private security-report flow via GitHub Security Advisories. (Rationale: the package handles 10 sets of API credentials — security disclosure is materially more relevant than for a typical package.)
+- **`.github/ISSUE_TEMPLATE/`** — `bug_report.md`, `feature_request.md`, `plugin_request.md`.
+- **`.github/PULL_REQUEST_TEMPLATE.md`**.
+
+### 8.4 Deferred to v1.1+
+
+- `CODE_OF_CONDUCT.md`
+- Dependabot config
+- SBOM generation
+- Sigstore signing
+- Coverage threshold in CI
+- MkDocs documentation site
+
+---
+
+## 9. Milestone scaffolding (copy-ready for issue creation)
+
+**Milestone:** `job-aggregator v1`
+**Repo:** `cbeaulieu-gt/job-aggregator`
+**Description:** "Phase 1: ship standalone job-aggregator package v1.0 (per design spec 2026-04-23) through Code-complete gate + Ship gate. Phase 2 migration of job-matcher-pr is tracked separately."
+
+Target: **19 issues.** Create in this order (parents before children) so GitHub renders the dependency graph correctly.
+
+| # | Title | Labels | Depends on | One-line description |
+|---|---|---|---|---|
+| A | Set up package skeleton, full CI pipeline, and public-package metadata | `infra`, `phase-1` | — | pyproject (3.11+, full metadata, SPDX license, classifiers, urls), `src/job_aggregator/` + `py.typed` + `__version__`, library logger, `LICENSE`, `CHANGELOG.md`, README with badges, `.pre-commit-config.yaml`, `ci.yml` with 5 parallel jobs (lint/typecheck/deps/test/audit), `publish.yml` with TestPyPI+PyPI trusted publishing, clean-venv install smoke test, initial all-green CI commit. |
+| B | Plugin contract: JobSource ABC v3 + PluginInfo/PluginField + entry-point collision policy + exception hierarchy | `design`, `phase-1` | A | ABC with 7 metadata attributes (`DISPLAY_NAME`, `HOME_URL`, `GEO_SCOPE`, `ACCEPTS_QUERY`, `ACCEPTS_LOCATION`, `ACCEPTS_COUNTRY`, `RATE_LIMIT_NOTES`) plus `REQUIRED_SEARCH_FIELDS` and `DESCRIPTION`. `PluginInfo` + `PluginField` dataclasses. `auto_register` raising `PluginConflictError`. Exception hierarchy (`JobAggregatorError`, `PluginConflictError`, `ScrapeError`, `CredentialsError`, `SchemaVersionError`) re-exported from package root. |
+| Preflight | Live-API smoke test across all 10 sources | `infra`, `phase-1`, `preflight` | B | 30-minute live run against each plugin's real endpoint using real credentials. Classify each as `green` / `needs-fixing` / `broken-defer-to-v1.1`. Deliverable: `docs/preflight-report.md`. Needs-fixing plugins have their B-N issue opened with scope amended; broken plugins are explicitly deferred out of v1.0 with a follow-up v1.1 issue. |
+| B1 | Migrate `adzuna` plugin + fill §11.5 row + VCR cassette | `plugin-migration`, `phase-1` | Preflight, B | Move plugin into package, fill all 7 metadata attributes with code-cited values, audit `normalise()` against §9.3, write `normalise()` unit test + VCR cassette for `fetch_page()`. Reference `job-matcher-pr` repo for existing `fetch_page()` shape. |
+| B2 | Migrate `arbeitnow` plugin + fill §11.5 row + VCR cassette | `plugin-migration`, `phase-1` | Preflight, B | Same shape as B1 for arbeitnow. |
+| B3 | Migrate `himalayas` plugin + fill §11.5 row + VCR cassette | `plugin-migration`, `phase-1` | Preflight, B | Same shape as B1 for himalayas. |
+| B4 | Migrate `jobicy` plugin + fill §11.5 row + VCR cassette | `plugin-migration`, `phase-1` | Preflight, B | Same shape as B1 for jobicy. |
+| B5 | Migrate `jooble` plugin + fill §11.5 row + VCR cassette | `plugin-migration`, `phase-1` | Preflight, B | Same shape as B1 for jooble. |
+| B6 | Migrate `jsearch` plugin + fill §11.5 row + VCR cassette | `plugin-migration`, `phase-1` | Preflight, B | Same shape as B1 for jsearch. |
+| B7 | Migrate `remoteok` plugin + fill §11.5 row + VCR cassette | `plugin-migration`, `phase-1` | Preflight, B | Same shape as B1 for remoteok. |
+| B8 | Migrate `remotive` plugin + fill §11.5 row + VCR cassette | `plugin-migration`, `phase-1` | Preflight, B | Same shape as B1 for remotive. |
+| B9 | Migrate `the_muse` plugin + fill §11.5 row + VCR cassette | `plugin-migration`, `phase-1` | Preflight, B | Same shape as B1 for the_muse. |
+| B10 | Migrate `usajobs` plugin + fill §11.5 row + VCR cassette | `plugin-migration`, `phase-1` | Preflight, B | Same shape as B1 for usajobs. |
+| C | JobRecord schema + record normalizer | `core`, `phase-1` | B | Identity / Always-present / Optional / `extra.*` categories. Normalizer: `redirect_url` → `url`, date normalization, `posted_at` backfill from `created_at`, empty-vs-null preservation per §9.4, `extra` blob assembly. |
+| D | `jobs` orchestrator + output formatters + in-memory dedup + --query warning + query_applied envelope | `core`, `cli`, `phase-1` | C | Fetch loop, `--strict`/`--dry-run`/`--limit`/`--sources`/`--exclude-sources` per §8.1. JSONL + JSON envelope per §9.2. In-memory dedup. Stderr warning when `--query` set with `accepts_query` in `{never,partial}`. Envelope carries `query_applied: {source_key: bool}`. |
+| E | `hydrate` command + move `scrape_description` + `SCRAPE_MIN_LENGTH` + §8.2.1 + truth-table tests | `core`, `cli`, `phase-1` | C | Move `scrape_description` / `SCRAPE_MIN_LENGTH` into `job_aggregator.scraping`. Implement §8.2.1 input handling table exhaustively. Parametrized test covering every row of the §9.6 `description_source` truth table. |
+| F | `sources` command + `list_plugins` / `get_plugin` Python API | `core`, `cli`, `phase-1` | B | Public API per §7. CLI per §8.3 (with `credentials_configured: bool` when `--credentials` passed). |
+| G | Documentation: README, output_schema.md (with PEP 387 policy), plugin_authoring.md, sample fixture | `docs`, `phase-1` | A (metadata); substantive sections need C, D, E, F | Publish `docs/output_schema.md` (§9 + `query_applied` + PEP 387 deprecation policy), `docs/plugin_authoring.md` (7 metadata attrs + cassette recording + exception hierarchy), `docs/examples/sample-output.jsonl` (real run), `extra.*` policy, schema-version policy. |
+| M | Community meta — CONTRIBUTING, SECURITY, issue/PR templates | `docs`, `phase-1`, `community` | A | `CONTRIBUTING.md`, `SECURITY.md` (GitHub Security Advisories process), `.github/ISSUE_TEMPLATE/{bug_report,feature_request,plugin_request}.md`, `.github/PULL_REQUEST_TEMPLATE.md`. Independent of core code. |
+
+### 9.1 Issue body template
+
+```
+## Goal
+<one sentence>
+
+## Acceptance criteria
+- [ ] <specific, testable check>
+- [ ] <specific, testable check>
+- [ ] Tests added/updated and passing in CI (all 5 jobs green)
+- [ ] (For B1-B10) §11.5 catalog row fully populated — no `?` or TBD; every value code-cited; rate-limit notes grounded in source docs or explicitly "Unknown — not documented"
+
+## Depends on
+- #<issue numbers>
+
+## References
+- Spec: docs/superpowers/specs/2026-04-23-job-aggregator-design.md §<section>
+- Plan: docs/superpowers/plans/2026-04-23-job-aggregator-v1-execution-plan.md §<section>
+```
+
+### 9.2 Issues NOT to create in this milestone
+
+- **H, I, J, K** from spec §13 — Phase 2, live in `job-matcher-pr` milestone.
+- **Concurrency for `hydrate`** — spec §18, deferred to v1.1.
+- **CODE_OF_CONDUCT.md, Dependabot, SBOM, sigstore, coverage threshold, MkDocs** — per §8.4, v1.1+.
+- **Python 3.12 support matrix** — v1.1 once cassettes confirm compatibility.
+
+---
+
+## 10. Self-review against spec
+
+- §2 Phase 1 goals → A, B, C, D, E, F, G
+- §4 user story #1 (`pip install job-aggregator`) → A (publish.yml) + Ship gate (v1.0.0 → PyPI)
+- §5.3 drift mitigation → E's parametrized §9.6 truth-table test (in-repo). Cross-repo parity is Phase 2's Issue J.
+- §6 package structure + pyproject → A (now also full public-package metadata)
+- §7 public Python API → F + B (exceptions re-exported)
+- §8 CLI surface → §8.1 D (incl. --query warning + query_applied), §8.2 + §8.2.1 E, §8.3 F
+- §9 output schema → §9.1 B1-B10, §9.2 D (+ query_applied addition), §9.3-§9.5 C + G (PEP 387), §9.6 E
+- §10 credentials format → F
+- §11 plugin contract → B (ABC + exception hierarchy)
+- §11.5 metadata catalog → B1-B10 per-row; G publishes consolidated table
+- §12.3 PyPI publishing contradiction → resolved in §2.1 (Phase 1)
+- §13 issue breakdown → reproduced in §9 with Preflight + M added
+- §14.1 testing strategy → lint/typecheck/deps/test/audit CI jobs in A; per-plugin cassettes in B1-B10; schema round-trip in C; orchestrator integration in D; §9.6 truth-table parametrized test in E; clean-venv install in A; CLI smoke in D/E/F
+- §15 constraints → enforced by deptry CI job (§2.2)
+- §16 inquisitor findings → N3 resolved by §2.3 (both warning + metadata)
+- §18 deferred items → correctly out of scope
+
+Phase 2 / §12 / Issues H-K → correctly excluded. Will live in `job-matcher-pr` milestone.
+
+---
+
+## 11. What happens after this plan is approved
+
+1. User completes the pre-work checklist in §3 (LICENSE decision + PyPI name confirmation + trusted-publishing registration + milestone reservation).
+2. User reviews the 19-issue list in §9 and confirms titles/labels/descriptions.
+3. Router creates the milestone, then the 19 issues in dependency order, each with the issue-body template in §9.1.
+4. **Creation is not start-of-work** — per CLAUDE.md, explicit go-ahead is required before Issue A's first commit.
+5. Work proceeds: A → (B + M in parallel) → Preflight → (B1-B10 + C in parallel) → D → E → F → G → Code-complete gate → external consumer integration → Ship gate → v1.0.0 on PyPI.

--- a/docs/superpowers/specs/2026-04-23-job-aggregator-design.md
+++ b/docs/superpowers/specs/2026-04-23-job-aggregator-design.md
@@ -1,0 +1,966 @@
+# `job-aggregator` Package — Design Spec (v3-patched)
+
+**Date:** 2026-04-23
+**Status:** Draft v3-patched — pending user review
+**Author:** Christopher Beaulieu (with Claude Code)
+**Repo strategy:** Separate repo (`job-aggregator`) developed **standalone**;
+**Phase 1** ships v1.0 of the package independently. **Phase 2 (deferred)**
+migrates `job-matcher-pr` to consume the package. The two phases are
+sequenced — Phase 2 does not begin until Phase 1's v1.0 is shipped and
+validated against the target external consumer.
+
+This separation guarantees no cross-contamination during initial
+development: changes to `job-matcher-pr` cannot disrupt `job-aggregator`'s
+work, and vice versa, until the deliberate Phase 2 migration.
+
+**Revision history:**
+- v1 → v2: address inquisitor blockers (translator/extraction/schema)
+- v2 → v3: **structural reframe.** Extract the data-source layer into an
+  independent `job-aggregator` package. `job-matcher-pr` becomes a consumer of
+  that package (alongside the user's other evaluation tools). Eliminates 9 of
+  14 inquisitor findings outright by removing the in-repo coupling that
+  forced them. See §15 for the v2→v3 reframe rationale.
+
+---
+
+## 1. Problem statement
+
+The job-aggregation logic in `job-matcher-pr` is currently inseparable from
+its LLM scoring and database-write stages — it is a private orchestrator with
+no public interface. Other job-evaluation tools the user maintains cannot
+reuse this work; they have to rebuild source coverage from scratch.
+
+The user wants a **reusable, structured data source** that any tool can
+consume. The user has a specific target consumer (an existing
+non-`job-matcher-pr` evaluation system the user maintains) in mind that needs
+full job descriptions for LLM scoring. That consumer should be able to:
+
+```bash
+pip install job-aggregator
+job-aggregator jobs --hours 24 --query "python developer" --credentials creds.json \
+  | job-aggregator hydrate > full.jsonl
+# now consumer's own pipeline reads full.jsonl
+```
+
+**The structural decision in v3:** rather than building this CLI inside
+`job-matcher-pr` (which forces refactoring the pipeline primitives,
+behaviour-preservation problems, DB-import topology issues, and the
+translator/`PipelineConfig` complications that v2's inquisitor identified),
+build it as a **fully independent Python package** in its own repo. Both
+`job-matcher-pr` and external tools become consumers of the package. Plugin
+code lives once.
+
+## 2. Goals
+
+### Phase 1 (this spec's primary scope)
+
+Ship a standalone Python package `job-aggregator` v1.0 providing:
+
+- `job-aggregator jobs` — fetch listings from configured aggregator sources,
+  normalize them, emit structured records
+- `job-aggregator hydrate` — read records from stdin/file, scrape full job
+  descriptions, emit enriched records
+- `job-aggregator sources` — discovery: enumerate available plugins
+- A typed Python introspection API (`list_plugins()`, `get_plugin(key)`)
+  consumable by any UI host
+- A stable, semver-versioned package contract (output schema, credentials
+  format, plugin contract) that external consumers can pin against
+
+The user's target external consumer integrates with v1.0 to validate the
+contract. **`job-matcher-pr` is not modified during Phase 1.**
+
+### Phase 2 (deferred to a separate later milestone)
+
+Migrate `job-matcher-pr` to consume `job-aggregator`:
+
+- Replace `job-matcher-pr/job_sources/` and `job-matcher-pr/plugins/sources/`
+  with imports from `job-aggregator`
+- Migrate `web/settings.py` and `web/admin.py` to use
+  `job_aggregator.list_plugins()` introspection
+- Add credentials adapter at the boundary
+- Preserve `job-matcher-pr`'s observable behaviour (ingest output, scoring,
+  DB writes all unchanged from a user perspective)
+
+Phase 2 begins only after Phase 1 is shipped, validated by the external
+consumer, and the package's contract has stabilized. Phase 2 details
+(§12-13 sub-sections labeled Phase 2) are included in this spec for
+forward-planning but are NOT part of the immediate work.
+
+## 3. Non-goals
+
+- **No scoring in the package.** LLM evaluation is the consumer's job.
+- **No database access from the package.** `job-aggregator` cannot import or
+  require any database client. External consumers run without `DATABASE_URL`.
+- **No filtering in the package** *beyond* fetch-side params (hours, source
+  selection). Title/contract filters and geo filters stay in
+  `job-matcher-pr` (they're tied to user profile / app config and don't
+  generalize).
+- **No XML output format.** JSONL (default) and JSON (envelope) only.
+- **No concurrency in v1.** Both `jobs` and `hydrate` are serial. v1.1 will
+  add `--concurrency N` to `hydrate` once the v1 contract is validated.
+- **Package does not store credentials.** Consumers (apps) own credential
+  storage. The package describes what credentials each plugin needs and
+  accepts them at invocation time.
+
+## 4. User stories
+
+### Phase 1 user stories
+
+1. **External consumer ad-hoc.** `pip install job-aggregator`. Run
+   `job-aggregator sources` to see what's available. Run `job-aggregator jobs
+   --hours 24 --query "python" --credentials ./my-creds.json | job-aggregator
+   hydrate > today.jsonl`. Feed `today.jsonl` into their own scoring
+   pipeline. **This is the primary Phase 1 validation user story.**
+
+2. **External consumer programmatic.** A Python script in another project
+   does `from job_aggregator import list_plugins, ScrapeRunner` and
+   orchestrates scraping in-process without spawning subprocesses.
+
+3. **Plugin author.** A developer wanting to add a new aggregator source
+   reads `docs/plugin_authoring.md`, subclasses `JobSource`, declares
+   metadata attributes, optionally publishes their plugin as a separate PyPI
+   package using entry-points.
+
+### Phase 2 user stories (deferred)
+
+4. **`job-matcher-pr` self-use.** `python ingest.py` works exactly as today.
+   Internally, `ingest.py` now does `from job_aggregator import
+   make_enabled_sources, scrape_description, ...` and uses the package's
+   primitives. No observable change for the user.
+
+5. **`job-matcher-pr` settings UI.** The user opens Settings → Sources, sees
+   the same list of sources with the same descriptions and credential fields
+   they see today. Internally, the route handler now calls
+   `job_aggregator.list_plugins()` instead of introspecting local plugin
+   classes. No visible change.
+
+## 5. Architectural decisions
+
+### 5.1 Two-command split (`jobs` and `hydrate`)
+
+`jobs` does fetch + normalize + emit (no scrape). Fast — completes in
+seconds for hundreds of listings. Output is records with snippet-level
+descriptions (whatever the source API returns) and `description_source` set
+to `"snippet"` or `"none"`.
+
+`hydrate` reads records (from stdin or `--input PATH`), fetches the full job
+description from each record's `url`, and emits the same records with
+`description` replaced and `description_source` set to `"full"` (or
+preserved as `"snippet"` on failure).
+
+**Why split rather than one command with a flag:** clean separation between
+the fast and slow stages. Consumers who only need metadata don't pay for
+scraping. The slow stage is named so its cost is visible. Each command is
+independently testable. Composable via shell pipes:
+
+```bash
+job-aggregator jobs --hours 24 --query python | job-aggregator hydrate > full.jsonl
+```
+
+### 5.2 Package owns plugin definitions; apps own user state
+
+| Concern | Owned by |
+|---|---|
+| What plugins exist | Package |
+| What each plugin does (description, geo scope) | Package |
+| What credentials each plugin needs (typed `PluginField` definitions) | Package |
+| Behavioural traits (`accepts_query`, etc.) | Package |
+| Per-user enable/disable state | App (e.g. `providers.json`) |
+| Per-user credential values | App |
+| How a credential field is rendered (HTML, label styling) | App |
+| Validation of submitted credential values | App, using package's typed field metadata |
+
+The package exposes typed `PluginInfo` and `PluginField` dataclasses;
+consuming apps render them however they want.
+
+### 5.3 No code shared between `ingest.run()` and the package's CLI
+
+This is the structural lesson from v2. `ingest.run()` keeps its current
+loop (scoring, DB writes, per-provider cost tracking, SSE event emission,
+filtering) untouched. The package's `job-aggregator jobs` orchestrator has its
+own loop (fetch + normalize + emit). They both call the same primitives
+(plugin `pages()`, `scrape_description`) but neither orchestrator depends
+on the other.
+
+This means:
+- No `process_listing()` extraction needed (v2 blocker B2 — eliminated)
+- No `PipelineConfig` translator needed (v2 blocker B1 — eliminated)
+- No behaviour-preservation drama for `ingest.run()` — its loop is unchanged
+- No `DATABASE_URL` import topology issue — package never imports `db`
+
+The cost: the per-listing call sequencing exists in two places (~30 LOC of
+duplicated control flow). This is acceptable because:
+- The duplicated lines are mechanical (`for listing: prefilter; geo; dedup;
+  scrape`)
+- Bug fixes to the actual logic (`prefilter`, `scrape_description`) live in
+  one place each — `prefilter` in `job-matcher-pr`, `scrape_description` in
+  the package
+- The two orchestrators have intentionally different semantics anyway
+  (different dedup, different output sink, different stages run)
+
+**Drift hazard the user must guard against (acknowledged):**
+
+The `description_source` classification (`"full"` / `"snippet"` / `"none"`)
+is part of the package's stable schema AND `ingest.run()`'s persistence path
+(via `db.insert_listing`'s `description_source` column). The classification
+logic (the truth table in §9.6) is implemented in the package's `hydrate`
+orchestrator and mirrored by `ingest.run()`'s inline scrape branch (lines
+1390-1416). If the user changes the logic in one place without the other,
+listings get inconsistent provenance depending on which code path produced
+them.
+
+**Mitigations:**
+- `_SCRAPE_MIN_LENGTH` lives in the package (`job_aggregator.scraping`),
+  exported as a public constant. `ingest.py` imports it: `from
+  job_aggregator.scraping import SCRAPE_MIN_LENGTH`. **One source of truth for
+  the constant.**
+- The truth table in §9.6 is the definitional reference. Both orchestrators
+  must implement it identically; tests in both repos validate against the
+  table.
+- A small contract test in `job-matcher-pr` (~20 LOC, in
+  `tests/test_scrape_classification_parity.py`) feeds a synthetic listing
+  with each table-row's input combination through `ingest.run()`'s scrape
+  branch and asserts the resulting `description_source` matches the table.
+  Future bugs in either implementation surface here.
+
+### 5.4 No GeoFilter in the package
+
+`GeoFilter` stays in `job-matcher-pr`. It has DB-cache coupling
+(`db.geocache_get_many` / `db.geocache_put`) that doesn't fit a no-DB
+package. External consumers needing geo filtering implement their own.
+
+The package CLI has no `--remote` or `--location` flag. Consumers do
+geo-related filtering on their own data. (This was v2's M2 blocker — fully
+eliminated by removing the feature.)
+
+## 6. Package structure
+
+```
+job-aggregator/                           # NEW REPO
+├── pyproject.toml                     # console script: job-aggregator
+├── README.md
+├── LICENSE
+├── docs/
+│   ├── output_schema.md               # public per-record contract
+│   ├── plugin_authoring.md            # how to write a new plugin
+│   └── examples/sample-output.jsonl
+├── src/
+│   └── job_aggregator/
+│       ├── __init__.py                # public API: re-exports
+│       ├── base.py                    # JobSource ABC (moved from job-matcher-pr/job_sources/base.py)
+│       ├── loader.py                  # plugin discovery (moved from job_sources/loader.py)
+│       ├── auto_register.py           # entry-point + filesystem registration
+│       ├── registry.py                # list_plugins / get_plugin
+│       ├── plugins/                   # 10 plugins (moved from job-matcher-pr/plugins/sources/)
+│       │   ├── adzuna/
+│       │   ├── arbeitnow/
+│       │   ├── ... (10 total)
+│       ├── schema.py                  # JobRecord, PluginInfo, PluginField
+│       ├── scraping.py                # scrape_description (moved from ingest.py)
+│       ├── orchestrator.py            # the fetch loop for `jobs`
+│       ├── hydrator.py                # the scrape loop for `hydrate`
+│       ├── output/
+│       │   ├── jsonl.py
+│       │   └── json.py
+│       └── cli/
+│           ├── __init__.py
+│           └── __main__.py            # argparse for jobs / hydrate / sources
+├── tests/
+│   ├── conftest.py
+│   ├── test_orchestrator.py
+│   ├── test_hydrator.py
+│   ├── test_registry.py
+│   ├── test_schema.py
+│   ├── plugins/                       # one test file per plugin
+│   └── fixtures/
+└── .github/workflows/ci.yml
+```
+
+`pyproject.toml` declares:
+
+```toml
+[project]
+name = "job-aggregator"
+version = "0.1.0"
+requires-python = ">=3.11"          # Himalayas plugin uses from datetime import UTC (3.11+)
+dependencies = [
+    "requests>=2.31",
+    "beautifulsoup4>=4.12",
+]
+# NOTE: no psycopg2, no flask, no llm/anthropic/openai/google packages.
+# CI must enforce this — see §14.
+
+[project.scripts]
+job-aggregator = "job_aggregator.cli.__main__:main"
+
+[project.entry-points."job_aggregator.plugins"]
+# v1 ships with built-in plugins; third parties can add via their own packages.
+adzuna = "job_aggregator.plugins.adzuna:AdzunaSource"
+# ... all 10 ...
+```
+
+**CI matrix for v1**: Python 3.11 only. Widening (3.12, 3.13) deferred until
+all plugins are audited for version-specific syntax/imports.
+
+**Entry-point collision policy**: when `auto_register` discovers two
+registrations claiming the same `source_key` (built-in vs third-party,
+duplicate filesystem registration vs entry-point, stale editable install vs
+PyPI install, etc.), it raises a clear `PluginConflictError` at startup
+listing both registration sources. **No silent first-wins or last-wins**:
+plugin identity ambiguity should fail loudly. Users resolve by uninstalling
+the duplicate or setting `JOB_SCRAPER_DISABLE_PLUGINS=key1,key2` env var to
+force-disable specific keys.
+
+## 7. Public Python API
+
+```python
+# Re-exported from job_aggregator.__init__:
+from job_aggregator import (
+    # Discovery
+    list_plugins,           # () -> list[PluginInfo]
+    get_plugin,             # (key: str) -> PluginInfo | None
+
+    # Plugin management
+    make_enabled_sources,   # (credentials: dict, search: SearchParams) -> list[JobSource]
+    JobSource,              # ABC; for plugin authors
+
+    # Pipeline primitives
+    scrape_description,     # (url: str, fallback: str) -> tuple[str, bool]
+
+    # Schema types
+    JobRecord,              # output dataclass / TypedDict
+    PluginInfo,
+    PluginField,
+    SearchParams,           # input dataclass — see below
+)
+
+# SearchParams shape:
+@dataclass(frozen=True)
+class SearchParams:
+    query: str | None = None
+    location: str | None = None
+    country: str | None = None        # ISO 3166-1 alpha-2
+    hours: int = 168
+    max_pages: int | None = None      # per-source cap; None = each plugin's default
+```
+
+`job-matcher-pr/ingest.py` migration:
+
+```python
+# Before:
+from job_sources import make_enabled_sources, get_required_search_fields
+# (scrape_description was a local function in ingest.py)
+
+# After:
+from job_aggregator import make_enabled_sources, scrape_description, list_plugins
+# get_required_search_fields equivalent: list_plugins() returns
+# requires_credentials per plugin
+```
+
+## 8. CLI surface
+
+### 8.1 `job-aggregator jobs`
+
+```
+job-aggregator jobs [OPTIONS]
+```
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--hours N` | int | 168 | Lookback window. |
+| `--query STRING` | string | none | Search terms. Applied per `accepts_query` per source. |
+| `--location STRING` | string | none | Free-text location. Plugins use as a search hint where supported (no client-side geo filtering). |
+| `--country CODE` | string | none | ISO 3166-1 alpha-2. |
+| `--sources LIST` | comma list | all configured | Plugins to enable. |
+| `--exclude-sources LIST` | comma list | none | |
+| `--limit N` | int | unlimited | Cap on emitted records. |
+| `--max-pages N` | int | source default | Cap per source. |
+| `--credentials PATH` | path | required | JSON file of credentials per plugin. See §10. |
+| `--format FORMAT` | enum | `jsonl` | `jsonl` \| `json`. |
+| `--output PATH` | path | stdout | |
+| `--strict` | flag | off | Exit non-zero on any source error. |
+| `--dry-run` | flag | off | List which sources would run with which params. No HTTP calls. |
+| `-v` / `-vv` / `--quiet` | flag | off | Stderr verbosity. |
+
+### 8.2 `job-aggregator hydrate`
+
+```
+job-aggregator hydrate [OPTIONS]
+```
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--input PATH` | path | stdin | JSONL file produced by `jobs`. `-` or omit for stdin. |
+| `--output PATH` | path | stdout | |
+| `--timeout-per-request N` | int | 15 | Per-URL HTTP timeout in seconds. |
+| `--timeout-total N` | int | none | Hard wall-clock budget for the whole run. When exceeded, remaining records pass through unchanged (description not replaced) and a warning is logged. |
+| `--continue-on-error` | flag | on | When a scrape fails (HTTP error, parse fail), pass the record through unchanged and log to stderr. Use `--strict` to exit non-zero on first failure instead. |
+| `--strict` | flag | off | Exit non-zero on any scrape failure. |
+| `--format FORMAT` | enum | inferred from input envelope | `jsonl` \| `json`. |
+| `-v` / `-vv` / `--quiet` | flag | off | |
+
+`hydrate` reads the envelope (if present) and propagates it; it modifies
+`description` and `description_source` on each record. Records with
+`description_source = "full"` already are passed through unchanged (no re-scrape).
+
+#### 8.2.1 `hydrate` input handling — explicit cases
+
+| Input record state | `hydrate` behaviour |
+|---|---|
+| `description_source = "full"` already | Pass through unchanged. No re-scrape. |
+| `url` key absent OR `url = null` OR `url = ""` | Pass through unchanged. Emit warning to stderr identifying the record by `(source, source_id)`. Do not crash. |
+| `url` is malformed (not http/https) | Same as missing url: pass through, warn. |
+| `description_source` value not in `{"full","snippet","none"}` | Pass through unchanged. Emit warning. Defensive — handle records from future package versions gracefully. |
+| Envelope `schema_version` differs from package's current major | Emit warning, proceed best-effort. Future-compat: same major version is required; cross-major refuses (exit code 4). |
+| Scrape returns < `SCRAPE_MIN_LENGTH` chars | Treat as failure: preserve input description and `description_source`. Log to stderr. |
+| Scrape returns HTTP 4xx/5xx or network error | Treat as failure: same behaviour as above. Log to stderr. |
+
+**`--format` inference rule** (when `--format` not set explicitly): peek the
+first non-whitespace byte of input. If it is `{` AND the first complete JSON
+value parses as a single object containing `"jobs"`, treat as `--format
+json`. Otherwise treat as `--format jsonl`. Document this in `--help`.
+
+### 8.3 `job-aggregator sources`
+
+Emits a JSON document describing every registered plugin:
+
+```json
+{
+  "schema_version": "1.0",
+  "plugins": [
+    {
+      "key": "adzuna",
+      "display_name": "Adzuna",
+      "description": "Global job aggregator with broad coverage...",
+      "home_url": "https://www.adzuna.com",
+      "geo_scope": "global-by-country",
+      "accepts_query": "always",
+      "accepts_location": true,
+      "accepts_country": true,
+      "rate_limit_notes": "1 req/sec, 250/day on free tier.",
+      "fields": [
+        {"name": "app_id", "label": "App ID", "type": "password", "required": true},
+        {"name": "app_key", "label": "App Key", "type": "password", "required": true}
+      ]
+    }
+  ]
+}
+```
+
+If `--credentials PATH` is provided, also includes per-plugin
+`credentials_configured: bool`.
+
+## 9. Output schema
+
+### 9.1 Plugin output audit (basis for the schema)
+
+Audited Adzuna and RemoteOK `normalise()` output. Inconsistencies the
+package's record normalizer must handle:
+
+| Field | Adzuna | RemoteOK | Normalizer behaviour |
+|---|---|---|---|
+| `source` | always | always | Required; passed through |
+| `source_id` | always (str) | always (str) | Required; records with empty value are emitted with empty string (NOT dropped — `ingest.run()` doesn't drop today; package doesn't either) |
+| `title` | always | always | Required; may be empty string |
+| `posted_at` | sometimes set | **never set** | Required after backfill; package's `jobs` orchestrator backfills from `created_at` (mirrors `ingest.run()` line 1503-1504) |
+| `redirect_url` | always | always | Renamed to `url` in output; may be empty string |
+| `description` | snippet | HTML-stripped snippet | Always present; in `jobs` output, this is the source's snippet. After `hydrate`, replaced with full text. |
+| `salary_period` | always None | always None | Optional; null for both audited plugins. Documented as "rarely populated by current plugins". |
+
+Audit must be repeated for the remaining 8 plugins as part of Issue B (see
+§13). Any normalization edge cases discovered get added to this section.
+
+### 9.2 Envelope
+
+For `--format json`:
+
+```json
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-04-23T18:45:12Z",
+  "command": "jobs",
+  "sources_used": ["adzuna", "jooble"],
+  "sources_failed": [],
+  "request_summary": {
+    "hours": 24,
+    "query": "python developer",
+    "location": "Atlanta, GA",
+    "country": null,
+    "sources": ["adzuna", "jooble"]
+  },
+  "jobs": [ /* records */ ]
+}
+```
+
+For `--format jsonl`: first line is the envelope (with `"jobs": []`); each
+subsequent line is one record.
+
+`hydrate` propagates the envelope from its input but updates `command` and
+`generated_at`; `request_summary` from `jobs` is preserved.
+
+### 9.3 Record fields — three categories
+
+**Identity (always present, validation-checked):**
+
+| Field | Type | Notes |
+|---|---|---|
+| `source` | string | Plugin key. |
+| `source_id` | string | May be empty if upstream provides none — passed through unchanged. |
+| `description_source` | enum | `"full"` (after `hydrate` succeeded) \| `"snippet"` (source-provided) \| `"none"` (no description available) |
+
+**Always-present (always serialised, may be empty per stated rules):**
+
+| Field | Type | Notes |
+|---|---|---|
+| `title` | string | May be empty when source provides nothing. |
+| `url` | string | Renamed from `redirect_url`. May be empty. `hydrate` requires non-empty `url` to perform the scrape; records with empty `url` pass through unchanged. |
+| `posted_at` | string \| null | RFC 3339 UTC. Backfilled from `created_at` by `jobs` orchestrator; null when both sources unparseable (logged to stderr). |
+| `description` | string | Snippet from source after `jobs`; full text after successful `hydrate`; empty string when source provides none. |
+
+**Optional (always serialised, often null):**
+
+| Field | Type | Notes |
+|---|---|---|
+| `company` | string \| null | Empty string preserved if source provides it; absent key → null. |
+| `location` | string \| null | Free-text from source. |
+| `salary_min` | number \| null | |
+| `salary_max` | number \| null | |
+| `salary_currency` | string \| null | ISO 4217 where source provides. |
+| `salary_period` | enum \| null | `"annual"` \| `"monthly"` \| `"hourly"`. **Currently null for all audited plugins.** |
+| `contract_type` | string \| null | |
+| `contract_time` | string \| null | |
+| `remote_eligible` | bool \| null | |
+
+**Source-specific blob:**
+
+| Field | Type | Notes |
+|---|---|---|
+| `extra` | object \| null | Plugin-specific keys (e.g. `extra.adzuna.category`). **Marked unstable** — schema versioning does not promise stability of `extra.*`. |
+
+### 9.4 Empty string vs. null
+
+A documented contract: empty string means "source provided an empty value";
+null means "source did not provide this key at all". Consumers can
+distinguish.
+
+### 9.5 Schema versioning
+
+`schema_version` follows semver. Major bump for: removed/renamed Identity or
+Always-present fields, type changes. Minor bump for: new Optional fields,
+new envelope keys.
+
+**`extra.*` policy (explicit):**
+- `extra.*` shape is **NOT** covered by `schema_version`.
+- The package may change `extra.*` keys, types, and structure in any
+  release (including patch versions) without notice.
+- Tests in the package do **not** assert `extra.*` shape; only that `extra`
+  is an object when present.
+- Consumers depending on `extra.*` are explicitly out of warranty.
+- When a field in `extra` is consistently demanded by consumers, it gets
+  promoted to a real Category 3 field in a minor version bump (which IS
+  covered by `schema_version`). Until then, `extra` is "best effort raw
+  passthrough."
+
+This policy is non-negotiable: a "documented unstable" subtree without
+testing or stability is the only sane way to handle source-specific data
+that the package can't generalize.
+
+### 9.6 `description_source` truth table (the canonical reference)
+
+Both the package's `jobs` orchestrator, the package's `hydrate` orchestrator,
+and `job-matcher-pr`'s `ingest.run()` scrape branch must implement this
+table identically. Tests in both repos validate against it.
+
+**`jobs` orchestrator (no scrape, just emit what plugins provide):**
+
+| Plugin sets `skip_scrape` | Plugin sets `description_is_full` | `len(description) >= SCRAPE_MIN_LENGTH` | Result `description_source` |
+|---|---|---|---|
+| True | True | True | `"full"` |
+| True | True | False | `"snippet"` |
+| True | False | n/a | `"snippet"` |
+| False | n/a | n/a | `"snippet"` |
+| n/a | n/a | description is empty | `"none"` |
+
+**`hydrate` orchestrator (does HTTP scrape):**
+
+| Input `description_source` | Scrape outcome | Result `description_source` | Result `description` |
+|---|---|---|---|
+| `"full"` | (skipped — already full) | `"full"` (unchanged) | unchanged |
+| `"snippet"` or `"none"` | success, body ≥ MIN | `"full"` | scraped text |
+| `"snippet"` or `"none"` | failure (HTTP error, parse fail, body < MIN) | unchanged | unchanged |
+| `"snippet"` or `"none"` | url empty/missing | unchanged | unchanged |
+
+**`ingest.run()` per-listing scrape branch:** logically equivalent to
+`jobs` row classification + (if scraping is in scope for the run) `hydrate`
+row classification. The contract test described in §5.3 validates this.
+
+**`SCRAPE_MIN_LENGTH`** is defined as a public constant in
+`job_aggregator.scraping`. `ingest.py` imports it; never redefines it locally.
+
+## 10. Credentials file format
+
+The package OWNS this format (it's part of the package's stable contract).
+
+```json
+{
+  "schema_version": "1.0",
+  "plugins": {
+    "adzuna": {
+      "app_id": "abc123",
+      "app_key": "def456"
+    },
+    "jooble": {
+      "api_key": "..."
+    }
+  }
+}
+```
+
+`job-matcher-pr` continues to use its existing `providers.json` shape (which
+has `job_sources.<key>.<field>` rather than `plugins.<key>.<field>`) — the
+app's existing storage is preserved. A named adapter function in
+`job-matcher-pr` (suggested location:
+`job-matcher-pr/credentials.py::translate_to_package_credentials`)
+translates the app's internal credential dict into the package's expected
+shape at the boundary where `make_enabled_sources()` is called.
+
+This adapter is **not 10 lines** — it must handle:
+
+1. **Env-var precedence**: `credentials.load_providers()` already injects
+   `ADZUNA_APP_ID` / `ADZUNA_APP_KEY` from env vars into the providers dict
+   via `_inject_env_var_credentials()`. The adapter receives the
+   **post-injection** dict (env-var precedence is preserved transparently).
+2. **Drop user state**: strip `enabled` toggle from each source entry — the
+   package's credential format only carries credential field values.
+3. **Skip disabled sources**: the package's `make_enabled_sources()` is
+   driven by which keys appear in the credentials dict; the adapter only
+   includes entries for sources whose `enabled = True` (or default-enabled
+   keyless sources with no entry). This mirrors the existing
+   `make_enabled_sources()` filtering logic.
+4. **Pass through the legacy `keys.json` migration**: `load_providers()`
+   handles this before the adapter sees the dict. No change needed in the
+   adapter itself.
+
+The adapter is ~30-40 LOC including its own unit tests. It lives in
+`job-matcher-pr` (not in the package) because the conversion is
+app-specific. External consumers of the package write credentials directly
+in the package's format — no adapter needed for them.
+
+The user-facing `providers.json` file on disk does not change shape; the
+Settings UI continues to read and write `providers.json` exactly as today.
+
+The package documents its credentials shape in `docs/output_schema.md`
+alongside the output schema. External consumers write credentials in this
+shape directly.
+
+## 11. Plugin contract
+
+Each plugin is a Python class that:
+
+1. Subclasses `job_aggregator.JobSource` (ABC)
+2. Declares class-level metadata: `SOURCE` (key), `DISPLAY_NAME`,
+   `DESCRIPTION`, `HOME_URL`, `GEO_SCOPE`, `ACCEPTS_QUERY`,
+   `ACCEPTS_LOCATION`, `ACCEPTS_COUNTRY`, `RATE_LIMIT_NOTES`
+3. Implements `settings_schema() -> dict` returning the field definitions
+   used to populate `PluginInfo.fields`
+4. Implements `pages() -> Iterator[list[dict]]` yielding pages of normalized
+   listings
+5. Implements `normalise(raw: dict) -> dict` mapping source-API responses to
+   the package's expected output shape
+
+`PluginInfo` is built by reading these declarations + the `settings_schema()`
+return value. `requires_credentials` is derived at runtime from
+`fields[].required`.
+
+**`required_search_fields` moves to `PluginInfo`** (drift mitigation per
+v3 inquisitor finding #8). Currently `REQUIRED_SEARCH_FIELDS` is a class
+attribute on each `JobSource` subclass, consumed by
+`ingest.validate_search_config` in `job-matcher-pr`. After migration:
+
+- The class attribute moves to the package alongside the rest of the plugin
+  metadata.
+- `PluginInfo.required_search_fields: list[str]` exposes it.
+- `validate_search_config` in `job-matcher-pr` reads from `PluginInfo` via
+  `list_plugins()`, NOT from the class attribute directly.
+- A new plugin declaring `REQUIRED_SEARCH_FIELDS = ("foo",)` automatically
+  flows through to the validator without requiring `job-matcher-pr` updates.
+
+This eliminates the silent cross-repo drift risk where adding a required
+search field in the package would cause runtime failures in
+`job-matcher-pr` until its validator was manually updated.
+
+The 10 existing plugins in `job-matcher-pr/plugins/sources/` mostly conform
+to the basic structure but **do not currently declare** the new metadata
+attributes (`DISPLAY_NAME`, `DESCRIPTION`, `HOME_URL`, `GEO_SCOPE`,
+`ACCEPTS_QUERY`, `ACCEPTS_LOCATION`, `ACCEPTS_COUNTRY`,
+`RATE_LIMIT_NOTES`). Filling these in for each plugin is a **real audit
+task**, not mechanical — the user must read each plugin's `fetch_page()` to
+determine actual query/location/country handling. This audit is tracked as
+per-plugin sub-issues in §13 (Issues B1-B10).
+
+## 11.5 Plugin metadata catalog (audit deliverable for Issues B1-B10)
+
+This section is the canonical audit deliverable. Each row is filled in by
+its corresponding per-plugin migration issue (B1-B10). Values left as `?`
+are unknown until the plugin's `fetch_page()` is read; values left as TBD
+are decisions the migrator makes based on that reading.
+
+| Plugin | DISPLAY_NAME | GEO_SCOPE | ACCEPTS_QUERY | ACCEPTS_LOCATION | ACCEPTS_COUNTRY | RATE_LIMIT_NOTES | REQUIRED_SEARCH_FIELDS |
+|---|---|---|---|---|---|---|---|
+| adzuna | Adzuna | global-by-country | always | true | true | "1 req/sec, 250/day on free tier" | ("country","what","where") (current) |
+| arbeitnow | ? | TBD | ? | ? | ? | ? | ? |
+| himalayas | ? | remote-only (likely) | ? | ? | ? | ? | ? |
+| jobicy | ? | remote-only (likely) | ? | ? | ? | ? | ? |
+| jooble | ? | global | ? | ? | ? | ? | ? |
+| jsearch | ? | global | always | ? | ? | "RapidAPI quota varies by plan" | ? |
+| remoteok | RemoteOK | remote-only | never | false | false | "Public, soft rate limits" | () |
+| remotive | ? | remote-only (likely) | ? | ? | ? | ? | ? |
+| the_muse | ? | TBD | ? | ? | ? | ? | ? |
+| usajobs | USAJobs | federal-us | partial | ? | false (US-only) | "Email-tagged user-agent required" | ? |
+
+The audit is real work, not mechanical. The values shown for adzuna,
+remoteok, jsearch, and usajobs are starting points based on what is already
+known from CLAUDE.md, plugin source, or prior context — they still must be
+verified against actual plugin behaviour as part of B1-B10.
+
+`DESCRIPTION` and `HOME_URL` for each plugin are reused from the existing
+`source.json` files (already populated; copy verbatim).
+
+The completed catalog becomes part of `docs/output_schema.md` in the
+package as the canonical "what each plugin supports" reference.
+
+## 12. Migration plan for `job-matcher-pr` — **PHASE 2 (DEFERRED)**
+
+> **This entire section describes Phase 2 work. It is included in the spec
+> for forward-planning but does NOT begin until Phase 1 has shipped v1.0 of
+> `job-aggregator` and the target external consumer has validated the
+> package contract. Treat the content below as a planning artifact, not as
+> immediate work.**
+
+### 12.1 Repo layout during development
+
+```
+~/code/
+├── job-matcher-pr/         # existing repo
+└── job-aggregator/            # NEW repo (sibling)
+```
+
+`job-matcher-pr`'s dev venv:
+
+```bash
+pip install -e ../job-aggregator
+```
+
+This means the working code on disk is the only copy; both repos read from
+the same source. **Zero divergence window.**
+
+### 12.2 Migration sequence (revised — lockstep to avoid plugin-set disagreement)
+
+The original ordering migrated UI before ingest, creating a window where
+the settings UI listed package plugins while ingest still loaded local
+plugins. If the two plugin sets disagreed (typo in entry-point, plugin added
+mid-migration), the user could enable a source in the UI that ingest
+couldn't run, or vice versa. Revised sequence eliminates this window:
+
+1. **Build `job-aggregator` package** (Issues A-G in §13). Install into
+   `job-matcher-pr` venv via editable install. Verify package CLI works
+   standalone.
+2. **Add a parity assertion test** in `job-matcher-pr` (~10 LOC) that
+   imports both the local `job_sources.get_sources()` and
+   `job_aggregator.list_plugins()` and asserts the keys match. This test is
+   added BEFORE step 3 and removed in step 4. It guards the migration.
+3. **Lockstep migration PR**: a single PR that migrates BOTH `ingest.py`
+   AND `web/settings.py` + `web/admin.py` to import from `job_aggregator`. The
+   parity test from step 2 ensures plugin sets match before this PR can
+   merge. UI and ingest read from the same source from the moment the PR
+   lands.
+4. **Delete `job-matcher-pr/job_sources/`** and
+   `job-matcher-pr/plugins/`. Remove the parity test (no longer applicable
+   — only one source of plugin definitions remains).
+5. **Run full test suite** (2062 tests). Fix any test breakage from import
+   path changes.
+6. **Add `job-aggregator>=1.0`** to `requirements.txt`.
+
+The lockstep PR (step 3) is the only step with risk; the parity test (step
+2) and full-suite verification (step 5) bracket it.
+
+### 12.3 Production deployment
+
+Two phases:
+- **Phase 1 (development)**: editable install from sibling directory. No
+  PyPI publish needed.
+- **Phase 2 (production)**: publish `job-aggregator` to PyPI; pin in
+  `job-matcher-pr/requirements.txt` (`job-aggregator==1.0.0`). Optional —
+  during the development period, consumers can install via git ref
+  (`pip install git+https://github.com/.../job-aggregator.git@v1.0.0`).
+
+## 13. Issue breakdown
+
+A Milestone titled **"job-aggregator v1"** in the new repo. A separate
+Milestone titled **"Migrate to job-aggregator"** in `job-matcher-pr`.
+
+### `job-aggregator` repo issues (Phase 1 — start here):
+
+| # | Title | Scope |
+|---|---|---|
+| A | Set up package skeleton (pyproject with `requires-python = ">=3.11"`, tests dir, CI workflow with import-fence check enforcing no `db`/`flask` imports, README) | Pure infrastructure |
+| B | **Plugin contract design**: define `JobSource` ABC v3 with new metadata attributes (`DISPLAY_NAME`, `DESCRIPTION`, `HOME_URL`, `GEO_SCOPE`, `ACCEPTS_QUERY`, `ACCEPTS_LOCATION`, `ACCEPTS_COUNTRY`, `RATE_LIMIT_NOTES`, `REQUIRED_SEARCH_FIELDS`). Define `PluginInfo` and `PluginField` schemas. Define entry-point collision policy. | New ABC + schemas |
+| B1-B10 | **Per-plugin migration** (one issue per plugin): adzuna, arbeitnow, himalayas, jobicy, jooble, jsearch, remoteok, remotive, the_muse, usajobs. For each: move file, fill in 8 new metadata attributes (read `fetch_page()` to verify actual behaviour), audit `normalise()` output against §9.3 categories, write per-plugin tests including VCR-recorded `fetch_page()` cassette (see §14.1), populate the metadata catalog row in §11.5. | 10 separate issues, ~1-3h each. The metadata audit is **explicit work**, not mechanical. |
+| C | Build `JobRecord` schema + record normalizer (renames, date normalization, posted_at backfill, empty-vs-null preservation, extra blob assembly) | New |
+| D | Build `job-aggregator jobs` orchestrator + output formatters + in-memory deduplicator | New |
+| E | Build `job-aggregator hydrate` command (move `scrape_description` and `SCRAPE_MIN_LENGTH` from ingest.py to `job_aggregator.scraping`); implement §8.2.1 input handling table | New |
+| F | Build `job-aggregator sources` command + `list_plugins`/`get_plugin` Python API | New |
+| G | Documentation: README, output schema (§9 of this spec), plugin authoring guide (incl. metadata attribute meanings), sample fixture (`docs/examples/sample-output.jsonl`), `extra.*` policy disclaimer | Docs |
+
+### `job-matcher-pr` repo issues (Phase 2 — deferred until Phase 1 ships):
+
+| # | Title | Scope |
+|---|---|---|
+| H | Add parity assertion test (per §12.2 step 2) that locks plugin-set equality between local and package | Pre-migration safety net |
+| I | **Lockstep migration PR**: migrate `ingest.py` AND `web/settings.py` + `web/admin.py` to use `job_aggregator`. Includes credentials adapter (per §10) at `credentials.py::translate_to_package_credentials` with its own unit tests. Update `validate_search_config` to read `required_search_fields` from `PluginInfo`. Delete local `job_sources/` and `plugins/`. Remove parity test. | The single risky step in the migration |
+| J | Add `tests/test_scrape_classification_parity.py` — contract test asserting `ingest.run()`'s scrape branch matches the §9.6 truth table (drift mitigation per §5.3) | Drift guard |
+| K | Update `requirements.txt`; verify CI passes against the editable install (or pinned version); update README with new dependency note | Plumbing |
+
+## 14. Testing strategy
+
+### 14.1 In `job-aggregator`
+
+**Per-plugin tests** (one file each, 10 files):
+
+- `normalise()` test: pass a synthetic raw API dict, assert output conforms
+  to §9.3 categories. Pure unit test, no I/O.
+- `fetch_page()` test: use VCR.py (`pytest-recording` or
+  `vcrpy`) cassettes. Each plugin has 1-2 cassettes recorded once with real
+  credentials by the maintainer, committed to
+  `tests/cassettes/<plugin>/`. CI replays cassettes — **no live API calls
+  in CI, no credential dependency**. To re-record (when a source's API
+  format changes), the maintainer deletes the cassette, runs the test
+  locally with real credentials, commits the new cassette.
+- `pages()` iteration test: drives `pages()` against a stub `fetch_page()`
+  return; asserts pagination termination and per-page list shape.
+
+**Schema tests:**
+
+- `JobRecord`, `PluginInfo`, `PluginField` round-trip serialization
+- `schema_version` compatibility: emit a v1.0 record, parse with v1.0
+  consumer, assert ≅
+- `extra.*` is **not** asserted — see §9.5 policy
+
+**Orchestrator tests** (end-to-end with stub plugins from
+`tests/fixtures/plugins/`):
+
+- `jobs`: JSONL stream shape, envelope correctness, `--strict` behaviour,
+  `--dry-run`, `--limit`, `--sources` filtering, `--exclude-sources`
+- `hydrate`: stub HTTP server (`responses` library), assert scrape success,
+  scrape failure → preserve, timeout enforcement, `--strict` vs default,
+  every row of the §9.6 hydrate truth table
+
+**CLI integration tests:** invoke `job-aggregator` as subprocess with various
+args; verify exit codes per §11; verify smoke test passes (`job-aggregator
+--help`, `job-aggregator sources`, `job-aggregator jobs --dry-run`).
+
+**Import-fence test** (added to CI): `tests/test_no_db_imports.py` greps
+the entire `src/job_aggregator/` tree for `import db`, `from psycopg2`, `from
+flask`, `from anthropic`, etc. Fails CI if any forbidden import is added.
+Enforces the no-DB / no-web / no-LLM constraint structurally.
+
+### 14.2 In `job-matcher-pr` — **PHASE 2 (DEFERRED)**
+
+- The existing 2062-test suite must continue to pass after migration
+- One new integration test: render `/settings/sources` page and assert all
+  10 plugins appear with correct field types
+- Contract test asserting `ingest.run()`'s scrape branch matches the §9.6
+  truth table (drift mitigation per §5.3)
+
+## 15. Constraints
+
+| # | Decision |
+|---|---|
+| 1 | Package is its own repo, separate from `job-matcher-pr`. |
+| 2 | Editable install (`pip install -e ../job-aggregator`) used during development. **No code duplication, no divergence window.** |
+| 3 | Package has zero database access. Cannot import `psycopg2`, `db`, or anything that does. CI enforces this with an import check. |
+| 4 | Package has zero web-framework access. No Flask, no Django imports. |
+| 5 | No filtering in package beyond fetch-side params (hours, source list). Title/contract/geo filters stay in `job-matcher-pr`. |
+| 6 | `jobs` and `hydrate` are separate commands; no `--include-descriptions` flag. |
+| 7 | Output schema is versioned per §9.5. Breaking changes bump major. |
+| 8 | Credentials file format is owned by package and versioned per §10. |
+| 9 | Plugin contract is the package's `JobSource` ABC; plugins authored against package version. |
+| 10 | `job-matcher-pr/ingest.py` continues to do its own scoring + DB writes. Package never touches scoring or DB. |
+
+## 16. Inquisitor finding resolution (v1 + v2 + v3-pass)
+
+| Finding | v1 status | v2 status | v3 status | v3 post-patch |
+|---|---|---|---|---|
+| B1 (salary_min consolidation) | Real | Paper-fixed | ✅ Eliminated (no filtering in package) | unchanged |
+| B2 (`process_listing()` extraction) | Real | Real | ✅ Eliminated (separate orchestrators) | unchanged |
+| B2 follow-on (empty source_id drop) | Real | Real | ✅ Eliminated (preserves empty) | unchanged |
+| B3 (`requires_credentials` audit) | Real | Real | 🟡 Tractable | ✅ **Resolved** — split into B1-B10 with per-plugin audit; §11.5 catalog tracks completion |
+| M1 ("required" fields not actually required) | Real | Real | 🟡 Tractable | ✅ **Resolved** — same split + §11.5 catalog |
+| M2 (GeoFilter DB coupling) | Real | Paper-fixed | ✅ Eliminated | unchanged |
+| M3 (30-min serial runs) | Real | Mitigated | ✅ Reframed | unchanged |
+| M4 (hours filter duplicated) | Real | Fixed via extraction | ✅ Eliminated | unchanged |
+| m8 (`--credentials` shape stability) | Real | Documented | ✅ Cleaner | unchanged |
+| m9 (`extra: {}` foot-gun) | Real | Documented | 🟡 Same | ✅ **Resolved** — explicit policy in §9.5: not version-covered, not tested, consumer-out-of-warranty |
+| m10 (`--dry-run` Nominatim) | Real | Fixed | ✅ Eliminated | unchanged |
+| N1 (`import ingest` requires DATABASE_URL) | — | Real | ✅ Eliminated | unchanged |
+| N2 (DBDeduplicator regression) | — | Real | ✅ Eliminated | unchanged |
+| N3 (`--query` mixed-mode trap) | — | Real | 🟡 Same | unchanged (documented design choice) |
+| **v3-pass: scrape decision tree drift** | — | — | — | ✅ **Resolved** — `SCRAPE_MIN_LENGTH` pinned to package; truth table in §9.6; parity test in `job-matcher-pr` (Issue J) |
+| **v3-pass: Issue B under-scoped** | — | — | — | ✅ **Resolved** — split into B + B1-B10; §11.5 catalog visualizes the work |
+| **v3-pass: migration step ordering** | — | — | — | ✅ **Resolved** — lockstep migration PR (§12.2 step 3) + parity test (Issue H) |
+| **v3-pass: credentials translation > 10 lines** | — | — | — | ✅ **Resolved** — promoted to named function `translate_to_package_credentials` with own tests; precedence rules documented in §10 |
+| **v3-pass: `hydrate` input contract gaps** | — | — | — | ✅ **Resolved** — §8.2.1 with explicit per-case behaviour table |
+| **v3-pass: entry-point collision semantics** | — | — | — | ✅ **Resolved** — error-on-collision policy in §6 |
+| **v3-pass: Python version policy** | — | — | — | ✅ **Resolved** — `requires-python = ">=3.11"` in §6 |
+| **v3-pass: `REQUIRED_SEARCH_FIELDS` cross-repo coupling** | — | — | — | ✅ **Resolved** — moved to `PluginInfo`; `validate_search_config` reads from package introspection (§11) |
+| **v3-pass: `fetch_page()` test fixtures** | — | — | — | ✅ **Resolved** — VCR cassettes per plugin; documented in §14.1 |
+| **v3-pass: `extra.*` enforcement policy** | — | — | — | ✅ **Resolved** — explicit policy in §9.5 |
+
+**Tally after v3 patches:** 23 of 24 findings resolved. 1 (N3) remains as a
+documented design choice with consumer-side mitigation.
+
+## 17. v2 → v3 reframe rationale
+
+v2 attempted to ship the CLI inside `job-matcher-pr` while sharing pipeline
+primitives with `ingest.run()`. The v2 inquisitor found that the
+combination of three goals — reuse existing primitives, no DB required from
+CLI, behaviour-preserving for `ingest.run()` — could not all be honored
+simultaneously. Each spec revision tightened one constraint at the cost of
+another.
+
+v3 dissolves the constraint by removing the in-repo coupling. Pipeline
+primitives move to a separate package; `job-matcher-pr` becomes a consumer
+of the package on the same footing as external evaluation tools. The
+package is structurally independent (its own repo, its own `pyproject.toml`,
+its own tests, its own CI, its own contract), so behaviour-preservation,
+import topology, and DB coupling become non-issues — the package literally
+cannot import the things that caused v2's problems, and `ingest.run()` is
+not modified.
+
+The cost is approximately the same engineering effort as v2 (move plugins,
+build CLI, build introspection API, write tests, migrate `ingest.py` and
+`web/settings.py`) but the result is structurally simpler and produces a
+real reusable package.
+
+## 18. Deferred (NOT for v1)
+
+- `--concurrency N` for `hydrate` (track as separate issue once v1 ships)
+- Salary normalization across `salary_period`
+- Caching layer between `jobs` and `hydrate` (consumers compose with shell)
+- Progress bar on stderr
+- `extra.*` field promotion process
+- REST/gRPC API surface
+- Plugin author publishing to PyPI as separate packages (entry-points
+  support is in place; documentation and ergonomics deferred to v1.1)
+
+## 19. References
+
+- **Brainstorm session** (2026-04-23) — this conversation
+- **Inquisitor reviews** — v1 review (3 blockers, 4 majors, 3 minors); v2
+  review (verified blockers + 3 new findings); v3 expected to be
+  substantially cleaner
+- **Existing code** — `job-matcher-pr/job_sources/`, `plugins/sources/`,
+  `ingest.py` (functions to migrate: `make_enabled_sources`, `scrape_description`)
+- **Plugin output audit** — Adzuna `plugins/sources/adzuna/plugin.py` lines
+  186-222; RemoteOK `plugins/sources/remoteok/plugin.py` lines 146-196.
+  Remaining 8 plugins to be audited as part of Issue B.


### PR DESCRIPTION
## Summary

Bootstrap commit: adds the v3-patched design spec produced through brainstorming + two adversarial inquisitor reviews.

The spec defines:

- **Phase 1 (primary scope)** — standalone package providing `job-aggregator jobs`, `job-aggregator hydrate`, and `job-aggregator sources` commands, plus a typed Python introspection API (`list_plugins`, `get_plugin`) for UI hosts. Migrates 10 existing aggregator plugins (Adzuna, Arbeitnow, Himalayas, Jobicy, Jooble, JSearch, RemoteOK, Remotive, The Muse, USAJobs) into a new plugin contract with full per-plugin metadata audit. No filtering, no scoring, no DB dependencies.
- **Phase 2 (deferred)** — migrates `job-matcher-pr` to consume this package instead of its local `job_sources/` and `plugins/sources/`. Includes credentials adapter, lockstep migration plan, drift mitigation tests.

## Design history

- v1: in-repo CLI inside `job-matcher-pr`. Inquisitor found 3 blockers + 4 majors + 3 minors.
- v2: in-repo CLI with `process_listing` extraction + `PipelineConfig` translator. Inquisitor verified all 10 v1 findings as still-real and added 3 new structural findings.
- v3: structural reframe to a separate package. Inquisitor verdict: "v3 is acceptable as a design and materially better than v1 or v2."
- v3-patched (this commit): targeted patches addressing inquisitor's 10 v3 concerns. 23 of 24 cumulative findings resolved; 1 (`--query` mixed-mode trap) remains as a documented design choice with consumer-side mitigation via `accepts_query` discovery field.

## Test plan

This is a docs-only commit; no tests required for the spec itself. Subsequent issues will be opened against this spec.

## Next steps after merge

- Open Milestone "v1.0" with Issues A through G + B1-B10 (per spec §13).
- Begin Phase 1 work on the package skeleton.

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*