### PR TITLE
feat: plugin contract — ABC, schemas, and exception hierarchy (#3)

### DIFF
--- a/src/job_aggregator/__init__.py
+++ b/src/job_aggregator/__init__.py
@@ -2,13 +2,25 @@
 
 Provides pluggable source plugins, normalized job-record output,
 and a structured CLI.  No scoring, no database, no LLM dependencies.
-
-Public exports will be added here as subsequent issues are implemented
-(Issues B through F in the v1 execution plan).
 """
 
 import logging
 from importlib.metadata import PackageNotFoundError, version
+
+from job_aggregator.base import JobSource
+from job_aggregator.errors import (
+    CredentialsError,
+    JobAggregatorError,
+    PluginConflictError,
+    SchemaVersionError,
+    ScrapeError,
+)
+from job_aggregator.schema import (
+    JobRecord,
+    PluginField,
+    PluginInfo,
+    SearchParams,
+)
 
 # ---------------------------------------------------------------------------
 # Version
@@ -34,9 +46,21 @@ except PackageNotFoundError:
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 # ---------------------------------------------------------------------------
-# Public API surface — intentionally empty for Issue A (skeleton).
-# Real exports (JobSource, list_plugins, get_plugin, JobRecord, …) are
-# added by Issues B through F.
+# Public API surface — Issue B exports.
+# Remaining exports (list_plugins, get_plugin, make_enabled_sources,
+# scrape_description) are added by Issues C through F.
 # ---------------------------------------------------------------------------
 
-__all__: list[str] = []
+__all__: list[str] = [
+    "CredentialsError",
+    "JobAggregatorError",
+    "JobRecord",
+    "JobSource",
+    "PluginConflictError",
+    "PluginField",
+    "PluginInfo",
+    "SchemaVersionError",
+    "ScrapeError",
+    "SearchParams",
+    "__version__",
+]

--- a/src/job_aggregator/auto_register.py
+++ b/src/job_aggregator/auto_register.py
@@ -1,0 +1,119 @@
+"""Entry-point based plugin discovery with collision detection.
+
+This module is intentionally free of side effects on import.  The
+:func:`discover_plugins` function must be called explicitly by the
+registry (:mod:`job_aggregator.registry`, Issue F) or by tests.
+
+Collision policy (spec §6):
+    When two registrations resolve to the same ``SOURCE`` key (detected
+    by loading each entry-point's class and reading its ``SOURCE``
+    attribute — NOT by entry-point name alone), a
+    :exc:`~job_aggregator.errors.PluginConflictError` is raised listing
+    both registration sources.  No silent first-wins or last-wins.
+
+Disable mechanism:
+    Set ``JOB_SCRAPER_DISABLE_PLUGINS=key1,key2`` to force-disable
+    specific plugin keys.  Filtering is applied *after* collision
+    detection so mis-configured third-party plugins are never silently
+    hidden.
+"""
+
+from __future__ import annotations
+
+import os
+from importlib.metadata import entry_points
+
+from job_aggregator.base import JobSource
+from job_aggregator.errors import PluginConflictError
+
+# ---------------------------------------------------------------------------
+# Entry-point group name (must match pyproject.toml)
+# ---------------------------------------------------------------------------
+
+_PLUGIN_GROUP = "job_aggregator.plugins"
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def discover_plugins() -> dict[str, type[JobSource]]:
+    """Discover and return all registered :class:`~job_aggregator.base.JobSource` plugins.
+
+    Reads entry-points from the ``job_aggregator.plugins`` group,
+    loads each class, and indexes the result by the class's ``SOURCE``
+    attribute.
+
+    Collision detection (spec §6):
+        If two entry-points load classes that share the same ``SOURCE``
+        key a :exc:`~job_aggregator.errors.PluginConflictError` is raised
+        listing *both* registration sources in the form
+        ``"<dist-name>::<entry-point-name>"``.  This is evaluated
+        **before** any disable filtering so that mis-configured packages
+        are never silently ignored.
+
+    Disable filtering:
+        Keys in the ``JOB_SCRAPER_DISABLE_PLUGINS`` environment variable
+        (comma-separated, whitespace around values is stripped) are
+        excluded from the returned mapping after collision detection runs.
+
+    Returns:
+        A dict mapping plugin ``SOURCE`` key → plugin class for all
+        discovered, non-disabled plugins.
+
+    Raises:
+        PluginConflictError: When two registrations claim the same
+            ``SOURCE`` key.
+    """
+    eps = entry_points(group=_PLUGIN_GROUP)
+
+    # ----------------------------------------------------------------
+    # Phase 1 — load all entry-points and collect (source_key → class)
+    # while detecting collisions.
+    # ----------------------------------------------------------------
+
+    # Maps SOURCE key → (class, registration_label)
+    # Registration label format: "<dist-name>::<ep-name>"
+    found: dict[str, tuple[type[JobSource], str]] = {}
+
+    for ep in eps:
+        cls: type[JobSource] = ep.load()
+        source_key: str = cls.SOURCE
+
+        # Build a human-readable label for this registration
+        dist_name: str = ep.dist.name if ep.dist is not None else "unknown-dist"
+        label = f"{dist_name}::{ep.name}"
+
+        if source_key in found:
+            _existing_cls, existing_label = found[source_key]
+            raise PluginConflictError(
+                key=source_key,
+                sources=[existing_label, label],
+            )
+
+        found[source_key] = (cls, label)
+
+    # ----------------------------------------------------------------
+    # Phase 2 — apply JOB_SCRAPER_DISABLE_PLUGINS filtering
+    # ----------------------------------------------------------------
+
+    disabled_keys = _parse_disable_env()
+    return {key: cls for key, (cls, _label) in found.items() if key not in disabled_keys}
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_disable_env() -> frozenset[str]:
+    """Parse the ``JOB_SCRAPER_DISABLE_PLUGINS`` env var into a set of keys.
+
+    Returns:
+        A frozenset of plugin keys to disable.  Returns an empty frozenset
+        when the variable is unset or blank.
+    """
+    raw = os.environ.get("JOB_SCRAPER_DISABLE_PLUGINS", "")
+    if not raw.strip():
+        return frozenset()
+    return frozenset(key.strip() for key in raw.split(",") if key.strip())

--- a/src/job_aggregator/base.py
+++ b/src/job_aggregator/base.py
@@ -1,0 +1,218 @@
+"""Abstract base class for job-aggregator source plugins.
+
+Plugin authors subclass :class:`JobSource`, declare the required class-level
+metadata attributes, and implement the three abstract methods.
+:meth:`JobSource.__init_subclass__` enforces attribute presence at
+class-creation time so missing metadata is caught at import, not at runtime.
+
+Example::
+
+    from collections.abc import Iterator
+    from typing import Any
+
+    from job_aggregator.base import JobSource
+
+
+    class MySource(JobSource):
+        SOURCE = "mysource"
+        DISPLAY_NAME = "My Source"
+        DESCRIPTION = "Fetches jobs from My Source API."
+        HOME_URL = "https://mysource.example.com"
+        GEO_SCOPE = "global"
+        ACCEPTS_QUERY = "always"
+        ACCEPTS_LOCATION = True
+        ACCEPTS_COUNTRY = True
+        RATE_LIMIT_NOTES = "No published limit."
+        REQUIRED_SEARCH_FIELDS: tuple[str, ...] = ()
+
+        def settings_schema(self) -> dict[str, Any]:
+            return {
+                "api_key": {
+                    "label": "API Key",
+                    "type": "password",
+                    "required": True,
+                }
+            }
+
+        def pages(self) -> Iterator[list[dict[str, Any]]]:
+            ...
+
+        def normalise(self, raw: dict[str, Any]) -> dict[str, Any]:
+            ...
+"""
+
+from __future__ import annotations
+
+import abc
+import inspect
+from collections.abc import Iterator
+from typing import Any, ClassVar, Literal
+
+# ---------------------------------------------------------------------------
+# Required class-level attribute names — enforced by __init_subclass__
+# ---------------------------------------------------------------------------
+
+_REQUIRED_CLASS_ATTRS: tuple[str, ...] = (
+    "SOURCE",
+    "DISPLAY_NAME",
+    "DESCRIPTION",
+    "HOME_URL",
+    "GEO_SCOPE",
+    "ACCEPTS_QUERY",
+    "ACCEPTS_LOCATION",
+    "ACCEPTS_COUNTRY",
+    "RATE_LIMIT_NOTES",
+)
+
+
+# ---------------------------------------------------------------------------
+# JobSource ABC
+# ---------------------------------------------------------------------------
+
+
+class JobSource(abc.ABC):
+    """Abstract base class for all job-aggregator source plugins.
+
+    Every plugin must subclass ``JobSource``, declare the required
+    class-level metadata attributes, and implement the three abstract
+    methods.  The ``__init_subclass__`` hook enforces attribute presence
+    at class-creation time; missing attributes raise :exc:`TypeError`
+    immediately on import rather than producing confusing
+    :exc:`AttributeError` failures at runtime.
+
+    Class-level attributes (must be declared on every concrete subclass):
+
+    Attributes:
+        SOURCE: Unique machine-readable plugin key used as the dict key
+            in credentials files and as the ``source`` field in output
+            records (e.g. ``"adzuna"``).
+        DISPLAY_NAME: Human-readable plugin name shown in UIs
+            (e.g. ``"Adzuna"``).
+        DESCRIPTION: Short description of the job source.
+        HOME_URL: URL for the source's public homepage.
+        GEO_SCOPE: Geographic coverage of the source.  One of:
+            ``"global"``, ``"global-by-country"``, ``"remote-only"``,
+            ``"federal-us"``, ``"regional"``, ``"unknown"``.
+        ACCEPTS_QUERY: How the source handles free-text queries.  One of:
+            ``"always"`` (query is sent to the API),
+            ``"partial"`` (query is partially supported or best-effort),
+            ``"never"`` (source does not accept a query parameter).
+        ACCEPTS_LOCATION: ``True`` if the source accepts a location
+            filter in its API.
+        ACCEPTS_COUNTRY: ``True`` if the source accepts a country code
+            filter in its API.
+        RATE_LIMIT_NOTES: Human-readable rate-limit information for the
+            source (e.g. ``"1 req/sec, 250/day on free tier"``).
+        REQUIRED_SEARCH_FIELDS: Tuple of :class:`~job_aggregator.schema.SearchParams`
+            field names that must be non-``None`` for the plugin to run
+            successfully (e.g. ``("country",)``).  Defaults to ``()``.
+    """
+
+    SOURCE: ClassVar[str]
+    DISPLAY_NAME: ClassVar[str]
+    DESCRIPTION: ClassVar[str]
+    HOME_URL: ClassVar[str]
+    GEO_SCOPE: ClassVar[
+        Literal["global", "global-by-country", "remote-only", "federal-us", "regional", "unknown"]
+    ]
+    ACCEPTS_QUERY: ClassVar[Literal["always", "partial", "never"]]
+    ACCEPTS_LOCATION: ClassVar[bool]
+    ACCEPTS_COUNTRY: ClassVar[bool]
+    RATE_LIMIT_NOTES: ClassVar[str]
+    REQUIRED_SEARCH_FIELDS: ClassVar[tuple[str, ...]] = ()
+
+    # ------------------------------------------------------------------
+    # Subclass enforcement hook
+    # ------------------------------------------------------------------
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Enforce required class-level attributes on concrete subclasses.
+
+        Called automatically by Python for every class that directly or
+        indirectly inherits from :class:`JobSource`.  If the subclass is
+        still abstract (i.e. it has unimplemented abstract methods),
+        enforcement is skipped so intermediate base classes can omit the
+        attributes without raising.
+
+        Args:
+            **kwargs: Forwarded to :func:`super().__init_subclass__`.
+
+        Raises:
+            TypeError: If the concrete subclass does not declare one or
+                more of the required class-level attributes listed in
+                :data:`_REQUIRED_CLASS_ATTRS`.
+        """
+        super().__init_subclass__(**kwargs)
+
+        # Skip enforcement for abstract intermediate classes.
+        # inspect.isabstract checks for non-empty __abstractmethods__
+        # which is set by ABCMeta before __init_subclass__ is called.
+        if inspect.isabstract(cls):
+            return
+
+        missing = [attr for attr in _REQUIRED_CLASS_ATTRS if not hasattr(cls, attr)]
+        if missing:
+            raise TypeError(
+                f"Concrete JobSource subclass {cls.__name__!r} must declare "
+                f"the following class-level attributes: "
+                f"{', '.join(missing)}."
+            )
+
+    # ------------------------------------------------------------------
+    # Abstract methods (must be implemented by every concrete subclass)
+    # ------------------------------------------------------------------
+
+    @abc.abstractmethod
+    def settings_schema(self) -> dict[str, Any]:
+        """Return the field definitions used to build :class:`~job_aggregator.schema.PluginInfo`.
+
+        Each key in the returned dict is a credential / configuration
+        field name; the value is a dict describing the field with the
+        following keys:
+
+        - ``"label"`` (:class:`str`) — human-readable field label.
+        - ``"type"`` (:class:`str`) — one of ``"text"``, ``"password"``,
+          ``"email"``, ``"url"``, ``"number"``.
+        - ``"required"`` (:class:`bool`, optional) — whether the field
+          must be present; defaults to ``False``.
+        - ``"help_text"`` (:class:`str`, optional) — explanatory text.
+
+        Returns:
+            A dict mapping field name to field definition.  Return an
+            empty dict for plugins that require no credentials.
+        """
+        ...
+
+    @abc.abstractmethod
+    def pages(self) -> Iterator[list[dict[str, Any]]]:
+        """Yield pages of raw job listings from the source API.
+
+        Each yielded page is a list of raw dicts as returned by the
+        source API.  The caller passes each raw dict to
+        :meth:`normalise`.  Search parameters (query, location,
+        country, hours, max_pages) are accepted by the constructor and
+        stored as instance attributes; ``pages()`` takes no arguments.
+
+        Yields:
+            A list of raw API dicts for each page of results.  Yielding
+            an empty list is valid and signals "no more results".
+        """
+        ...
+
+    @abc.abstractmethod
+    def normalise(self, raw: dict[str, Any]) -> dict[str, Any]:
+        """Map a raw source-API dict to the package's normalised record shape.
+
+        The returned dict should conform to the :class:`~job_aggregator.schema.JobRecord`
+        TypedDict contract.  In particular it must include the identity
+        fields ``source``, ``source_id``, and ``description_source``, and
+        the always-present fields ``title``, ``url``, ``posted_at``, and
+        ``description``.
+
+        Args:
+            raw: A single raw listing dict as yielded by :meth:`pages`.
+
+        Returns:
+            A normalised dict ready for output as a :class:`~job_aggregator.schema.JobRecord`.
+        """
+        ...

--- a/src/job_aggregator/errors.py
+++ b/src/job_aggregator/errors.py
@@ -1,0 +1,167 @@
+"""Exception hierarchy for the job-aggregator package.
+
+All package-specific exceptions inherit from ``JobAggregatorError`` so
+callers can catch any package error with a single except clause while
+still being able to distinguish individual failure modes.
+"""
+
+from __future__ import annotations
+
+
+class JobAggregatorError(Exception):
+    """Base class for all job-aggregator exceptions."""
+
+
+class PluginConflictError(JobAggregatorError):
+    """Two registrations claim the same plugin SOURCE key.
+
+    Raised by :func:`job_aggregator.auto_register.discover_plugins` when
+    the entry-point scan finds duplicate ``SOURCE`` values across different
+    distribution packages or entry-point names.  The error is fatal: the
+    ambiguity must be resolved by the user (uninstall the duplicate or add
+    the key to ``JOB_SCRAPER_DISABLE_PLUGINS``) before the package can
+    start cleanly.
+
+    Attributes:
+        key: The conflicting plugin key (e.g. ``"adzuna"``).
+        sources: Both registration identifiers in the form
+            ``"<dist-name>::<entry-point-name>"``.
+    """
+
+    def __init__(self, key: str, sources: list[str]) -> None:
+        """Initialise the error with the conflicting key and both sources.
+
+        Args:
+            key: The plugin SOURCE key that is claimed by multiple
+                registrations.
+            sources: A two-element list of registration identifiers, each
+                in the form ``"<dist-name>::<entry-point-name>"``.
+        """
+        self.key = key
+        self.sources = sources
+        super().__init__(str(self))
+
+    def __str__(self) -> str:
+        """Return a human-readable description listing both sources.
+
+        Returns:
+            A string naming the conflicting key and both registration
+            sources so the user knows exactly which packages to examine.
+        """
+        sources_str = ", ".join(self.sources)
+        return (
+            f"Plugin key {self.key!r} is registered by multiple sources: "
+            f"{sources_str}. "
+            f"Uninstall one of the conflicting packages or add "
+            f"{self.key!r} to JOB_SCRAPER_DISABLE_PLUGINS."
+        )
+
+
+class ScrapeError(JobAggregatorError):
+    """HTTP or parse failure while scraping a job description URL.
+
+    Raised (or stored and emitted) by
+    :func:`job_aggregator.scraping.scrape_description` when the HTTP
+    request fails or the response body cannot be parsed.
+
+    Attributes:
+        url: The URL that was being scraped.
+        reason: Human-readable explanation of the failure (e.g.
+            ``"HTTP 404"`` or ``"connection timed out"``).
+    """
+
+    def __init__(self, url: str, reason: str) -> None:
+        """Initialise the error with the target URL and failure reason.
+
+        Args:
+            url: The job posting URL that triggered the scrape failure.
+            reason: A short human-readable explanation of why the scrape
+                failed (HTTP status, network error, parse error, etc.).
+        """
+        self.url = url
+        self.reason = reason
+        super().__init__(str(self))
+
+    def __str__(self) -> str:
+        """Return a human-readable description of the scrape failure.
+
+        Returns:
+            A string combining the URL and reason for quick log diagnosis.
+        """
+        return f"Scrape failed for {self.url!r}: {self.reason}"
+
+
+class CredentialsError(JobAggregatorError):
+    """Missing or invalid credentials at plugin construction time.
+
+    Raised by a ``JobSource`` subclass ``__init__`` when the credentials
+    dict supplied by the caller omits one or more required fields.
+
+    Attributes:
+        plugin_key: The SOURCE key of the plugin that raised this error.
+        missing_fields: Names of the credential fields that were absent or
+            empty in the supplied credentials dict.
+    """
+
+    def __init__(self, plugin_key: str, missing_fields: list[str]) -> None:
+        """Initialise the error with the plugin key and missing field names.
+
+        Args:
+            plugin_key: The ``SOURCE`` key of the plugin that detected the
+                missing credentials (e.g. ``"adzuna"``).
+            missing_fields: List of field names that are absent or empty in
+                the credentials dict provided by the caller.
+        """
+        self.plugin_key = plugin_key
+        self.missing_fields = missing_fields
+        super().__init__(str(self))
+
+    def __str__(self) -> str:
+        """Return a human-readable description of the missing fields.
+
+        Returns:
+            A string naming the plugin and each missing field so the user
+            knows exactly what to supply.
+        """
+        fields_str = ", ".join(self.missing_fields)
+        return f"Plugin {self.plugin_key!r} is missing required credentials: {fields_str}."
+
+
+class SchemaVersionError(JobAggregatorError):
+    """Input envelope schema_version is incompatible with this package version.
+
+    Raised by ``job-aggregator hydrate`` when the envelope's
+    ``schema_version`` major component differs from the package's current
+    major version (cross-major is refused; see spec §8.2.1).
+
+    Attributes:
+        got: The ``schema_version`` string found in the input envelope.
+        expected: The ``schema_version`` string the package expects (current
+            major, e.g. ``"1.0"``).
+    """
+
+    def __init__(self, got: str, expected: str) -> None:
+        """Initialise the error with the received and expected versions.
+
+        Args:
+            got: The ``schema_version`` value found in the input envelope.
+            expected: The ``schema_version`` value this package version
+                accepts.
+        """
+        self.got = got
+        self.expected = expected
+        super().__init__(str(self))
+
+    def __str__(self) -> str:
+        """Return a human-readable description of the version mismatch.
+
+        Returns:
+            A string comparing the received version against the expected
+            version so the user knows how to resolve the incompatibility.
+        """
+        return (
+            f"Input schema_version {self.got!r} is incompatible with "
+            f"this package (expected major version {self.expected!r}). "
+            f"Re-generate the input with a compatible version of "
+            f"job-aggregator."
+        )

--- a/src/job_aggregator/schema.py
+++ b/src/job_aggregator/schema.py
@@ -1,0 +1,216 @@
+"""Schema types for the job-aggregator package.
+
+Defines the structured data types used across the public API:
+
+- :class:`PluginField` — describes one credential or configuration field
+  that a plugin requires.
+- :class:`PluginInfo` — a complete, serialisable description of a plugin
+  built from its class-level metadata and ``settings_schema()`` return
+  value.
+- :class:`SearchParams` — the search parameters accepted by ``jobs``.
+- :class:`JobRecord` — the normalized per-job output record (TypedDict).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, TypedDict
+
+# ---------------------------------------------------------------------------
+# PluginField
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class PluginField:
+    """Describes one credential or configuration field for a plugin.
+
+    Used to build :attr:`PluginInfo.fields`.  The consuming application
+    renders these fields as HTML inputs or CLI prompts — the package
+    describes *what* is needed but does not render or validate.
+
+    Attributes:
+        name: Machine-readable field identifier (e.g. ``"app_id"``).
+            Must be a valid Python identifier; used as the dict key in
+            the credentials file.
+        label: Human-readable display name for the field
+            (e.g. ``"App ID"``).
+        type: Input type hint for the consuming UI.  One of
+            ``"text"``, ``"password"``, ``"email"``, ``"url"``,
+            ``"number"``.
+        required: ``True`` if the plugin cannot function without this
+            field; ``False`` for optional enhancement fields.
+        help_text: Optional explanatory text shown alongside the input,
+            e.g. ``"Found in your Adzuna developer console."``
+    """
+
+    name: str
+    label: str
+    type: Literal["text", "password", "email", "url", "number"]
+    required: bool = False
+    help_text: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# PluginInfo
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class PluginInfo:
+    """Complete, serialisable description of a registered plugin.
+
+    Built from a :class:`~job_aggregator.base.JobSource` subclass's
+    class-level metadata and its :meth:`settings_schema` return value.
+    Consumed by ``list_plugins()`` / ``get_plugin()`` and emitted by
+    ``job-aggregator sources``.
+
+    Attributes:
+        key: Unique plugin identifier (mirrors ``JobSource.SOURCE``).
+        display_name: Human-readable plugin name
+            (mirrors ``JobSource.DISPLAY_NAME``).
+        description: Short description of the source
+            (mirrors ``JobSource.DESCRIPTION``).
+        home_url: URL for the source's public homepage
+            (mirrors ``JobSource.HOME_URL``).
+        geo_scope: Geographic coverage of the source
+            (mirrors ``JobSource.GEO_SCOPE``).
+        accepts_query: How the source handles free-text search queries
+            (mirrors ``JobSource.ACCEPTS_QUERY``).
+        accepts_location: Whether the source accepts a location filter
+            (mirrors ``JobSource.ACCEPTS_LOCATION``).
+        accepts_country: Whether the source accepts a country filter
+            (mirrors ``JobSource.ACCEPTS_COUNTRY``).
+        rate_limit_notes: Human-readable rate-limit description
+            (mirrors ``JobSource.RATE_LIMIT_NOTES``).
+        required_search_fields: Field names that must be present in
+            :class:`SearchParams` for this plugin to run successfully
+            (mirrors ``JobSource.REQUIRED_SEARCH_FIELDS``).
+        fields: Credential / config field definitions built from
+            ``JobSource.settings_schema()``.
+        requires_credentials: ``True`` if any field in :attr:`fields`
+            is marked ``required=True``.  Derived property.
+    """
+
+    key: str
+    display_name: str
+    description: str
+    home_url: str
+    geo_scope: str
+    accepts_query: str
+    accepts_location: bool
+    accepts_country: bool
+    rate_limit_notes: str
+    required_search_fields: tuple[str, ...]
+    fields: tuple[PluginField, ...]
+
+    @property
+    def requires_credentials(self) -> bool:
+        """Return True if any field is marked required.
+
+        Returns:
+            ``True`` when at least one :class:`PluginField` in
+            :attr:`fields` has ``required=True``; ``False`` otherwise
+            (including when :attr:`fields` is empty).
+        """
+        return any(f.required for f in self.fields)
+
+
+# ---------------------------------------------------------------------------
+# SearchParams
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class SearchParams:
+    """Parameters that control a ``job-aggregator jobs`` run.
+
+    All fields are optional; omitted fields use sensible defaults.
+    Pass an instance to ``make_enabled_sources()`` or the ``jobs``
+    orchestrator.
+
+    Attributes:
+        query: Free-text search query (e.g. ``"python developer"``).
+            Ignored by plugins where ``accepts_query="never"``.
+        location: Free-text location hint (e.g. ``"Atlanta, GA"``).
+            Used as a search parameter by plugins that support it; no
+            client-side geo filtering is performed.
+        country: ISO 3166-1 alpha-2 country code (e.g. ``"us"``).
+            Passed to plugins that accept a country filter.
+        hours: Lookback window in hours.  Only listings posted within
+            the last ``hours`` hours are returned.  Defaults to 168
+            (one week).
+        max_pages: Per-source page cap.  ``None`` means each plugin
+            uses its own default maximum.
+    """
+
+    query: str | None = None
+    location: str | None = None
+    country: str | None = None
+    hours: int = 168
+    max_pages: int | None = None
+
+
+# ---------------------------------------------------------------------------
+# JobRecord
+# ---------------------------------------------------------------------------
+
+# PEP 655 Required / NotRequired are available in Python 3.11+ via typing.
+# We use NotRequired for optional fields so the TypedDict is total=True
+# for the required base and uses NotRequired for everything else — cleaner
+# than the two-class inheritance pattern and compatible with mypy --strict.
+
+
+class JobRecord(TypedDict, total=False):
+    """Normalised per-job output record.
+
+    Produced by plugin ``normalise()`` calls and emitted by the ``jobs``
+    orchestrator.  Consumed by ``hydrate`` (which may update
+    ``description`` and ``description_source``).
+
+    Three field categories match spec §9.3:
+
+    **Identity (always present, validation-checked):**
+    ``source``, ``source_id``, ``description_source``
+
+    **Always-present (always serialised, may be empty per stated rules):**
+    ``title``, ``url``, ``posted_at``, ``description``
+
+    **Optional (serialised, often null):**
+    ``company``, ``location``, ``salary_min``, ``salary_max``,
+    ``salary_currency``, ``salary_period``, ``contract_type``,
+    ``contract_time``, ``remote_eligible``
+
+    **Source-specific blob:**
+    ``extra`` — explicitly *not* covered by schema versioning; consumers
+    depend on ``extra.*`` at their own risk.
+
+    Notes:
+        Empty string means "source provided an empty value".
+        ``None`` means "source did not provide this key at all".
+    """
+
+    # ---- Identity (required) ----
+    source: str
+    source_id: str
+    description_source: Literal["full", "snippet", "none"]
+
+    # ---- Always-present (required) ----
+    title: str
+    url: str
+    posted_at: str | None
+    description: str
+
+    # ---- Optional ----
+    company: str | None
+    location: str | None
+    salary_min: float | None
+    salary_max: float | None
+    salary_currency: str | None
+    salary_period: Literal["annual", "monthly", "hourly"] | None
+    contract_type: str | None
+    contract_time: str | None
+    remote_eligible: bool | None
+
+    # ---- Source-specific blob ----
+    extra: dict[str, Any] | None

--- a/tests/test_auto_register.py
+++ b/tests/test_auto_register.py
@@ -1,0 +1,305 @@
+"""Tests for the auto_register entry-point discovery module.
+
+Uses unittest.mock to patch importlib.metadata.entry_points so no real
+installed plugins are needed. Tests cover:
+- Normal discovery (no conflicts, no disables)
+- Collision detection (same SOURCE key from two registrations)
+- JOB_SCRAPER_DISABLE_PLUGINS env-var filtering
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from job_aggregator.auto_register import discover_plugins
+from job_aggregator.base import JobSource
+from job_aggregator.errors import PluginConflictError
+
+# ---------------------------------------------------------------------------
+# Helpers: synthetic JobSource subclasses and mock entry-points
+# ---------------------------------------------------------------------------
+
+
+def _make_source_class(source_key: str) -> type[JobSource]:
+    """Dynamically create a minimal concrete JobSource with the given SOURCE key."""
+
+    class _Src(JobSource):
+        SOURCE = source_key
+        DISPLAY_NAME = source_key.title()
+        DESCRIPTION = f"Test source {source_key}."
+        HOME_URL = f"https://{source_key}.example.com"
+        GEO_SCOPE = "global"
+        ACCEPTS_QUERY = "always"
+        ACCEPTS_LOCATION = True
+        ACCEPTS_COUNTRY = True
+        RATE_LIMIT_NOTES = "None."
+        REQUIRED_SEARCH_FIELDS = ()
+
+        def settings_schema(self) -> dict[str, Any]:
+            return {}
+
+        def pages(self) -> Iterator[list[dict[str, Any]]]:
+            return iter([])
+
+        def normalise(self, raw: dict[str, Any]) -> dict[str, Any]:
+            return raw
+
+    # Give the class a unique name so Python's type system doesn't merge them
+    _Src.__name__ = f"_Src_{source_key}"
+    _Src.__qualname__ = f"_Src_{source_key}"
+    return _Src
+
+
+def _make_entry_point(name: str, cls: type[JobSource], dist_name: str) -> MagicMock:
+    """Return a mock object that satisfies the EntryPoint protocol used in auto_register."""
+    ep = MagicMock()
+    ep.name = name
+    ep.load.return_value = cls
+    ep.dist = MagicMock()
+    ep.dist.name = dist_name
+    return ep
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: multiple distinct plugins
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverPluginsHappyPath:
+    """discover_plugins returns all registered plugins when there are no conflicts."""
+
+    def test_returns_empty_dict_when_no_entry_points(self) -> None:
+        """discover_plugins returns {} when no entry-points are registered."""
+        with patch(
+            "job_aggregator.auto_register.entry_points",
+            return_value=[],
+        ):
+            result = discover_plugins()
+        assert result == {}
+
+    def test_single_plugin_registered(self) -> None:
+        """discover_plugins returns {SOURCE: cls} for one registered plugin."""
+        cls_a = _make_source_class("adzuna")
+        ep_a = _make_entry_point("adzuna", cls_a, "job-aggregator")
+
+        with patch(
+            "job_aggregator.auto_register.entry_points",
+            return_value=[ep_a],
+        ):
+            result = discover_plugins()
+
+        assert "adzuna" in result
+        assert result["adzuna"] is cls_a
+
+    def test_multiple_distinct_plugins_all_returned(self) -> None:
+        """All distinct plugin classes are returned when there are no conflicts."""
+        cls_a = _make_source_class("adzuna")
+        cls_b = _make_source_class("remoteok")
+        eps = [
+            _make_entry_point("adzuna", cls_a, "job-aggregator"),
+            _make_entry_point("remoteok", cls_b, "job-aggregator"),
+        ]
+
+        with patch(
+            "job_aggregator.auto_register.entry_points",
+            return_value=eps,
+        ):
+            result = discover_plugins()
+
+        assert set(result.keys()) == {"adzuna", "remoteok"}
+        assert result["adzuna"] is cls_a
+        assert result["remoteok"] is cls_b
+
+
+# ---------------------------------------------------------------------------
+# Collision detection
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverPluginsCollisionDetection:
+    """Raises PluginConflictError when two registrations claim the same SOURCE key."""
+
+    def test_same_source_key_raises_conflict_error(self) -> None:
+        """Two entry-points loading classes with the same SOURCE key raises PluginConflictError."""
+        cls_builtin = _make_source_class("adzuna")
+        cls_thirdparty = _make_source_class("adzuna")
+        eps = [
+            _make_entry_point("adzuna", cls_builtin, "job-aggregator"),
+            _make_entry_point("adzuna-extra", cls_thirdparty, "adzuna-extra-pkg"),
+        ]
+
+        with (
+            pytest.raises(PluginConflictError) as exc_info,
+            patch(
+                "job_aggregator.auto_register.entry_points",
+                return_value=eps,
+            ),
+        ):
+            discover_plugins()
+
+        err = exc_info.value
+        assert err.key == "adzuna"
+
+    def test_conflict_error_lists_both_registration_sources(self) -> None:
+        """PluginConflictError str/sources includes both dist+name identifiers."""
+        cls_a = _make_source_class("adzuna")
+        cls_b = _make_source_class("adzuna")
+        eps = [
+            _make_entry_point("adzuna", cls_a, "job-aggregator"),
+            _make_entry_point("adzuna-extra", cls_b, "adzuna-extra-pkg"),
+        ]
+
+        with (
+            pytest.raises(PluginConflictError) as exc_info,
+            patch(
+                "job_aggregator.auto_register.entry_points",
+                return_value=eps,
+            ),
+        ):
+            discover_plugins()
+
+        err = exc_info.value
+        msg = str(err)
+        # Both registration sources must appear in the error message
+        assert "job-aggregator" in msg
+        assert "adzuna-extra-pkg" in msg
+
+    def test_conflict_detected_by_source_attribute_not_ep_name(self) -> None:
+        """Collision is detected via the class's SOURCE attr, not entry-point name.
+
+        Scenario: entry-point is named 'foo' but loads a class with SOURCE='adzuna',
+        which conflicts with a correctly-named 'adzuna' entry-point.
+        """
+        cls_correct = _make_source_class("adzuna")
+        cls_misnamed = _make_source_class("adzuna")  # SOURCE='adzuna' but ep name='foo'
+        eps = [
+            _make_entry_point("adzuna", cls_correct, "job-aggregator"),
+            _make_entry_point("foo", cls_misnamed, "some-other-pkg"),
+        ]
+
+        with (
+            pytest.raises(PluginConflictError) as exc_info,
+            patch(
+                "job_aggregator.auto_register.entry_points",
+                return_value=eps,
+            ),
+        ):
+            discover_plugins()
+
+        assert exc_info.value.key == "adzuna"
+
+
+# ---------------------------------------------------------------------------
+# JOB_SCRAPER_DISABLE_PLUGINS env-var filtering
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverPluginsDisableFilter:
+    """Keys listed in JOB_SCRAPER_DISABLE_PLUGINS are excluded from results."""
+
+    def test_disabled_key_excluded_from_result(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A key in JOB_SCRAPER_DISABLE_PLUGINS does not appear in the result."""
+        monkeypatch.setenv("JOB_SCRAPER_DISABLE_PLUGINS", "adzuna")
+        cls_a = _make_source_class("adzuna")
+        cls_b = _make_source_class("remoteok")
+        eps = [
+            _make_entry_point("adzuna", cls_a, "job-aggregator"),
+            _make_entry_point("remoteok", cls_b, "job-aggregator"),
+        ]
+
+        with patch(
+            "job_aggregator.auto_register.entry_points",
+            return_value=eps,
+        ):
+            result = discover_plugins()
+
+        assert "adzuna" not in result
+        assert "remoteok" in result
+
+    def test_multiple_disabled_keys_all_excluded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Multiple comma-separated keys are all excluded."""
+        monkeypatch.setenv("JOB_SCRAPER_DISABLE_PLUGINS", "adzuna,remoteok")
+        cls_a = _make_source_class("adzuna")
+        cls_b = _make_source_class("remoteok")
+        cls_c = _make_source_class("jooble")
+        eps = [
+            _make_entry_point("adzuna", cls_a, "job-aggregator"),
+            _make_entry_point("remoteok", cls_b, "job-aggregator"),
+            _make_entry_point("jooble", cls_c, "job-aggregator"),
+        ]
+
+        with patch(
+            "job_aggregator.auto_register.entry_points",
+            return_value=eps,
+        ):
+            result = discover_plugins()
+
+        assert "adzuna" not in result
+        assert "remoteok" not in result
+        assert "jooble" in result
+
+    def test_disable_filter_applied_after_collision_detection(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Collision detection runs on the full set before disable filtering.
+
+        Even if a colliding key would later be disabled, the collision must
+        still be raised.  This prevents a scenario where disabling one entry
+        silently hides a mis-configured third-party plugin.
+        """
+        monkeypatch.setenv("JOB_SCRAPER_DISABLE_PLUGINS", "adzuna")
+        cls_a = _make_source_class("adzuna")
+        cls_b = _make_source_class("adzuna")  # conflict!
+        eps = [
+            _make_entry_point("adzuna", cls_a, "job-aggregator"),
+            _make_entry_point("adzuna-dupe", cls_b, "some-pkg"),
+        ]
+
+        with (
+            pytest.raises(PluginConflictError),
+            patch(
+                "job_aggregator.auto_register.entry_points",
+                return_value=eps,
+            ),
+        ):
+            discover_plugins()
+
+    def test_no_disable_var_returns_all_plugins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When JOB_SCRAPER_DISABLE_PLUGINS is not set, all plugins are returned."""
+        monkeypatch.delenv("JOB_SCRAPER_DISABLE_PLUGINS", raising=False)
+        cls_a = _make_source_class("adzuna")
+        cls_b = _make_source_class("remoteok")
+        eps = [
+            _make_entry_point("adzuna", cls_a, "job-aggregator"),
+            _make_entry_point("remoteok", cls_b, "job-aggregator"),
+        ]
+
+        with patch(
+            "job_aggregator.auto_register.entry_points",
+            return_value=eps,
+        ):
+            result = discover_plugins()
+
+        assert set(result.keys()) == {"adzuna", "remoteok"}
+
+    def test_disable_var_with_spaces_around_commas(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Spaces around comma separators are stripped when parsing the disable list."""
+        monkeypatch.setenv("JOB_SCRAPER_DISABLE_PLUGINS", " adzuna , remoteok ")
+        cls_a = _make_source_class("adzuna")
+        cls_b = _make_source_class("remoteok")
+        eps = [
+            _make_entry_point("adzuna", cls_a, "job-aggregator"),
+            _make_entry_point("remoteok", cls_b, "job-aggregator"),
+        ]
+
+        with patch(
+            "job_aggregator.auto_register.entry_points",
+            return_value=eps,
+        ):
+            result = discover_plugins()
+
+        assert result == {}

--- a/tests/test_base_abc.py
+++ b/tests/test_base_abc.py
@@ -1,0 +1,254 @@
+"""Tests for the JobSource abstract base class.
+
+Tests verify:
+- A fully-declared concrete subclass instantiates successfully
+- Missing any one required class-level attribute raises TypeError at
+  class-definition time
+- Failing to implement an abstract method raises TypeError on instantiation
+- The abstract method ABC enforcement is independent of attribute enforcement
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from job_aggregator.base import JobSource
+
+# ---------------------------------------------------------------------------
+# A complete, valid concrete subclass used across multiple tests
+# ---------------------------------------------------------------------------
+
+
+class _ValidSource(JobSource):
+    """Minimal concrete JobSource for tests."""
+
+    SOURCE = "valid"
+    DISPLAY_NAME = "Valid Source"
+    DESCRIPTION = "A test source."
+    HOME_URL = "https://valid.example.com"
+    GEO_SCOPE = "global"
+    ACCEPTS_QUERY = "always"
+    ACCEPTS_LOCATION = True
+    ACCEPTS_COUNTRY = True
+    RATE_LIMIT_NOTES = "No known limits."
+    REQUIRED_SEARCH_FIELDS = ()
+
+    def settings_schema(self) -> dict[str, Any]:
+        """Return empty settings schema."""
+        return {}
+
+    def pages(self) -> Iterator[list[dict[str, Any]]]:
+        """Yield no pages."""
+        return iter([])
+
+    def normalise(self, raw: dict[str, Any]) -> dict[str, Any]:
+        """Return raw unchanged."""
+        return raw
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: valid subclass
+# ---------------------------------------------------------------------------
+
+
+class TestValidSubclass:
+    """A fully-conforming subclass works without errors."""
+
+    def test_instantiates_successfully(self) -> None:
+        """A concrete subclass with all required attrs and methods instantiates."""
+        src = _ValidSource()
+        assert src is not None
+
+    def test_source_attribute_accessible(self) -> None:
+        """SOURCE attribute is accessible on the instance."""
+        src = _ValidSource()
+        assert src.SOURCE == "valid"
+
+    def test_pages_is_callable(self) -> None:
+        """pages() is callable and returns an iterator."""
+        src = _ValidSource()
+        result = src.pages()
+        # Must be iterable; consuming it should produce no pages for _ValidSource
+        pages = list(result)
+        assert pages == []
+
+    def test_normalise_is_callable(self) -> None:
+        """normalise() is callable and returns a dict."""
+        src = _ValidSource()
+        raw: dict[str, Any] = {"key": "value"}
+        assert src.normalise(raw) == raw
+
+    def test_settings_schema_returns_dict(self) -> None:
+        """settings_schema() returns a dict."""
+        src = _ValidSource()
+        schema = src.settings_schema()
+        assert isinstance(schema, dict)
+
+
+# ---------------------------------------------------------------------------
+# Attribute enforcement: missing required class-level attrs → TypeError
+# ---------------------------------------------------------------------------
+
+
+class TestMissingRequiredAttributes:
+    """Each missing required class-level attribute raises TypeError at class definition."""
+
+    REQUIRED_ATTRS = (
+        "SOURCE",
+        "DISPLAY_NAME",
+        "DESCRIPTION",
+        "HOME_URL",
+        "GEO_SCOPE",
+        "ACCEPTS_QUERY",
+        "ACCEPTS_LOCATION",
+        "ACCEPTS_COUNTRY",
+        "RATE_LIMIT_NOTES",
+    )
+
+    def _make_subclass_missing(self, missing_attr: str) -> None:
+        """Dynamically create a subclass that omits one required attribute.
+
+        We use type() rather than exec() so the class is constructed in
+        a way that triggers __init_subclass__ at class-creation time.
+        """
+        # Build a namespace with all required attrs except the missing one
+        namespace: dict[str, Any] = {
+            "SOURCE": "test",
+            "DISPLAY_NAME": "Test",
+            "DESCRIPTION": "Test source.",
+            "HOME_URL": "https://test.example.com",
+            "GEO_SCOPE": "global",
+            "ACCEPTS_QUERY": "always",
+            "ACCEPTS_LOCATION": True,
+            "ACCEPTS_COUNTRY": True,
+            "RATE_LIMIT_NOTES": "None.",
+            "REQUIRED_SEARCH_FIELDS": (),
+            "settings_schema": lambda self: {},
+            "pages": lambda self: iter([]),
+            "normalise": lambda self, raw: raw,
+        }
+        del namespace[missing_attr]
+        # type() triggers __init_subclass__ — should raise TypeError
+        type("_IncompleteSource", (JobSource,), namespace)
+
+    @pytest.mark.parametrize("attr", REQUIRED_ATTRS)
+    def test_missing_attribute_raises_type_error(self, attr: str) -> None:
+        """Creating a subclass that omits a required attribute raises TypeError."""
+        with pytest.raises(TypeError, match=attr):
+            self._make_subclass_missing(attr)
+
+
+# ---------------------------------------------------------------------------
+# Abstract method enforcement: missing implementation → TypeError on init
+# ---------------------------------------------------------------------------
+
+
+class TestAbstractMethodEnforcement:
+    """Subclasses missing abstract method implementations cannot be instantiated."""
+
+    def test_missing_pages_raises_type_error(self) -> None:
+        """A subclass missing pages() cannot be instantiated."""
+
+        class _NoPagesSource(JobSource):
+            SOURCE = "no_pages"
+            DISPLAY_NAME = "No Pages"
+            DESCRIPTION = "Missing pages."
+            HOME_URL = "https://no-pages.example.com"
+            GEO_SCOPE = "global"
+            ACCEPTS_QUERY = "always"
+            ACCEPTS_LOCATION = False
+            ACCEPTS_COUNTRY = False
+            RATE_LIMIT_NOTES = "N/A"
+            REQUIRED_SEARCH_FIELDS = ()
+
+            def settings_schema(self) -> dict[str, Any]:
+                return {}
+
+            def normalise(self, raw: dict[str, Any]) -> dict[str, Any]:
+                return raw
+
+            # pages() intentionally omitted
+
+        with pytest.raises(TypeError):
+            _NoPagesSource()  # type: ignore[abstract]
+
+    def test_missing_normalise_raises_type_error(self) -> None:
+        """A subclass missing normalise() cannot be instantiated."""
+
+        class _NoNormaliseSource(JobSource):
+            SOURCE = "no_normalise"
+            DISPLAY_NAME = "No Normalise"
+            DESCRIPTION = "Missing normalise."
+            HOME_URL = "https://no-normalise.example.com"
+            GEO_SCOPE = "remote-only"
+            ACCEPTS_QUERY = "never"
+            ACCEPTS_LOCATION = False
+            ACCEPTS_COUNTRY = False
+            RATE_LIMIT_NOTES = "N/A"
+            REQUIRED_SEARCH_FIELDS = ()
+
+            def settings_schema(self) -> dict[str, Any]:
+                return {}
+
+            def pages(self) -> Iterator[list[dict[str, Any]]]:
+                return iter([])
+
+            # normalise() intentionally omitted
+
+        with pytest.raises(TypeError):
+            _NoNormaliseSource()  # type: ignore[abstract]
+
+    def test_missing_settings_schema_raises_type_error(self) -> None:
+        """A subclass missing settings_schema() cannot be instantiated."""
+
+        class _NoSchemaSource(JobSource):
+            SOURCE = "no_schema"
+            DISPLAY_NAME = "No Schema"
+            DESCRIPTION = "Missing schema."
+            HOME_URL = "https://no-schema.example.com"
+            GEO_SCOPE = "federal-us"
+            ACCEPTS_QUERY = "partial"
+            ACCEPTS_LOCATION = False
+            ACCEPTS_COUNTRY = False
+            RATE_LIMIT_NOTES = "N/A"
+            REQUIRED_SEARCH_FIELDS = ()
+
+            def pages(self) -> Iterator[list[dict[str, Any]]]:
+                return iter([])
+
+            def normalise(self, raw: dict[str, Any]) -> dict[str, Any]:
+                return raw
+
+            # settings_schema() intentionally omitted
+
+        with pytest.raises(TypeError):
+            _NoSchemaSource()  # type: ignore[abstract]
+
+
+# ---------------------------------------------------------------------------
+# Intermediate abstract subclasses are not attribute-checked
+# ---------------------------------------------------------------------------
+
+
+class TestAbstractSubclassSkipsAttrEnforcement:
+    """Abstract subclasses (still abstract) don't trigger attribute enforcement."""
+
+    def test_abstract_subclass_without_attrs_does_not_raise(self) -> None:
+        """An abstract intermediate class that omits metadata doesn't raise TypeError."""
+        import abc
+
+        # This class is itself abstract (has un-implemented abstract methods),
+        # so __init_subclass__ enforcement should be skipped.
+        class _AbstractMiddle(JobSource):
+            # Still abstract — does not implement all abstract methods
+            @abc.abstractmethod
+            def extra_method(self) -> None: ...
+
+        # Class creation should NOT raise TypeError because _AbstractMiddle is
+        # still abstract (has abstractmethods). This is correct — we only
+        # enforce attr presence on concrete (non-abstract) subclasses.
+        # If we get here without an exception, the test passes.
+        assert True

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,150 @@
+"""Tests for the job_aggregator exception hierarchy.
+
+Every exception class must:
+- Inherit from JobAggregatorError
+- Accept structured constructor arguments
+- Expose those arguments as attributes
+- Produce a useful __str__ representation
+"""
+
+from job_aggregator.errors import (
+    CredentialsError,
+    JobAggregatorError,
+    PluginConflictError,
+    SchemaVersionError,
+    ScrapeError,
+)
+
+
+class TestJobAggregatorError:
+    """Base exception class tests."""
+
+    def test_is_exception(self) -> None:
+        """JobAggregatorError must be a standard Exception subclass."""
+        err = JobAggregatorError("test message")
+        assert isinstance(err, Exception)
+
+    def test_message_preserved(self) -> None:
+        """Constructor message is accessible via args[0]."""
+        err = JobAggregatorError("boom")
+        assert str(err) == "boom"
+
+
+class TestPluginConflictError:
+    """Tests for PluginConflictError."""
+
+    def test_inherits_from_base(self) -> None:
+        """PluginConflictError is a JobAggregatorError."""
+        err = PluginConflictError(
+            key="adzuna",
+            sources=["job-aggregator (built-in)", "adzuna-extra (third-party)"],
+        )
+        assert isinstance(err, JobAggregatorError)
+
+    def test_key_attribute(self) -> None:
+        """The conflicting plugin key is stored on the exception."""
+        err = PluginConflictError(
+            key="adzuna",
+            sources=["pkg-a::adzuna", "pkg-b::adzuna"],
+        )
+        assert err.key == "adzuna"
+
+    def test_sources_attribute(self) -> None:
+        """Both registration sources are stored on the exception."""
+        sources = ["job-aggregator::adzuna", "adzuna-extra::adzuna"]
+        err = PluginConflictError(key="adzuna", sources=sources)
+        assert err.sources == sources
+
+    def test_str_contains_both_sources(self) -> None:
+        """__str__ must name both registration sources."""
+        err = PluginConflictError(
+            key="adzuna",
+            sources=["job-aggregator::adzuna", "adzuna-extra::adzuna"],
+        )
+        msg = str(err)
+        assert "job-aggregator::adzuna" in msg
+        assert "adzuna-extra::adzuna" in msg
+
+    def test_str_contains_key(self) -> None:
+        """__str__ includes the conflicting key."""
+        err = PluginConflictError(key="adzuna", sources=["a::x", "b::x"])
+        assert "adzuna" in str(err)
+
+
+class TestScrapeError:
+    """Tests for ScrapeError."""
+
+    def test_inherits_from_base(self) -> None:
+        """ScrapeError is a JobAggregatorError."""
+        err = ScrapeError(url="https://example.com/job/1", reason="HTTP 404")
+        assert isinstance(err, JobAggregatorError)
+
+    def test_url_attribute(self) -> None:
+        """The target URL is stored on the exception."""
+        err = ScrapeError(url="https://example.com/job/1", reason="timeout")
+        assert err.url == "https://example.com/job/1"
+
+    def test_reason_attribute(self) -> None:
+        """The failure reason is stored on the exception."""
+        err = ScrapeError(url="https://example.com/job/1", reason="HTTP 503")
+        assert err.reason == "HTTP 503"
+
+    def test_str_contains_url_and_reason(self) -> None:
+        """__str__ includes both url and reason for quick diagnosis."""
+        err = ScrapeError(url="https://example.com/job/1", reason="connection refused")
+        msg = str(err)
+        assert "https://example.com/job/1" in msg
+        assert "connection refused" in msg
+
+
+class TestCredentialsError:
+    """Tests for CredentialsError."""
+
+    def test_inherits_from_base(self) -> None:
+        """CredentialsError is a JobAggregatorError."""
+        err = CredentialsError(plugin_key="adzuna", missing_fields=["app_id"])
+        assert isinstance(err, JobAggregatorError)
+
+    def test_plugin_key_attribute(self) -> None:
+        """The plugin key is stored on the exception."""
+        err = CredentialsError(plugin_key="adzuna", missing_fields=["app_key"])
+        assert err.plugin_key == "adzuna"
+
+    def test_missing_fields_attribute(self) -> None:
+        """The list of missing fields is stored on the exception."""
+        err = CredentialsError(plugin_key="adzuna", missing_fields=["app_id", "app_key"])
+        assert err.missing_fields == ["app_id", "app_key"]
+
+    def test_str_contains_plugin_and_fields(self) -> None:
+        """__str__ includes the plugin key and missing field names."""
+        err = CredentialsError(plugin_key="adzuna", missing_fields=["app_id", "app_key"])
+        msg = str(err)
+        assert "adzuna" in msg
+        assert "app_id" in msg
+        assert "app_key" in msg
+
+
+class TestSchemaVersionError:
+    """Tests for SchemaVersionError."""
+
+    def test_inherits_from_base(self) -> None:
+        """SchemaVersionError is a JobAggregatorError."""
+        err = SchemaVersionError(got="2.0", expected="1.0")
+        assert isinstance(err, JobAggregatorError)
+
+    def test_got_attribute(self) -> None:
+        """The received schema version is stored on the exception."""
+        err = SchemaVersionError(got="2.0", expected="1.0")
+        assert err.got == "2.0"
+
+    def test_expected_attribute(self) -> None:
+        """The expected schema version is stored on the exception."""
+        err = SchemaVersionError(got="2.0", expected="1.0")
+        assert err.expected == "1.0"
+
+    def test_str_contains_both_versions(self) -> None:
+        """__str__ includes both the received and expected versions."""
+        err = SchemaVersionError(got="2.0", expected="1.0")
+        msg = str(err)
+        assert "2.0" in msg
+        assert "1.0" in msg

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,278 @@
+"""Tests for job_aggregator schema dataclasses and TypedDict.
+
+Covers PluginField, PluginInfo, SearchParams, and the JobRecord TypedDict
+structural expectations.
+"""
+
+from job_aggregator.schema import (
+    JobRecord,
+    PluginField,
+    PluginInfo,
+    SearchParams,
+)
+
+
+class TestPluginField:
+    """Tests for the PluginField frozen dataclass."""
+
+    def test_required_fields_only(self) -> None:
+        """PluginField can be constructed with only required fields."""
+        field = PluginField(name="app_id", label="App ID", type="password")
+        assert field.name == "app_id"
+        assert field.label == "App ID"
+        assert field.type == "password"
+
+    def test_default_required_is_false(self) -> None:
+        """required defaults to False when not specified."""
+        field = PluginField(name="app_id", label="App ID", type="text")
+        assert field.required is False
+
+    def test_default_help_text_is_none(self) -> None:
+        """help_text defaults to None when not specified."""
+        field = PluginField(name="app_id", label="App ID", type="text")
+        assert field.help_text is None
+
+    def test_all_fields(self) -> None:
+        """PluginField stores all provided attribute values correctly."""
+        field = PluginField(
+            name="app_key",
+            label="App Key",
+            type="password",
+            required=True,
+            help_text="Found in your Adzuna developer console.",
+        )
+        assert field.name == "app_key"
+        assert field.label == "App Key"
+        assert field.type == "password"
+        assert field.required is True
+        assert field.help_text == "Found in your Adzuna developer console."
+
+    def test_is_frozen(self) -> None:
+        """PluginField instances are immutable."""
+        import dataclasses
+
+        field = PluginField(name="x", label="X", type="text")
+        assert dataclasses.is_dataclass(field)
+        with __import__("pytest").raises((dataclasses.FrozenInstanceError, TypeError)):
+            field.name = "y"  # type: ignore[misc]
+
+    def test_all_valid_types(self) -> None:
+        """All five declared field types are constructable."""
+        valid_types: list[str] = ["text", "password", "email", "url", "number"]
+        for ftype in valid_types:
+            # Iterating over a list[str] loses the Literal type; cast to satisfy mypy.
+            field = PluginField(name="f", label="F", type=ftype)  # type: ignore[arg-type]
+            assert field.type == ftype
+
+
+class TestPluginInfo:
+    """Tests for the PluginInfo frozen dataclass."""
+
+    def _make_info(
+        self,
+        fields: tuple[PluginField, ...] = (),
+    ) -> PluginInfo:
+        """Return a minimal valid PluginInfo for testing."""
+        return PluginInfo(
+            key="dummy",
+            display_name="Dummy",
+            description="A dummy source.",
+            home_url="https://dummy.example.com",
+            geo_scope="global",
+            accepts_query="always",
+            accepts_location=True,
+            accepts_country=False,
+            rate_limit_notes="None.",
+            required_search_fields=(),
+            fields=fields,
+        )
+
+    def test_basic_construction(self) -> None:
+        """PluginInfo can be created with all fields populated."""
+        info = self._make_info()
+        assert info.key == "dummy"
+        assert info.display_name == "Dummy"
+
+    def test_requires_credentials_false_when_no_required_fields(self) -> None:
+        """requires_credentials is False when no field is marked required."""
+        fields = (
+            PluginField(name="optional_key", label="Optional Key", type="text", required=False),
+        )
+        info = self._make_info(fields=fields)
+        assert info.requires_credentials is False
+
+    def test_requires_credentials_true_when_any_field_required(self) -> None:
+        """requires_credentials is True when at least one field is required."""
+        fields = (
+            PluginField(name="app_id", label="App ID", type="password", required=True),
+            PluginField(name="app_key", label="App Key", type="password", required=False),
+        )
+        info = self._make_info(fields=fields)
+        assert info.requires_credentials is True
+
+    def test_requires_credentials_true_when_all_fields_required(self) -> None:
+        """requires_credentials is True when all fields are required."""
+        fields = (PluginField(name="api_key", label="API Key", type="password", required=True),)
+        info = self._make_info(fields=fields)
+        assert info.requires_credentials is True
+
+    def test_requires_credentials_false_when_no_fields(self) -> None:
+        """requires_credentials is False when there are no fields."""
+        info = self._make_info(fields=())
+        assert info.requires_credentials is False
+
+    def test_required_search_fields_stored(self) -> None:
+        """required_search_fields tuple is preserved."""
+        info = PluginInfo(
+            key="adzuna",
+            display_name="Adzuna",
+            description="Global aggregator.",
+            home_url="https://www.adzuna.com",
+            geo_scope="global-by-country",
+            accepts_query="always",
+            accepts_location=True,
+            accepts_country=True,
+            rate_limit_notes="1 req/sec.",
+            required_search_fields=("country", "what"),
+            fields=(),
+        )
+        assert info.required_search_fields == ("country", "what")
+
+
+class TestSearchParams:
+    """Tests for the SearchParams frozen dataclass."""
+
+    def test_all_defaults(self) -> None:
+        """SearchParams can be constructed with no arguments."""
+        params = SearchParams()
+        assert params.query is None
+        assert params.location is None
+        assert params.country is None
+        assert params.hours == 168
+        assert params.max_pages is None
+
+    def test_custom_values(self) -> None:
+        """All SearchParams fields can be set explicitly."""
+        params = SearchParams(
+            query="python developer",
+            location="Atlanta, GA",
+            country="us",
+            hours=24,
+            max_pages=3,
+        )
+        assert params.query == "python developer"
+        assert params.location == "Atlanta, GA"
+        assert params.country == "us"
+        assert params.hours == 24
+        assert params.max_pages == 3
+
+    def test_is_frozen(self) -> None:
+        """SearchParams instances are immutable."""
+        import dataclasses
+
+        params = SearchParams()
+        with __import__("pytest").raises((dataclasses.FrozenInstanceError, TypeError)):
+            params.hours = 48  # type: ignore[misc]
+
+
+class TestJobRecord:
+    """Tests for the JobRecord TypedDict structural contract.
+
+    JobRecord is a TypedDict, not a runtime-enforced class.  These tests
+    confirm that the dict shape assembles without error and that field
+    names exist on the type (via presence in annotations).
+    """
+
+    def test_minimal_required_record_is_valid_dict(self) -> None:
+        """A record with only required fields is a valid plain dict."""
+        record: JobRecord = {
+            "source": "dummy",
+            "source_id": "abc123",
+            "description_source": "snippet",
+            "title": "Software Engineer",
+            "url": "https://example.com/job/1",
+            "posted_at": "2026-04-23T00:00:00Z",
+            "description": "A great job.",
+        }
+        assert record["source"] == "dummy"
+        assert record["source_id"] == "abc123"
+        assert record["description_source"] == "snippet"
+
+    def test_full_record_with_optional_fields(self) -> None:
+        """A fully populated record (all optional fields) is a valid dict."""
+        record: JobRecord = {
+            "source": "adzuna",
+            "source_id": "xyz",
+            "description_source": "full",
+            "title": "Backend Engineer",
+            "url": "https://adzuna.com/job/xyz",
+            "posted_at": None,
+            "description": "Full description here.",
+            "company": "Acme Corp",
+            "location": "London, UK",
+            "salary_min": 60000.0,
+            "salary_max": 90000.0,
+            "salary_currency": "GBP",
+            "salary_period": "annual",
+            "contract_type": "permanent",
+            "contract_time": "full_time",
+            "remote_eligible": True,
+            "extra": {"adzuna_category": "IT Jobs"},
+        }
+        assert record["company"] == "Acme Corp"
+        assert record["salary_period"] == "annual"
+        assert record["extra"] == {"adzuna_category": "IT Jobs"}
+
+    def test_record_accepts_none_for_optional_fields(self) -> None:
+        """Optional fields may be explicitly set to None."""
+        record: JobRecord = {
+            "source": "remoteok",
+            "source_id": "ro-1",
+            "description_source": "none",
+            "title": "",
+            "url": "",
+            "posted_at": None,
+            "description": "",
+            "company": None,
+            "location": None,
+            "salary_min": None,
+            "salary_max": None,
+            "salary_currency": None,
+            "salary_period": None,
+            "contract_type": None,
+            "contract_time": None,
+            "remote_eligible": None,
+            "extra": None,
+        }
+        assert record["salary_period"] is None
+        assert record["extra"] is None
+
+    def test_required_identity_fields_exist_in_annotations(self) -> None:
+        """JobRecord's __annotations__ contains the three identity fields."""
+        annotations = {**JobRecord.__annotations__}
+        for field in ("source", "source_id", "description_source"):
+            assert field in annotations, f"Missing identity field: {field}"
+
+    def test_required_always_present_fields_exist_in_annotations(self) -> None:
+        """JobRecord's annotations contain the four always-present fields."""
+        annotations = {**JobRecord.__annotations__}
+        for field in ("title", "url", "posted_at", "description"):
+            assert field in annotations, f"Missing always-present field: {field}"
+
+    def test_optional_fields_exist_in_annotations(self) -> None:
+        """JobRecord's annotations contain all optional fields."""
+        annotations = {**JobRecord.__annotations__}
+        optional_fields = (
+            "company",
+            "location",
+            "salary_min",
+            "salary_max",
+            "salary_currency",
+            "salary_period",
+            "contract_type",
+            "contract_time",
+            "remote_eligible",
+            "extra",
+        )
+        for field in optional_fields:
+            assert field in annotations, f"Missing optional field: {field}"


### PR DESCRIPTION
## Summary

- Adds `JobSource` ABC v3 with nine required class-level metadata attributes enforced at class-creation time via `__init_subclass__` (raises `TypeError` on import for incomplete plugins, not at runtime)
- Adds `PluginField`, `PluginInfo`, `SearchParams`, and `JobRecord` schema types (`schema.py`)
- Adds five-exception hierarchy rooted at `JobAggregatorError` (`errors.py`)
- Adds `discover_plugins()` in `auto_register.py` with entry-point discovery, `SOURCE`-attribute-based collision detection (raises `PluginConflictError` before any disable filtering), and `JOB_SCRAPER_DISABLE_PLUGINS` env-var support
- Re-exports all public types from `job_aggregator.__init__`

## Files Added

- `src/job_aggregator/base.py` — `JobSource` ABC
- `src/job_aggregator/schema.py` — `PluginField`, `PluginInfo`, `SearchParams`, `JobRecord`
- `src/job_aggregator/errors.py` — exception hierarchy
- `src/job_aggregator/auto_register.py` — entry-point discovery
- `src/job_aggregator/__init__.py` — updated with re-exports
- `tests/test_base_abc.py`, `tests/test_schema.py`, `tests/test_errors.py`, `tests/test_auto_register.py`

## Test Summary

70 tests pass (69 new + 1 existing smoke test). All 7 verification commands green:

- `ruff check` — pass
- `ruff format --check` — pass
- `mypy src/ tests/` — pass (strict, 13 files)
- `deptry src/` — pass
- `pytest -v` — 70/70 pass
- `pip-audit` — no known vulnerabilities

Closes #3

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*