### PR TITLE
feat: migrate remotive plugin (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Plugin: `remotive` source migrated from legacy repo (#12)
+
 ### Changed
 
 ### Deprecated

--- a/docs/superpowers/specs/2026-04-23-job-aggregator-design.md
+++ b/docs/superpowers/specs/2026-04-23-job-aggregator-design.md
@@ -714,7 +714,7 @@ are decisions the migrator makes based on that reading.
 | jooble | ? | global | ? | ? | ? | ? | ? |
 | jsearch | ? | global | always | ? | ? | "RapidAPI quota varies by plan" | ? |
 | remoteok | RemoteOK | remote-only | never | false | false | "Public, soft rate limits" | () |
-| remotive | ? | remote-only (likely) | ? | ? | ? | ? | ? |
+| remotive | Remotive | remote-only | always | false | false | "No published rate limit; public API, use conservatively." | () |
 | the_muse | ? | TBD | ? | ? | ? | ? | ? |
 | usajobs | USAJobs | federal-us | partial | ? | false (US-only) | "Email-tagged user-agent required" | ? |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ job-aggregator = "job_aggregator.cli.__main__:main"
 # Plugin entry-points are registered here by subsequent issues (B1-B10).
 # Third-party plugins may also register here via their own pyproject.toml.
 # Example: adzuna = "job_aggregator.plugins.adzuna:AdzunaSource"
+remotive = "job_aggregator.plugins.remotive:Plugin"
 
 # ---------------------------------------------------------------------------
 # Dependency groups (PEP 735 — read natively by uv)

--- a/src/job_aggregator/plugins/__init__.py
+++ b/src/job_aggregator/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""job_aggregator.plugins — namespace package for source plugins."""

--- a/src/job_aggregator/plugins/remotive/__init__.py
+++ b/src/job_aggregator/plugins/remotive/__init__.py
@@ -1,0 +1,11 @@
+"""job_aggregator.plugins.remotive — Remotive remote-jobs source plugin.
+
+Exports :class:`Plugin` as the single public name so the entry-point
+loader and consumers can use a consistent import path::
+
+    from job_aggregator.plugins.remotive import Plugin
+"""
+
+from job_aggregator.plugins.remotive.plugin import RemotivePlugin as Plugin
+
+__all__ = ["Plugin"]

--- a/src/job_aggregator/plugins/remotive/plugin.py
+++ b/src/job_aggregator/plugins/remotive/plugin.py
@@ -1,0 +1,309 @@
+"""Remotive source plugin for job-aggregator.
+
+Wraps the public Remotive remote-jobs API (https://remotive.com/api/remote-jobs).
+No authentication is required.  The API returns a single page of results;
+pagination is not supported upstream.
+
+HTML is stripped from the ``description`` field using :mod:`html.parser`
+via :class:`html.parser.HTMLParser` rather than importing BeautifulSoup at
+the module level, which keeps the import dependency explicit and avoids
+pulling in bs4 unless it is already installed.
+
+Salary is returned as free-text by Remotive (e.g. ``"$120k-$150k"``).
+``salary_min`` / ``salary_max`` are set to ``None`` because reliable parsing
+would require a heuristic that is out of scope for this plugin; the raw
+string is preserved in ``extra.salary_raw``.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from html.parser import HTMLParser
+from typing import Any
+
+import requests
+
+from job_aggregator.base import JobSource
+from job_aggregator.errors import ScrapeError
+
+logger = logging.getLogger(__name__)
+
+_REMOTIVE_URL = "https://remotive.com/api/remote-jobs"
+
+
+# ---------------------------------------------------------------------------
+# HTML stripping helper
+# ---------------------------------------------------------------------------
+
+
+class _HTMLStripper(HTMLParser):
+    """Minimal HTMLParser subclass that collects text content only.
+
+    Attributes:
+        _parts: Accumulated text fragments between tags.
+    """
+
+    def __init__(self) -> None:
+        """Initialise the parser and the internal text-accumulator."""
+        super().__init__()
+        self._parts: list[str] = []
+
+    def handle_data(self, data: str) -> None:
+        """Append a text fragment from between tags.
+
+        Args:
+            data: Raw text content extracted by the HTML parser.
+        """
+        self._parts.append(data)
+
+    @property
+    def text(self) -> str:
+        """Return all accumulated text joined into a single string.
+
+        Returns:
+            Concatenated text fragments with no extra whitespace added.
+        """
+        return "".join(self._parts)
+
+
+def _strip_html(raw: str) -> str:
+    """Remove HTML tags from *raw* and return plain text.
+
+    Args:
+        raw: A string that may contain HTML markup.
+
+    Returns:
+        Plain text with all HTML tags removed.  Whitespace inside the
+        original HTML is preserved as-is; no additional normalisation is
+        applied.
+    """
+    stripper = _HTMLStripper()
+    stripper.feed(raw)
+    return stripper.text
+
+
+# ---------------------------------------------------------------------------
+# Plugin
+# ---------------------------------------------------------------------------
+
+
+class RemotivePlugin(JobSource):
+    """JobSource plugin for the Remotive remote-jobs API.
+
+    Remotive exposes a single public endpoint that returns a JSON object
+    containing a ``"jobs"`` list.  The API is not paginated — one request
+    returns all matching listings up to the configured ``limit``.
+
+    No credentials are required.  Pass a ``query`` to filter by keyword
+    or a ``category`` to restrict to a job category (e.g.
+    ``"software-dev"``).  Both are optional; omitting them returns all
+    recently posted remote jobs.
+
+    Attributes:
+        SOURCE: Plugin key ``"remotive"``.
+        DISPLAY_NAME: ``"Remotive"``.
+        DESCRIPTION: From ``source.json``.
+        HOME_URL: ``"https://remotive.com"``.
+        GEO_SCOPE: ``"remote-only"`` — Remotive is a curated remote board.
+        ACCEPTS_QUERY: ``"always"`` — supports free-text ``search`` param.
+        ACCEPTS_LOCATION: ``False`` — no location filter; all jobs remote.
+        ACCEPTS_COUNTRY: ``False`` — no country filter in the API.
+        RATE_LIMIT_NOTES: No published rate limit; conservative use advised.
+        REQUIRED_SEARCH_FIELDS: ``()`` — no mandatory search parameters.
+    """
+
+    SOURCE = "remotive"
+    DISPLAY_NAME = "Remotive"
+    DESCRIPTION = (
+        "Curated remote tech jobs across software, design, and marketing. "
+        "Free API with no authentication. "
+        "Smaller volume but strong signal-to-noise."
+    )
+    HOME_URL = "https://remotive.com"
+    GEO_SCOPE = "remote-only"
+    ACCEPTS_QUERY = "always"
+    ACCEPTS_LOCATION = False
+    ACCEPTS_COUNTRY = False
+    RATE_LIMIT_NOTES = "No published rate limit; public API, use conservatively."
+    REQUIRED_SEARCH_FIELDS = ()
+
+    def __init__(
+        self,
+        query: str | None = None,
+        category: str | None = None,
+        limit: int = 100,
+    ) -> None:
+        """Initialise the Remotive plugin.
+
+        Args:
+            query: Optional free-text keyword filter forwarded to the
+                Remotive ``search`` query parameter.
+            category: Optional job category slug (e.g. ``"software-dev"``,
+                ``"design"``) forwarded to the Remotive ``category``
+                parameter.  See https://remotive.com/api/remote-jobs for
+                valid values.  Defaults to ``None`` (all categories).
+            limit: Maximum number of listings to request.  Remotive caps
+                the response at their server-side maximum regardless.
+                Defaults to ``100``.
+        """
+        self._query = query
+        self._category = category
+        self._limit = limit
+
+    # ------------------------------------------------------------------
+    # JobSource interface
+    # ------------------------------------------------------------------
+
+    def settings_schema(self) -> dict[str, Any]:
+        """Return an empty schema — Remotive requires no credentials.
+
+        Returns:
+            An empty dict, as the Remotive API is public.
+        """
+        return {}
+
+    def pages(self) -> Iterator[list[dict[str, Any]]]:
+        """Yield the single page of Remotive listings.
+
+        Remotive is a single-page API.  This method makes one GET request
+        and yields a list of normalised :class:`~job_aggregator.schema.JobRecord`
+        dicts.  Yields nothing if the API returns no listings.
+
+        Yields:
+            A single list of normalised listing dicts, or nothing if the
+            response is empty or non-200.
+
+        Raises:
+            ScrapeError: If the HTTP request fails due to a network-level
+                error (connection refused, timeout, DNS failure, etc.).
+        """
+        params: dict[str, Any] = {"limit": self._limit}
+        if self._query:
+            params["search"] = self._query
+        if self._category:
+            params["category"] = self._category
+
+        try:
+            response = requests.get(_REMOTIVE_URL, params=params, timeout=15)
+        except requests.RequestException as exc:
+            raise ScrapeError(
+                url=_REMOTIVE_URL,
+                reason=f"Network error: {exc}",
+            ) from exc
+
+        if response.status_code != 200:
+            logger.warning(
+                "Remotive returned HTTP %d; skipping.",
+                response.status_code,
+            )
+            return
+
+        try:
+            data: dict[str, Any] = response.json()
+        except ValueError as exc:
+            logger.warning("Remotive response is not valid JSON: %s", exc)
+            return
+
+        raw_jobs: list[dict[str, Any]] = data.get("jobs") or []
+        if not raw_jobs:
+            return
+
+        yield [self.normalise(job) for job in raw_jobs]
+
+    def normalise(self, raw: dict[str, Any]) -> dict[str, Any]:
+        """Map a single Remotive job dict to the canonical JobRecord shape.
+
+        Field audit (§9.3 categories):
+
+        **Identity:**
+        - ``source`` — always ``"remotive"``
+        - ``source_id`` — ``str(raw["id"])``; empty string when absent
+        - ``description_source`` — ``"snippet"`` (Remotive provides HTML
+          descriptions; full text is available but not scraped here)
+
+        **Always-present:**
+        - ``title`` — ``raw["title"]``; empty string when None
+        - ``url`` — ``raw["url"]``; empty string when None
+        - ``posted_at`` — ``raw["publication_date"]``; None when absent
+        - ``description`` — ``raw["description"]`` with HTML stripped
+
+        **Optional:**
+        - ``company`` — ``raw["company_name"]``; None when None/absent
+        - ``location`` — ``raw["candidate_required_location"]``; None when
+          None/absent
+        - ``salary_min`` — None (salary is free-text; cannot parse reliably)
+        - ``salary_max`` — None (same reason)
+        - ``salary_currency`` — None (same reason)
+        - ``salary_period`` — None (same reason)
+        - ``contract_type`` — None (no direct upstream equivalent)
+        - ``contract_time`` — ``raw["job_type"]``; None when absent
+        - ``remote_eligible`` — ``True`` (Remotive is a remote-only board)
+
+        **Dropped fields (source-specific, stored in extra):**
+        - ``raw["company_logo"]`` → ``extra["company_logo"]``
+        - ``raw["category"]`` → ``extra["category"]``
+        - ``raw["tags"]`` → ``extra["tags"]``
+        - ``raw["salary"]`` → ``extra["salary_raw"]`` (preserved verbatim)
+
+        Args:
+            raw: A single entry from the Remotive ``"jobs"`` array.
+
+        Returns:
+            A dict conforming to :class:`~job_aggregator.schema.JobRecord`.
+        """
+        raw_id = raw.get("id")
+        source_id = str(raw_id) if raw_id is not None else ""
+
+        title = raw.get("title") or ""
+        url = raw.get("url") or ""
+        posted_at: str | None = raw.get("publication_date") or None
+        raw_desc = raw.get("description") or ""
+        description = _strip_html(raw_desc)
+
+        company_raw = raw.get("company_name")
+        company: str | None = company_raw if company_raw is not None else None
+
+        location_raw = raw.get("candidate_required_location")
+        location: str | None = location_raw if location_raw is not None else None
+
+        contract_time_raw = raw.get("job_type")
+        contract_time: str | None = contract_time_raw if contract_time_raw is not None else None
+
+        # Salary is free-text (e.g. "$120k-$150k"); reliable parsing is
+        # out-of-scope.  Preserve raw string in extra; numeric fields → None.
+        salary_raw: str | None = raw.get("salary") or None
+
+        extra: dict[str, Any] = {}
+        if salary_raw is not None:
+            extra["salary_raw"] = salary_raw
+        if raw.get("company_logo") is not None:
+            extra["company_logo"] = raw["company_logo"]
+        if raw.get("category") is not None:
+            extra["category"] = raw["category"]
+        if raw.get("tags") is not None:
+            extra["tags"] = raw["tags"]
+
+        return {
+            # Identity
+            "source": self.SOURCE,
+            "source_id": source_id,
+            "description_source": "snippet",
+            # Always-present
+            "title": title,
+            "url": url,
+            "posted_at": posted_at,
+            "description": description,
+            # Optional
+            "company": company,
+            "location": location,
+            "salary_min": None,
+            "salary_max": None,
+            "salary_currency": None,
+            "salary_period": None,
+            "contract_type": None,
+            "contract_time": contract_time,
+            "remote_eligible": True,
+            # Source-specific blob
+            "extra": extra if extra else None,
+        }

--- a/tests/sources/remotive/cassettes/test_remotive_integration/test_pages_returns_listings_from_cassette.yaml
+++ b/tests/sources/remotive/cassettes/test_remotive_integration/test_pages_returns_listings_from_cassette.yaml
@@ -1,0 +1,4190 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.1
+    method: GET
+    uri: https://remotive.com/api/remote-jobs?limit=5&search=python
+  response:
+    body:
+      string: '{"00-warning": "Remotive main domain moved to remotive.com ! Please
+        make your API calls on remotive.com/api/remote-jobs instead of remotive.io
+        now ;) Legacy endpoint remotive.io/api/remote-jobs will be terminated in June
+        2022. Thank you!", "0-legal-notice": "Legal warning - Hey, thanks for using
+        Remotive''s API, we appreciate it! Please note that API documentation and
+        access is granted so that developers can share our jobs further. Please do
+        not submit Remotive jobs to third Party websites, including but not limited
+        to: Jooble, Neuvoo, Google Jobs, LinkedIn Jobs. Please link back to the URL
+        found on Remotive AND mention Remotive as a source in order to Remotive to
+        get traffic from your listing. If you don''t do that, we''ll terminate your
+        API access, sorry! Jobs displayed are delayed by 24 hours, the goal being
+        that jobs are attributed to Remotive on various platforms. Displaying our
+        jobs in order to collect signups/email addresses to show a listing constitutes
+        a breach of our terms of services. We offer a private, paid-for API, please
+        email us at hello(at)remotive(dot)io for more information (starting budget
+        is $5k/mo). Please find out terms of services on https://remotive.com/api-documentation.
+        Please note that there is absolutely no need to request Remotive Job data
+        too frequently. Typically, you only need to GET Remotive job data through
+        this API a couple of times a day (we advise max. 4 times a day). Our data
+        is not changing much faster than that anyway. Note that excessive requests
+        will be blocked. Many thanks (Rodolphe & the Remotive team!)", "job-count":
+        22, "total-job-count": 22, "jobs": [{"id": 2089990, "url": "https://remotive.com/remote-jobs/all-others/content-reviewer-us-2089990",
+        "title": "Content Reviewer - US", "company_name": "TELUS Digital", "company_logo":
+        "https://remotive.com/job/2089990/logo", "category": "All others", "tags":
+        ["android", "go", "ios", "social media", "AI/ML", "diversity"], "job_type":
+        "part_time", "publication_date": "2026-04-21T12:46:23", "candidate_required_location":
+        "USA", "salary": "$14/hour", "description": "<p class=\"figma-padding-bottom-32
+        tw-border-b tw-border-[#E3E6E8]\" style=\"border-width: 0px 0px 1px; border-color:
+        #e3e6e8; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; --tw-border-opacity: 1; padding-bottom:
+        32px; color: #212529;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow:
+        0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">Looking
+        for a freelance opportunity where you can make an impact on technology from
+        the comfort of your home? If you are dynamic, tech-savvy, and always online
+        to learn more, this part-time flexible project is the perfect fit for you!\u00a0</span></p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; font-weight: bolder; background-color:
+        transparent;\">A Day in the Life of a </span>Content Reviewer - US<span style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; font-weight: bolder; background-color:
+        transparent;\">:</span></p>\n<ul style=\"\">\n<li style=\"\"><span style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">In
+        this role, you\u2019ll be analyzing and providing feedback on texts, pages,
+        images, and other types of information for top search engines, using an online
+        tool</span></li>\n<li style=\"\"><span style=\"border-color: #e5e7eb; --tw-shadow:
+        0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; background-color: transparent;\">Through reviewing and rating search
+        results for relevance and quality, you\u2019ll be helping to improve the overall
+        user experience for millions of search engine users, including yourself.</span></li>\n</ul>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">Join
+        our team today and start putting your skills to work for one of the world''s
+        leading search engines.</span></p>\n<p style=\"border-color: #e5e7eb; --tw-shadow:
+        0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\">\u00a0</p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\"><span style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">The
+        estimated hourly earnings for this role are\u00a014 USD</span> per hour.\u00a0</p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; color: #26282a;\">Please note only
+        one member per household can work on this program. If at a later stage it
+        is identified that more than one person in your household is working on the
+        TELUS Digital Rating Program, it will result in removal from the program.</span></p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\">\u00a0</p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\"><span style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; font-weight: bolder; background-color:
+        transparent;\">TELUS Digital AI Community</span></p>\n<p style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\"><span style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">Our
+        global AI Community is a vibrant network of 1 million+ contributors from diverse
+        backgrounds who help our customers collect, enhance, train, translate, and
+        localize content to build better AI models. Become part of our growing community
+        and make an impact supporting the machine learning models of some of the world\u2019s
+        largest brands.</span></p>\n<p class=\"pt-7 figma-padding-bottom-32 tw-border-b
+        tw-border-[#E3E6E8]\" style=\"border-width: 0px 0px 1px; border-color: #e3e6e8;
+        --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; --tw-border-opacity: 1; padding-bottom:
+        32px; color: #212529; padding-top: 2.5rem !important;\">\u00a0</p>\n<div class=\"h4\"
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; line-height: 1.75rem; color: #414547;
+        letter-spacing: 0px; --tw-text-opacity: 1;\">Qualification path</div>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\"><span style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">No
+        previous professional experience is required to apply to this role, however,
+        working on this project will require you to pass the basic requirements and
+        go through a standard assessment process. This is a part-time long-term project
+        and your work will be subject to our standard quality assurance checks during
+        the term of this agreement.\u00a0</span></p>\n<p style=\"border-color: #e5e7eb;
+        --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; font-weight: bolder; background-color:
+        transparent;\">Basic Requirements</span></p>\n<ul style=\"\">\n<li style=\"\"><span
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">Working
+        as a freelancer with excellent communication skills in English</span></li>\n<li
+        style=\"\"><span style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">Bein</span>g
+        a resident in the United States for the last 3 consecutive years and having
+        familiarity with current and historical business, media, sport, news, social
+        media, and cultural affairs in the US.</li>\n<li style=\"\">Active use of
+        Gmail and other forms of social media and experience in the use of web browsers
+        to navigate and interact with a variety of content</li>\n<li style=\"\">Daily
+        access to a broadband internet connection, a smartphone (Android 5.0, iOS
+        14 or higher), and a personal computer to work on.</li>\n</ul>\n<p style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; font-weight: bolder;\">Assessment</span></p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">In order to be hired into the program, you\u2019ll take a language assessment
+        and an\u00a0<span style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">open
+        book qualification exam that will determine your suitability for the position
+        and complete ID verification. Don\u2019t worry, our team will provide you
+        with guidelines and learning materials before your exam. You will be required
+        to complete the exam in a specific timeframe but at your convenience!</span></p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; font-weight: bolder;\">Equal Opportunity</span></p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\"><span style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">All
+        qualified applicants will receive consideration for a contractual relationship
+        without regard to race, color, religion, sex, sexual orientation, gender identity,
+        national origin, disability, or protected veteran status. At TELUS Digital
+        AI, we are proud to offer equal opportunities and are committed to creating
+        a diverse and inclusive community. All aspects of selection are based on applicants\u2019
+        qualifications, merits, competence, and performance without regard to any
+        characteristic related to diversity</span></p>\n<img src=\"https://remotive.com/job/track/2089990/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/2089990/logo"},
+        {"id": 2089958, "url": "https://remotive.com/remote-jobs/ai-ml/ai-engineer-2089958",
+        "title": "AI Engineer", "company_name": "Dry Ground AI", "company_logo": "https://remotive.com/job/2089958/logo",
+        "category": "AI / ML", "tags": ["api", "cloud", "fullstack", "python", "AI/ML",
+        "automation", "research", "CI/CD", "TensorFlow", "spark", "NLP", "CMS", "Pytorch",
+        "REST"], "job_type": "full_time", "publication_date": "2026-04-21T08:16:20",
+        "candidate_required_location": "Brazil, Colombia, Philippines", "salary":
+        "$40- $60k", "description": "<p class=\"MsoNormal\">We are seeking a versatile
+        and highly skilled AI Engineer to join our fast-growing Full-Stack AI Solutions
+        company. This role blends the expertise of building cutting-edge AI/ML models
+        with the practical know-how of automation and agentic system integrations.
+        You will design, develop, deploy, and optimize intelligent solutions that
+        leverage the power of generative AI, automation platforms, and agent-based
+        systems to enhance client operations, streamline workflows, and deliver measurable
+        results.</p>\n<p class=\"MsoNormal\">This is a unique opportunity to work
+        across a diverse range of technologies\u2014from fine-tuning transformer models
+        to building real-world AI-powered automation stacks. If you\u2019re passionate
+        about pushing the boundaries of AI while creating real value through systems
+        thinking and practical implementation, this role is for you.</p>\n<p class=\"MsoNormal\">\u00a0</p>\n<div
+        class=\"h3\">Key Responsibilities</div>\n<p class=\"MsoNormal\"><strong>AI/ML
+        Development:</strong></p>\n<p>\u00a0</p>\n<ul style=\"\" type=\"disc\">\n<li
+        class=\"MsoNormal\" style=\"\">Design, build, and deploy machine learning
+        and generative AI models for custom use cases.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Fine-tune and optimize large language models
+        (e.g., GPT, BERT) using frameworks like Hugging Face Transformers.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Conduct ongoing research to stay ahead of advancements
+        in AI/ML, including LLMs, generative AI, and transformer-based architectures.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Develop data pipelines for preprocessing, feature
+        engineering, and model training.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\"
+        style=\"\">Test, validate, and monitor model performance in real-world scenarios;
+        iterate for reliability and accuracy.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\"
+        style=\"\">Collaborate with cross-functional teams to embed AI into products,
+        platforms, and services.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\" style=\"\">Mentor
+        junior engineers and contribute to technical leadership.\n<p>\u00a0</p>\n</li>\n</ul>\n<p
+        class=\"MsoNormal\"><strong>Automation &amp; Agentic Systems:</strong></p>\n<p>\u00a0</p>\n<ul
+        style=\"\" type=\"disc\">\n<li class=\"MsoNormal\" style=\"\">Design, implement,
+        and maintain automation workflows using tools such as:\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">LangChain, LangGraph, LangSmith, LangFuse n8n,
+        ElevenLabs, and CMS integrations.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\"
+        style=\"\">Engineer system-to-system integrations using APIs to enable intelligent
+        process automation.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\" style=\"\">Apply
+        prompt and context engineering techniques to enhance the performance of conversational
+        AI tools.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\" style=\"\">Implement
+        prompt management and QA processes for agents and assistants.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Explore and deploy Microsoft Copilot Studio,
+        PowerApps, and PowerAutomate solutions (preferred but not required).\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Continuously evaluate emerging AI and automation
+        tools and assess their applicability in client use cases.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Collaborate with clients and internal teams
+        to scope, deliver, and maintain agentic and automation solutions aligned with
+        business goals.\n<p>\u00a0</p>\n</li>\n</ul>\n<div class=\"h3\"><strong>Qualifications</strong></div>\n<p
+        class=\"MsoNormal\">\u00a0</p>\n<p class=\"MsoNormal\"><strong>Required</strong></p>\n<p>\u00a0</p>\n<ul
+        style=\"\" type=\"disc\">\n<li class=\"MsoNormal\" style=\"\">2+ years of
+        hands-on experience in AI/ML development, including training and deploying
+        models in production.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\" style=\"\">Strong
+        programming skills in Python, with proficiency in frameworks such as TensorFlow,
+        PyTorch, Scikit-learn, and Hugging Face Transformers.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Experience working with AI tools like Langchain,
+        OpenAI, or Stable Diffusion.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\"
+        style=\"\">Practical experience with automation platforms and AI agent builders
+        (as listed above).\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\" style=\"\">Deep
+        understanding of machine learning algorithms, neural networks, and NLP concepts.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Proficiency in using REST APIs for tool and
+        platform integrations.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\" style=\"\">Familiarity
+        with cloud-based AI/ML platforms.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\"
+        style=\"\">Strong analytical skills and the ability to translate business
+        problems into technical AI/automation solutions.\n<p>\u00a0</p>\n</li>\n</ul>\n<p
+        class=\"MsoNormal\"><strong>Preferred</strong></p>\n<p>\u00a0</p>\n<ul style=\"\"
+        type=\"disc\">\n<li class=\"MsoNormal\" style=\"\">Experience working with
+        Agentic AI frameworks, voice automation, and prompt tuning systems.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Exposure to MLOps best practices, including
+        model versioning, CI/CD, and monitoring.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\"
+        style=\"\">Knowledge of reinforcement learning, GANs, or edge AI deployments.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Familiarity with distributed computing frameworks
+        such as Spark or Ray.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\" style=\"\">Background
+        in AI agency workflows and client-facing solution delivery.\n<p>\u00a0</p>\n</li>\n</ul>\n<div
+        class=\"h3\">Work Environment &amp; Benefits</div>\n<p>\u00a0</p>\n<ul style=\"\"
+        type=\"disc\">\n<li class=\"MsoNormal\" style=\"\">Competitive salary and
+        performance-based incentives.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\"
+        style=\"\">Flexible work environment: Remote-first.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Collaborative, innovation-driven culture with
+        a commitment to personal and professional growth.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Opportunity to work at the forefront of AI
+        innovation across industries and verticals.</li>\n</ul>\n<img src=\"https://remotive.com/job/track/2089958/blank.gif?source=public_api\"
+        alt=\"\"/>"}, {"id": 2088659, "url": "https://remotive.com/remote-jobs/finance/crypto-trader-full-training-provided-2088659",
+        "title": "Crypto Trader (Full Training Provided)", "company_name": "Elemental
+        Terra Capital Ltd", "company_logo": "https://remotive.com/job/2088659/logo",
+        "category": "Finance", "tags": ["crypto", "research", "market research", "trading",
+        "onboarding"], "job_type": "part_time", "publication_date": "2026-04-20T16:00:51",
+        "candidate_required_location": "Worldwide", "salary": "$48k - $60k", "description":
+        "<p style=\"color: #333333;\">Elemental Terra is an international company
+        working with digital assets, market research, and data-driven trading solutions.
+        We are building a team of specialists who want to understand how crypto markets
+        operate in practice and develop professional skills in a real market environment.</p>\n<p
+        style=\"color: #333333;\">We are opening a Crypto Trader position for candidates
+        who are at the beginning of their professional journey and are interested
+        in trading, market analysis, and data-driven decision-making. This role involves
+        independent trading activity with structured training and ongoing support
+        from experienced professionals. No prior professional experience is required
+        - full training is provided.</p>\n<p style=\"color: #333333;\"><strong><br>Your
+        Responsibilities</strong></p>\n<p style=\"color: #333333;\">\u00a0</p>\n<ul
+        style=\"\">\n<li style=\"\">Execute trades on digital asset markets using
+        company strategies and guidelines.</li>\n<li style=\"\">Monitor price movements,
+        liquidity, and market conditions in real time.</li>\n<li style=\"\">Analyze
+        charts, indicators, and market signals to support trading decisions.</li>\n<li
+        style=\"\">Manage positions and assess potential risks.</li>\n<li style=\"\">Review
+        crypto news and its impact on market behavior.</li>\n<li style=\"\">Work with
+        professional trading platforms and analytical tools.</li>\n<li style=\"\">Track
+        and report personal trading performance.</li>\n<li style=\"\">Continuously
+        improve trading skills and market understanding.</li>\n</ul>\n<p style=\"color:
+        #333333;\"><br><strong>What We Offer</strong></p>\n<p style=\"color: #333333;\">\u00a0</p>\n<ul
+        style=\"\">\n<li style=\"\">Opportunity to join an early-stage international
+        company.</li>\n<li style=\"\">Fully remote work - no location restrictions.</li>\n<li
+        style=\"\">Flexible workload and schedule.</li>\n<li style=\"\">Structured
+        onboarding and full training provided at the company''s expense.</li>\n<li
+        style=\"\">Work on official, professional trading platforms.</li>\n<li style=\"\">Access
+        to real market data and advanced analytical tools.</li>\n<li style=\"\">Step-by-step
+        development with increasing responsibility.</li>\n<li style=\"\">Continuous
+        support from experienced market specialists.</li>\n<li style=\"\">Compensation
+        based on your trading performance and results.</li>\n</ul>\n<p style=\"color:
+        #333333;\"><br><strong>Interview Process</strong></p>\n<p style=\"color: #333333;\">\u00a0</p>\n<ul
+        style=\"\">\n<li style=\"\">A scheduled phone call with our representative
+        - we will contact you directly, so please be available to answer.</li>\n<li
+        style=\"\">Detailed interview with an HR manager.</li>\n<li style=\"\">Practical
+        training session with one of our trading specialists.</li>\n</ul>\n<img src=\"https://remotive.com/job/track/2088659/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/2088659/logo"},
+        {"id": 2088656, "url": "https://remotive.com/remote-jobs/customer-service/customer-retention-manager-2088656",
+        "title": "Customer Retention Manager", "company_name": "AutoHDR", "company_logo":
+        "https://remotive.com/job/2088656/logo", "category": "Customer Service", "tags":
+        ["AI/ML", "editing", "startup"], "job_type": "full_time", "publication_date":
+        "2026-04-16T21:16:09", "candidate_required_location": "USA", "salary": "",
+        "description": "<div class=\"h5\"><strong>Role: </strong>Customer Success
+        Representative</div>\n<p>AutoHDR is the fastest growing AI startup in real
+        estate media. We train custom image editing models for real estate, and are
+        currently editing 25% of all US real estate listings!</p>\n<p>Join our team
+        and work with an exceptional team to build cutting edge products and continue
+        growing 20% month over month!</p>\n<p>Our vision is to produce the majority
+        of media for the real estate industry - and you can join early on.</p>\n<div
+        class=\"h5\">\u00a0</div>\n<div class=\"h5\"><strong>The role:</strong></div>\n<ul
+        style=\"\">\n<li style=\"\">\n<p>Own customer retention; build systems, automations,
+        and build relationships to ensure a customer never leaves once using the platform.</p>\n</li>\n<li
+        style=\"\">\n<p>Call un-subscribed customers to collect feedback and conduct
+        our winback process</p>\n</li>\n<li style=\"\">\n<p>Call customers who report
+        low quality ratings in realtime to proactively prevent churn. Consult them
+        on how to prevent the issue &amp; share upcoming product updates.</p>\n</li>\n<li
+        style=\"\">\n<p>Proactively call existing users to collect feedback and proactively
+        mitigate any churn risks.</p>\n</li>\n</ul>\n<div class=\"h5\">\u00a0</div>\n<div
+        class=\"h5\"><strong>Your key responsibility:</strong></div>\n<ul style=\"\">\n<li
+        style=\"\">\n<p>Make sure 100% of tickets from un-subscribed customers and
+        low quality ratings are called through every single day. Come up with ideas
+        and systematic, data-driven approaches for churn prevention.</p>\n</li>\n</ul>\n<div
+        class=\"h5\">\u00a0</div>\n<div class=\"h5\"><strong>Requirements:</strong></div>\n<ul
+        style=\"\">\n<li style=\"\">\n<p>Background working with real estate photographers
+        or editing companies</p>\n</li>\n<li style=\"\">\n<p>Understanding of HDR
+        or flambient real estate photo workflows</p>\n</li>\n<li style=\"\">\n<p>Perfect
+        English fluency and no accent</p>\n</li>\n</ul>\n<div class=\"h5\">\u00a0</div>\n<div
+        class=\"h5\"><strong>Schedule:</strong></div>\n<ul style=\"\">\n<li style=\"\">\n<p>Full-time
+        (US Business Hours)</p>\n</li>\n</ul>\n<div class=\"h5\"><strong>AutoHDR Core
+        Values:</strong></div>\n<p>Our core values are the fuel for our continuous
+        20% month over month growth. Iron sharpens iron in our office, and the entire
+        dev team is bought in to winning together.</p>\n<div class=\"h5\">\u00a0</div>\n<div
+        class=\"h5\"><strong>Persistence</strong></div>\n<p>You believe anything is
+        possible - the only variable is how long it will take. You will always continue
+        trying to solve a problem, look for new solutions, and figure it out at all
+        costs through continous effort - even when most would give up.</p>\n<div class=\"h5\"><strong>Optimism</strong></div>\n<p>You
+        believe strongly that you can accomplish anything you want - regardless of
+        the odds. Even when the worst case scenario happens, and everything is on
+        fire, you never doubt your ability to pull through and win at what you set
+        out to do.</p>\n<div class=\"h5\"><strong>Competitive greatness</strong></div>\n<p>Every
+        individual on our team wants to be the best in the world at what they do.
+        We are extremely compeitive, and will settle for nothing other than being
+        the #1 player for AI real estate editing.</p>\n<img src=\"https://remotive.com/job/track/2088656/blank.gif?source=public_api\"
+        alt=\"\"/>"}, {"id": 2088655, "url": "https://remotive.com/remote-jobs/customer-service/customer-support-representative-2088655",
+        "title": "Customer Support Representative", "company_name": "AutoHDR", "company_logo":
+        "https://remotive.com/job/2088655/logo", "category": "Customer Service", "tags":
+        ["saas", "AI/ML", "editing", "technical support", "onboarding", "responsive"],
+        "job_type": "full_time", "publication_date": "2026-04-16T21:00:55", "candidate_required_location":
+        "USA", "salary": "", "description": "<div class=\"h3\">Company Description</div>\n<p>\u00a0</p>\n<p>AutoHDR
+        is an AI real estate photo editing platform. We launched less than a year
+        ago and already edit 25% of U.S. real estate listings.</p>\n<p>\u00a0</p>\n<p>We\u2019re
+        building a category-defining product and looking for people who want to help
+        us scale it fast. This is an early hire on a small team of A players changing
+        the industry.</p>\n<p>\u00a0</p>\n<div class=\"h3\">Role Description</div>\n<p>\u00a0</p>\n<p>We\u2019re
+        hiring a Customer Support Rep to own inbound support and make sure the product
+        is delivered well to users.</p>\n<p>\u00a0</p>\n<p>This is not a passive support
+        role. We want someone fast, sharp, calm under pressure, and great with people.
+        Your job is to respond quickly, solve problems clearly, and make sure every
+        customer gets the right outcome fast.</p>\n<p>\u00a0</p>\n<p>You\u2019ll handle
+        inbound questions, quality issues, flagged shoots, human edit requests, and
+        account-related problems. You\u2019ll also be responsible for spotting when
+        something is actually a bug, a churn risk, a sales opportunity, or an onboarding
+        issue, and routing it correctly.</p>\n<p>\u00a0</p>\n<p>We want someone who
+        can think clearly, communicate well, and use judgment. You should be able
+        to solve what can be solved, escalate what needs escalation, and always leave
+        the customer feeling taken care of.</p>\n<p>\u00a0</p>\n<p>You should also
+        be constantly thinking about how support can be faster, smarter, and more
+        scalable over time.</p>\n<p>\u00a0</p>\n<div class=\"h3\">Requirements</div>\n<p>\u00a0</p>\n<p>You
+        love helping people and communicating clearly.</p>\n<p>You are fast, organized,
+        and highly responsive.</p>\n<p>You have strong judgment and know how to solve
+        problems without overcomplicating them.</p>\n<p>You are high-agency and take
+        ownership instead of waiting around.</p>\n<p>You can stay calm under pressure
+        and handle urgent issues well.</p>\n<p>You pay close attention to detail and
+        care about quality.</p>\n<p>You are good at figuring out whether something
+        is a support issue, a bug, a churn risk, or a sales opportunity.</p>\n<p>You
+        think in systems and naturally look for ways to improve workflows over time.</p>\n<p>You
+        are comfortable working quickly across inboxes, tickets, Slack, and internal
+        tools.</p>\n<p>\u00a0</p>\n<div class=\"h3\">Bonus if you:</div>\n<p>\u00a0</p>\n<p>Have
+        worked in customer support, operations, or a fast-paced SaaS environment.</p>\n<p>Have
+        experience in real estate media or real estate photography.</p>\n<p>Have experience
+        handling quality control, escalations, or technical support.</p>\n<p>Have
+        used AI tools to improve workflows or automate repetitive wor</p>\n<img src=\"https://remotive.com/job/track/2088655/blank.gif?source=public_api\"
+        alt=\"\"/>"}, {"id": 1919266, "url": "https://remotive.com/remote-jobs/software-development/senior-independent-ai-engineer-architect-1919266",
+        "title": "Senior Independent AI Engineer / Architect", "company_name": "A.Team",
+        "company_logo": "https://remotive.com/job/1919266/logo", "category": "Software
+        Development", "tags": ["go", "UI/UX", "wordpress", "chat", "apple", "testing",
+        "catalyst"], "job_type": "contract", "publication_date": "2026-04-16T10:16:01",
+        "candidate_required_location": "Americas, Europe, Israel", "salary": "$120
+        - $170 /hour", "description": "<p class=\"my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block
+        [&amp;_strong:has(+br)]:pb-2\" style=\"border-color: oklch(0.3039 0.04 213.68
+        / 0.16); scrollbar-color: initial; scrollbar-width: initial; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\"><span
+        style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial;
+        scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Location:</span>\u00a0Americas,
+        Europe, or Israel</p>\n<div class=\"h2\" style=\"border-color: oklch(0.3039
+        0.04 213.68 / 0.16); scrollbar-color: initial; scrollbar-width: initial; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        1rem; line-height: 1.5rem;\">The Opportunity</div>\n<p class=\"my-2 [&amp;+p]:mt-4
+        [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\" style=\"border-color:
+        oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial; scrollbar-width:
+        initial; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow:
+        0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Join A.Team\u2019s invite-only
+        network of senior builders and access exclusive missions with Fortune 500s
+        and top startups. This isn\u2019t client work or employment\u2014it\u2019s
+        a vetted collective where you\u2019re matched to impactful projects.<br style=\"border-color:
+        oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial; scrollbar-width:
+        initial; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow:
+        0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">At A.Team, you won\u2019t just
+        implement someone else\u2019s plan. You\u2019ll be the technical decision-maker,
+        owning everything from model design to enterprise integration.</p>\n<div class=\"h2\"
+        style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial;
+        scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        1rem; line-height: 1.5rem;\">Why A.Team</div>\n<ul class=\"marker:text-quiet
+        list-disc\" style=\"\">\n<li class=\"py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0
+        [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2
+        [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\"
+        style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial;
+        scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        0px; padding-top: 0px;\"><span style=\"border-color: oklch(0.3039 0.04 213.68
+        / 0.16); scrollbar-color: initial; scrollbar-width: initial; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Elite
+        peers</span>: ex-OpenAI, Google, Meta, Amazon.</p>\n</li>\n<li class=\"py-0
+        my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2
+        [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block
+        [&amp;_strong:has(+br)]:pb-2\" style=\"border-color: oklch(0.3039 0.04 213.68
+        / 0.16); scrollbar-color: initial; scrollbar-width: initial; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        0px; padding-top: 0px;\"><span style=\"border-color: oklch(0.3039 0.04 213.68
+        / 0.16); scrollbar-color: initial; scrollbar-width: initial; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Precision
+        matching</span>: Missions in LLMs, CV, NLP, ML infra, fine-tuning.</p>\n</li>\n<li
+        class=\"py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0
+        [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2 [&amp;+p]:mt-4
+        [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\" style=\"border-color:
+        oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial; scrollbar-width:
+        initial; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow:
+        0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top: 0px; padding-top: 0px;\"><span
+        style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial;
+        scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Compensation</span>:
+        $120\u2013$170/hr, biweekly payouts, you keep 100%.</p>\n</li>\n<li class=\"py-0
+        my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2
+        [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block
+        [&amp;_strong:has(+br)]:pb-2\" style=\"border-color: oklch(0.3039 0.04 213.68
+        / 0.16); scrollbar-color: initial; scrollbar-width: initial; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        0px; padding-top: 0px;\"><span style=\"border-color: oklch(0.3039 0.04 213.68
+        / 0.16); scrollbar-color: initial; scrollbar-width: initial; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Autonomy</span>:
+        Choose only missions that excite you\u2014no small gigs, no chasing.</p>\n</li>\n</ul>\n<div
+        class=\"h2\" style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color:
+        initial; scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        1rem; line-height: 1.5rem;\">What You\u2019ll Do</div>\n<ul class=\"marker:text-quiet
+        list-disc\" style=\"\">\n<li class=\"py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0
+        [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2
+        [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\"
+        style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial;
+        scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        0px; padding-top: 0px;\">Lead the design, deployment, and scaling of production
+        AI systems.</p>\n</li>\n<li class=\"py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0
+        [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2
+        [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\"
+        style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial;
+        scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        0px; padding-top: 0px;\">Build ambitious software 0\u21921 in small, senior
+        teams (3\u20135 people).</p>\n</li>\n<li class=\"py-0 my-0 prose-p:pt-0 prose-p:mb-2
+        prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0\" style=\"\">\n<p
+        class=\"my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\"
+        style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial;
+        scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        0px; padding-top: 0px;\">Scope, propose, and execute solutions with real ownership.</p>\n</li>\n<li
+        class=\"py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0
+        [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2 [&amp;+p]:mt-4
+        [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\" style=\"border-color:
+        oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial; scrollbar-width:
+        initial; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow:
+        0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top: 0px; padding-top: 0px;\">Partner
+        with founders, CTOs, and product leaders to deliver outcomes that matter.</p>\n</li>\n</ul>\n<div
+        class=\"h2\" style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color:
+        initial; scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        1rem; line-height: 1.5rem;\">Who Thrives Here</div>\n<ul class=\"marker:text-quiet
+        list-disc\" style=\"\">\n<li class=\"py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0
+        [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2
+        [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\"
+        style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial;
+        scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        0px; padding-top: 0px;\">Senior AI/ML Engineers with production systems live.</p>\n</li>\n<li
+        class=\"py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0
+        [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2 [&amp;+p]:mt-4
+        [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\" style=\"border-color:
+        oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial; scrollbar-width:
+        initial; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow:
+        0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top: 0px; padding-top: 0px;\">AI
+        Architects who\u2019ve built enterprise AI stacks.</p>\n</li>\n<li class=\"py-0
+        my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2
+        [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block
+        [&amp;_strong:has(+br)]:pb-2\" style=\"border-color: oklch(0.3039 0.04 213.68
+        / 0.16); scrollbar-color: initial; scrollbar-width: initial; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        0px; padding-top: 0px;\">Tech Leaders balancing architecture with business
+        outcomes.</p>\n</li>\n<li class=\"py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0
+        [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2
+        [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\"
+        style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial;
+        scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        0px; padding-top: 0px;\">Specialists in LLMs, CV, NLP, or infra with proven
+        depth.</p>\n</li>\n</ul>\n<p><strong><em>Not a fit</em></strong>: under 4
+        years\u2019 experience, simple website builders, or small gig seekers.</p>\n<div
+        class=\"h2\" style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color:
+        initial; scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        1rem; line-height: 1.5rem;\">Proof in the Network</div>\n<p class=\"my-2 [&amp;+p]:mt-4
+        [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\" style=\"border-color:
+        oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial; scrollbar-width:
+        initial; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow:
+        0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Your peers have scaled apps to
+        millions, built enterprise AI platforms, shipped AI at unicorns, and deployed
+        infra handling billions/day.</p>\n<div class=\"h2\" style=\"border-color:
+        oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial; scrollbar-width:
+        initial; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow:
+        0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top: 1rem; line-height:
+        1.5rem;\">How to Apply</div>\n<p class=\"my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block
+        [&amp;_strong:has(+br)]:pb-2\" style=\"border-color: oklch(0.3039 0.04 213.68
+        / 0.16); scrollbar-color: initial; scrollbar-width: initial; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Apply
+        once at\u00a0<a href=\"http://a.team/ai-talent?utm_source=remotive&amp;utm_medium=post&amp;utm_campaign=welikeremotiveAI\"
+        rel=\"nofollow\" target=\"_self\">build.a.team/apply-ai</a>.<br style=\"border-color:
+        oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial; scrollbar-width:
+        initial; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow:
+        0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Short, rigorous process\u2014we
+        care more about what you\u2019ve built than lengthy forms.</p>\n<p>\u00a0</p>\n<img
+        src=\"https://remotive.com/job/track/1919266/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/1919266/logo"},
+        {"id": 1919265, "url": "https://remotive.com/remote-jobs/software-development/senior-independent-software-developer-1919265",
+        "title": "Senior Independent Software Developer", "company_name": "A.Team",
+        "company_logo": "https://remotive.com/job/1919265/logo", "category": "Software
+        Development", "tags": ["go", "wordpress", "chat", "apple", "testing", "catalyst"],
+        "job_type": "contract", "publication_date": "2026-04-16T10:15:53", "candidate_required_location":
+        "Americas, Europe, Israel", "salary": "$90 - $150 /hour", "description": "<p
+        style=\"text-size-adjust: 100%; overflow-wrap: break-word;\"><em>You must
+        be located in the Americas, Europe, or Israel to apply.<br></em><br><br><a
+        href=\"https://build.a.team/remotivereferral\" rel=\"nofollow\">A\u00b7Team</a>
+        is a VC-backed, stealth, application-only home on the internet for senior
+        independent software builders to team up with hand-picked, high-growth companies
+        on their next big thing.\u00a0</p>\n<p style=\"text-size-adjust: 100%; overflow-wrap:
+        break-word;\">After talking with hundreds of independent engineers, designers,
+        and product folks, we heard over and over that finding vetted, high-quality,
+        consistent clients is hard, and projects are often too small to be rewarding.
+        A\u00b7Team matches small teams of the most talented builders in the world
+        with companies backed by a16z, YC, Softbank, General Catalyst, etc. on a contract
+        basis for many of their most important initiatives. We quietly launched in
+        May 2020, and have helped A\u00b7Teamers earn $85+ million since.</p>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 12pt; margin-bottom: 12pt;\"><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; vertical-align:
+        baseline;\"><em>As part of A\u00b7Team, you can expect:</em></span></p>\n<ul
+        style=\"\">\n<li style=\"\"><strong>High-paying, meaningful missions with
+        the most audacious companies</strong> sent your way; generally $90-$150+/hr,
+        with vetted, fascinating clients doing work that matters. We''re picky about
+        who we partner with; new clients only come in via trusted referral. We''ve
+        worked with Lyft, McGraw Hill, ClearCo, Pepsi, Walmart, the former CEO of
+        Waze, the leading vaccine production software, several new unicorns we can''t
+        say here, and dozens of startups backed by a16z/YC/Softbank/Insight/Tiger/etc.</li>\n<li
+        style=\"\"><strong>Work alongside friends old &amp; new: </strong>our niche
+        is small/diverse product teams, since clients with larger budgets and higher-impact
+        work tell us they want teams, not individuals. Of course, we keep friends
+        together whenever we can.</li>\n<li style=\"\"><strong>Full autonomy:</strong>
+        say \"no\" to things that don''t excite you. The most talented builders often
+        juggle a few things at once, so there''s never pressure to join an A\u00b7Team
+        mission if you don''t have the bandwidth. If we''re no longer a fit, it''s
+        easy to leave or pause too.\u00a0</li>\n<li style=\"\"><strong>Small, curated,
+        off-the-record gatherings:</strong> for conversations hard to have elsewhere.
+        Long-term, we''re creating micro-communities for the world''s top builders
+        to become friends around the things they care about.</li>\n<li style=\"\"><strong>Keep
+        100% of what you earn: </strong>if you charge $120/hr, you get $120/hr. A\u00b7Team
+        makes money by charging a small, flat, transparent platform fee on <em>top</em>
+        of your rate.</li>\n</ul>\n<p>\u00a0</p>\n<p>\u00a0</p>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; margin-top: 12pt; margin-bottom: 12pt;\"><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; vertical-align: baseline;\"><strong>How
+        to apply:</strong></span></p>\n<p dir=\"ltr\" style=\"line-height: 1.38; margin-top:
+        12pt; margin-bottom: 12pt;\"><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; vertical-align: baseline;\">Go here:\u00a0<a href=\"https://build.a.team/remotivereferral\"
+        rel=\"nofollow\">https://build.a.team/remotivereferral</a>\u00a0+ mention
+        Remotive.\u00a0</span>We respect your time so the application is short. We''re
+        also much more interested in seeing what you''ve made, and excited to chat
+        more if there\u2019s a fit.</p>\n<p dir=\"ltr\" style=\"line-height: 1.38;
+        margin-top: 12pt; margin-bottom: 12pt;\"><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; vertical-align: baseline;\"><strong>What
+        you\u2019ll do:</strong></span></p>\n<ul style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 12pt; margin-bottom: 0pt;\"><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; vertical-align:
+        baseline;\">Once part of A.Team, you\u2019ll regularly be invited to impactful
+        missions that match your interests. Find the right pick from early-stage incubations
+        with world-class founders, to fast-growing super-funded companies, to old
+        school non-tech incumbents looking to build as a tech giant would</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; margin-top:
+        0pt; margin-bottom: 0pt;\"><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; vertical-align: baseline;\">Missions usually involve building an ambitious
+        piece of software from 0 to 1 as part of a small 3-4 person team.\u00a0</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; margin-top:
+        0pt; margin-bottom: 12pt;\"><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; vertical-align: baseline;\">You\u2019ll be paid to scope it out, give
+        the client options, guide strategy, and execute on the selected solution.
+        Sometimes the client has a clear vision, sometimes not; which is why A.Team
+        builders tend to be senior folks who can work together to find the right direction.\u00a0</span></p>\n</li>\n</ul>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 12pt; margin-bottom: 12pt;\"><strong><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; vertical-align:
+        baseline;\">Who A</span><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; vertical-align: baseline;\">\u00b7</span><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; vertical-align: baseline;\">Team
+        is for:</span></strong></p>\n<ul style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 12pt; margin-bottom: 0pt;\"><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; vertical-align:
+        baseline;\">Senior software developers who left large companies and high-growth
+        startups to pursue their craft with autonomy.</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; margin-top: 0pt; margin-bottom:
+        0pt;\"><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; vertical-align: baseline;\">Those who prefer consistent contract work
+        over a full-time role, who want to create a variety of new products alongside
+        other top-tier builders.</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 0pt; margin-bottom: 12pt;\"><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; vertical-align:
+        baseline;\">The majority of A.Teamers spend most of their time doing independent
+        work, but a sizeable percentage are either employed full-time (but testing
+        out client work), bootstrapping a side project, or looking for their next
+        big thing</span></p>\n</li>\n</ul>\n<p dir=\"ltr\" style=\"line-height: 1.38;
+        margin-top: 12pt; margin-bottom: 12pt;\"><strong><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; vertical-align: baseline;\">Who A</span><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; vertical-align:
+        baseline;\">\u00b7</span><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; vertical-align: baseline;\">Team is </span><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; vertical-align: baseline;\">not</span><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; vertical-align:
+        baseline;\"> for:</span></strong></p>\n<ul style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 12pt; margin-bottom: 0pt;\"><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; vertical-align:
+        baseline;\">People looking for small gigs</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; margin-top: 0pt; margin-bottom:
+        0pt;\"><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; vertical-align: baseline;\">Folks looking to build simple wordpress/wix/squarespace-style
+        websites</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height:
+        1.38; margin-top: 0pt; margin-bottom: 12pt;\"><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; vertical-align: baseline;\">Those
+        still early in their careers (&lt;4 years) and recent university/bootcamp
+        grads (at least not yet)</span></p>\n</li>\n</ul>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; margin-top: 12pt; margin-bottom: 12pt;\"><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; vertical-align: baseline;\"><strong>Our
+        long-term vision:</strong></span></p>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; margin-top: 12pt; margin-bottom: 12pt;\"><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; vertical-align: baseline;\"><a href=\"https://build.a.team/remotivereferral\"
+        rel=\"nofollow\">A\u00b7Team</a> is a new type of company for a new kind of
+        independent software builder. We call them \"unhirables\": people who traditional
+        companies couldn\u2019t hire full-time even if they wanted to, but who want
+        to do their most meaningful work with their favorite people in small, autonomous,
+        distributed expert teams.\u00a0</span></p>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; margin-top: 12pt; margin-bottom: 12pt;\"><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; vertical-align: baseline;\">To help
+        us secure amazing missions, we raised $60 million+\u00a0 from Insight Partenrs,
+        Tiger Global, NFX, RocNation, along with the former CEO of Upwork, the founders
+        of Fiverr and Lemonade, Apple''s Global Head of Recruiting, YC Partner Aaron
+        Harris, Wharton''s Adam Grant, and Duke''s Dan Ariely.</span></p>\n<img src=\"https://remotive.com/job/track/1919265/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/1919265/logo"},
+        {"id": 2088711, "url": "https://remotive.com/remote-jobs/software-development/senior-full-stack-react-developer-2088711",
+        "title": "Senior Full-stack React Developer", "company_name": "Lemon.io",
+        "company_logo": "https://remotive.com/job/2088711/logo", "category": "Software
+        Development", "tags": [".Net", "android", "AWS", "azure", "backend", "C",
+        "C#", "C++", "data science", "fullstack", "golang", "ios", "java", "javascript",
+        "node.js", "php", "python", "react", "react js", "ruby/rails", "shopify",
+        "video", "blockchain", "AI/ML", "react native", "rust", "unity", "spring",
+        "data analysis", "laravel", "solidity", "flask", "Typescript ", "angular ",
+        "GCP", "data engineering", "Symfony", "startup", "marketplace", "next.js"],
+        "job_type": "contract", "publication_date": "2026-04-15T14:19:37", "candidate_required_location":
+        "Americas, Europe, Asia, Oceania", "salary": "", "description": "<p>Are you
+        a talented Senior Developer looking for a remote job that lets you show your
+        skills and get decent compensation? Look no further than <a href=\"https://lemon.io/for-developers/?utm_source=remotive&amp;utm_medium=job_ad&amp;utm_campaign=supply_en_react_python/golang_apr_2026_job_ad\"
+        rel=\"nofollow\" target=\"_self\">Lemon.io</a> \u2014 the marketplace that
+        connects you with hand-picked startups in the US and Europe.</p>\n<p><strong>\u00a0</strong></p>\n<p><strong>What
+        we offer:</strong></p>\n<ul style=\"\">\n<li style=\"\">The rate depends on
+        your seniority level, skills and experience. We''ve already paid out over
+        $11M to our engineers.</li>\n<li style=\"\">No more hunting for clients or
+        negotiating rates \u2014 let us handle the business side of things so you
+        can focus on what you do best.</li>\n<li style=\"\">We''ll manually find the
+        best project for you according to your skills and preferences.</li>\n<li style=\"\">Choose
+        a schedule that works best for you. It\u2019s possible to communicate async
+        or minimally overlap within team working hours.</li>\n<li style=\"\">We respect
+        your seniority so you can expect no micromanagement or screen trackers.</li>\n<li
+        style=\"\">Communicate directly with the clients. Most of them have technical
+        backgrounds. Sounds good, yeah?</li>\n<li style=\"\">We will support you from
+        the time you submit the application throughout all cooperation stages.</li>\n<li
+        style=\"\">Most of our projects involve working in a fast-paced startup environment.
+        We hope you like it as much as we do.</li>\n</ul>\n<div class=\"h4\">\n<ul
+        style=\"\">\n<li style=\"\">Through our community, we will connect you with
+        the best developers from more than 71 countries.</li>\n</ul>\n<br>We have
+        several open positions for Full-Stack React.js Developers - please see the
+        details below. We also have some backend positions; the full list is included
+        below as well.</div>\n<div class=\"h3\"><strong>\u00a0</strong></div>\n<div
+        class=\"h3\"><strong>Requirements for the Senior React &amp; Python Position:</strong></div>\n<ul
+        style=\"\">\n<li style=\"\">4+ years of software development experience</li>\n</ul>\n<p><strong>Commercial
+        experience:</strong></p>\n<ul style=\"\">\n<li style=\"\">React.js 3+ years
+        and Python 3+ years <strong>OR</strong> React.js 2+ years and Python 5+ years
+        <strong>OR</strong> React.js 5+ years and Python 2+ years</li>\n<li style=\"\">Experience
+        with AWS, GCP, or Azure is required</li>\n</ul>\n<div class=\"h3\"><strong>\u00a0</strong></div>\n<div
+        class=\"h3\"><strong>Requirements for the Senior Python Position:</strong></div>\n<ul
+        style=\"\">\n<li style=\"\">5+ years of software development experience</li>\n<li
+        style=\"\">5+ years of commercial experience with Python</li>\n<li style=\"\">3+
+        years of commercial experience with Flask</li>\n</ul>\n<div class=\"h3\"><strong>\u00a0</strong></div>\n<div
+        class=\"h3\"><strong>Requirements for the Senior Golang &amp; React Position:</strong></div>\n<ul
+        style=\"\">\n<li style=\"\">4+ years of software development experience</li>\n<li
+        style=\"\">React.js 3+ years and Golang 3+ years <strong>OR</strong> React.js
+        2+ years and Golang 5+ years <strong>OR</strong> React.js 5+ years and Golang
+        2+ years</li>\n</ul>\n<div class=\"h3\"><strong>\u00a0</strong></div>\n<div
+        class=\"h3\"><strong>Requirements for the Senior Golang Position:</strong></div>\n<ul
+        style=\"\">\n<li style=\"\">5+ years of software development experience</li>\n<li
+        style=\"\">5+ years of commercial experience with Golang</li>\n</ul>\n<p><strong>\u00a0</strong></p>\n<p><strong>Other
+        requirements:</strong></p>\n<ul style=\"\">\n<li style=\"\">Strong technical
+        skills: as a Senior Developer, you are expected to be able to create projects
+        from scratch and have a deep understanding of application architecture.</li>\n<li
+        style=\"\">Clear and effective communication in English \u2014 advanced ability
+        to discuss business tasks, justify decisions, and communicate issues. Good
+        self-presentation is also essential for upcoming client calls.</li>\n<li style=\"\">Strong
+        self-organizational skills \u2014 ability to work full-time remotely with
+        no supervision.</li>\n<li style=\"\">Reliability \u2014 we want to trust you
+        and expect that you won\u2019t let us and the client down.</li>\n<li style=\"\">Adaptability
+        and Flexibility \u2014 the ability to onboard the project promptly after accepting
+        it and start delivering results quickly.</li>\n</ul>\n<p>\u00a0</p>\n<p>Sounds
+        good for you? Apply now and join the <a href=\"https://lemon.io/for-developers/?utm_source=remotive&amp;utm_medium=job_ad&amp;utm_campaign=supply_en_react_python/golang_apr_2026_job_ad\"
+        rel=\"nofollow\" target=\"_self\">Lemon.io</a> community!</p>\n<p><strong>\u00a0</strong></p>\n<p><strong>NOT
+        YOUR TECH STACK?</strong></p>\n<p>We have multiple projects available for
+        Senior Developers. If you have 4+ years of commercial software development
+        experience and are proficient in any of the following areas:\u00a0React &amp;
+        Node, React &amp; Ruby, PHP &amp; Angular, PHP &amp; Vue, Vue &amp; Node.js,
+        React &amp; .NET, Android &amp; iOS, Angular &amp; .NET, Angular &amp; Node.js,
+        Vue &amp; .NET, Python &amp; Vue, MLOps, React &amp; Java, Data Science, Blockchain
+        (Web3/Solidity/Solana), Symfony &amp; React, Symfony &amp; Vue, Symfony &amp;
+        Angular, Symfony &amp; JavaScript &amp; Next.js &amp; TypeScript, Data Analysis,
+        React &amp; PHP, Data Engineering, AI Engineering, Data Annotation, DevOps,
+        Svelte &amp; Python, Svelte &amp; Node, Svelte &amp; TypeScript, Rust, Shopify
+        &amp; JavaScript, Vue &amp; Nuxt, Python &amp; Node, Angular &amp; TypeScript,
+        Ruby &amp; Ruby on Rails, React Native &amp; Ruby, React Native &amp; Python,
+        PHP &amp; Laravel, .NET &amp; C#, Java &amp; Spring, Unreal Engine &amp; C++,
+        Python &amp; LLM, Unity, Machine Learning Engineering\u00a0\u2014 we\u2019d
+        be happy to connect and match you with a suitable project.</p>\n<p>\u00a0</p>\n<p><strong>If
+        your experience matches our requirements, be ready for the next steps:</strong></p>\n<ul
+        style=\"\">\n<li style=\"\">VideoAsk \u2014 watch a short video about our
+        startup, up to 10 minutes</li>\n<li style=\"\">Complete your profile on our
+        website</li>\n<li style=\"\">Screening call</li>\n<li style=\"\">Technical
+        interview</li>\n<li style=\"\">Feedback</li>\n<li style=\"\">Magic Box (we
+        are looking for the best project for you).</li>\n</ul>\n<p>\u00a0</p>\n<p>We
+        do not provide visa assistance, and our cooperation model does not include
+        the benefits typically offered with direct hire.</p>\n<p>\u00a0</p>\n<p>P.S.
+        <strong>We work with developers from 71+ countries in different regions:</strong>
+        Europe, LATAM, the U.S (if you are an owner of W-9 ben form), Canada, Asia
+        (Japan, Singapore, South Korea, Philippines, Indonesia), Oceania (Australia,
+        New Zealand, Papua New Guinea), and the the UK. However, we have some exceptions.</p>\n<p><strong>\u00a0</strong></p>\n<p><strong>At
+        the moment, we don\u2019t have a legal basis to accept applicants from the
+        following countries:</strong></p>\n<ul style=\"\">\n<li style=\"\">European:
+        Hungary, Iceland, Liechtenstein, Kosovo, Belarus, Russia, and Serbia.</li>\n<li
+        style=\"\">Latin America: Cuba and Nicaragua</li>\n<li style=\"\">Most Asian
+        countries and Africa.</li>\n</ul>\n<p>We expand and shorten the list of exemptions
+        regularly.</p>\n<p><!-- notionvc: 49abefed-fba6-4833-8e6d-3554e2c38fc5 --></p>\n<p>\u00a0</p>\n<p>Do
+        you represent a company with engineers who match the description and want
+        to collaborate with us through staff augmentation? Then register <a href=\"https://lemon.io/for-developers/?utm_source=remotive&amp;utm_medium=job_ad&amp;utm_campaign=supply_en_react_python/golang_apr_2026_job_ad\"
+        rel=\"nofollow\" target=\"_self\">here</a>.</p>\n<img src=\"https://remotive.com/job/track/2088711/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/2088711/logo"},
+        {"id": 2069746, "url": "https://remotive.com/remote-jobs/software-development/tech-lead-full-stack-rails-engineer-2069746",
+        "title": "Tech Lead Full-Stack Rails Engineer", "company_name": "Mitre Media",
+        "company_logo": "https://remotive.com/job/2069746/logo", "category": "Software
+        Development", "tags": ["api", "CSS", "docker", "elasticsearch", "fullstack",
+        "html", "javascript", "kubernetes", "postgresql", "react", "ror", "ruby/rails",
+        "AI/ML", "CAD", "advertising", "Redis", "ES6", "web applications", "MySQL",
+        "NLP", "fintech", "Micro services", "github", "system architecture"], "job_type":
+        "full_time", "publication_date": "2026-04-14T21:01:45", "candidate_required_location":
+        "USA, Canada, USA timezones", "salary": "$170k - $200k", "description": "<p
+        class=\"h1\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 24pt; margin-bottom: 0pt; padding: 0pt 0pt 6pt 0pt;\"><span style=\"color:
+        #000000; font-weight: bold; white-space-collapse: preserve;\">About Mitre
+        Media</span></p>\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt; padding: 0pt 0pt 18pt 0pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">Mitre Media is redefining FinTech with AI-driven
+        tools that empower millions of investors. Our portfolio, including Dividend.com
+        and MutualFunds.com, leverages LLMs to deliver novel data insights and visually
+        rich user experiences. For over a decade, we\u2019ve served individual investors,
+        financial advisors, and top asset managers like BlackRock and Vanguard through
+        our premium data, tools, and advertising solutions. Join our lean, entrepreneurial
+        team to shape the future of AI-powered investing from your location \u00b13
+        hours from Eastern Time.</span></p>\n<p dir=\"ltr\" style=\"line-height: 1.38;
+        background-color: #ffffff; margin-top: 0pt; margin-bottom: 0pt; padding: 0pt
+        0pt 18pt 0pt;\"><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Our users are deeply
+        engaged, spending over 5 minutes per visit with a bounce rate below 10%, researching
+        investments across hundreds of different categories. With 40 million brokerage
+        accounts in the U.S., we take pride in building tools that make a real impact,
+        fostering a culture of trust, innovation, and dynamism. If you\u2019re passionate
+        about financial technology and AI, we\u2019d love to connect!</span></p>\n<p
+        class=\"h2\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt; padding: 14pt 0pt 18pt 0pt;\"><span style=\"color:
+        #000000; background-color: transparent; font-weight: bold; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">About the Role</span></p>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom: 0pt; padding:
+        0pt 0pt 18pt 0pt;\"><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">As a Full-Stack Rails
+        Tech Lead, you\u2019ll architect and implement LLM-powered web applications
+        within our microservices-based Rails 8 platform. Reporting directly to our
+        CTO, you\u2019ll collaborate with a small, high-impact team to deliver user
+        experiences across Dividend.com, MutualFunds.com and other brands within our
+        portfolio. This role combines expert Ruby on Rails skills with AI integration
+        expertise, requiring you to leverage LLMs in your development workflow, state
+        management and user interactions.</span></p>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom: 0pt; padding:
+        0pt 0pt 18pt 0pt;\"><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">You\u2019ll work
+        in a remote-first hybrid environment, which encourages in person collaboration,
+        using ShapeUp to manage projects that trade-off on-time delivery for de-scoped
+        outcomes. As a technical leader, you''ll have a seat at the table shaping
+        system architecture, implementing core features all while embracing an entrepreneurial
+        mindset and a \u201cget things done\u201d mentality.</span></p>\n<p class=\"h2\"
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 18pt; padding: 14pt 0pt 0pt 0pt;\"><span style=\"color:
+        #000000; background-color: transparent; font-weight: bold; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">Responsibilities</span></p>\n<ul style=\"\">\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 9pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Architect and maintain
+        Rails applications (Rails 8)</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Integrate LLMs into
+        our microservices architecture for state management and real-time user experiences.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Enhance
+        front-end experiences with Hotwire, StimulusJS, or React, ensuring seamless
+        AI-driven interactions.</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 27pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Optimize LLM inference
+        for low latency and cost, using caching and asynchronous processing.</span></p>\n</li>\n</ul>\n<p
+        class=\"h2\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 32pt; margin-bottom: 0pt; padding: 0pt 0pt 18pt 0pt;\"><span style=\"color:
+        #000000; background-color: transparent; font-weight: bold; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">Required Technical Skills</span></p>\n<p class=\"h3\" dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom:
+        9pt;\"><span style=\"color: #000000; background-color: transparent; font-weight:
+        bold; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">Back-End</span></p>\n<ul style=\"\">\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 9pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Ruby
+        (5+ years, expert-level)</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Ruby on Rails (Rails
+        6-8 preferred)</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom:
+        0pt;\"><span style=\"color: #000000; background-color: transparent; font-weight:
+        400; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">PostgreSQL (or MySQL)</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Elasticsearch</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Redis</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 27pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Docker</span></p>\n</li>\n</ul>\n<p
+        class=\"h3\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 22pt; margin-bottom: 9pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Front-End</span></p>\n<ul
+        style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 9pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">StimulusJS or JavaScript ES6</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Tailwind
+        CSS</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">HTML</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 27pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">HTTP</span></p>\n</li>\n</ul>\n<p
+        class=\"h3\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 22pt; margin-bottom: 9pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">AI
+        Integration</span></p>\n<ul style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 9pt; margin-bottom:
+        0pt;\"><span style=\"color: #000000; background-color: transparent; font-weight:
+        400; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">Experience integrating AI/ML models (e.g.,
+        LLMs, NLP) with web applications</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 27pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Familiarity with
+        LLM frameworks (e.g., LangChain, Hugging Face) or APIs (e.g., xAI, Anthropic)</span></p>\n</li>\n</ul>\n<p
+        class=\"h2\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 32pt; margin-bottom: 18pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Nice-to-Have
+        Technical Skills</span></p>\n<ul style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        9pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Kubernetes for microservices
+        orchestration</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom:
+        0pt;\"><span style=\"color: #000000; background-color: transparent; font-weight:
+        400; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">React for advanced front-end components</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Graph
+        databases for complex financial data</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 27pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Contributions to
+        open-source RoR or AI projects</span></p>\n</li>\n</ul>\n<p class=\"h2\" dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 32pt; margin-bottom:
+        18pt;\"><span style=\"color: #000000; background-color: transparent; font-weight:
+        bold; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">Required Soft Skills</span></p>\n<ul style=\"\">\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 9pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Entrepreneurial
+        mindset with a passion for AI and FinTech</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Natural leader who
+        mentors and inspires teammates</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Problem-solver with
+        a \u201cget things done\u201d mentality</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Excellent communication,
+        thriving in remote and cross-team collaboration</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Attention to detail,
+        ensuring clean, maintainable code</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 27pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Team player comfortable
+        as an individual contributor</span></p>\n</li>\n</ul>\n<p class=\"h2\" dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 32pt; margin-bottom:
+        18pt;\"><span style=\"color: #000000; background-color: transparent; font-weight:
+        bold; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">Why Join Us?</span></p>\n<ul style=\"\">\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 9pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Impactful
+        Work</span><span style=\"color: #000000; background-color: transparent; font-weight:
+        400; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">: Build AI-powered tools that help millions
+        of investors make informed decisions from data-driven insights.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Cutting-Edge
+        Tech</span><span style=\"color: #000000; background-color: transparent; font-weight:
+        400; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">: Work with Rails 8, LLMs, and modern tools
+        like Hotwire, Databricks, and xAI\u2019s API in a microservices architecture.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Autonomy
+        and Influence</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">: Collaborate directly
+        with our CEO and CTO to shape our AI-driven platform, with freedom to innovate.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Competitive
+        Compensation</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">: $160,000\u2013$200,000
+        CAD/USD (based on experience) and benefits.</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Remote
+        Flexibility</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">: Remote-first (\u00b13
+        hours from ET) with hybrid in office collaboration in Toronto or NYC</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Growth
+        Opportunities</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">: Budget for AI and
+        Rails conferences (e.g., NeurIPS, RailsConf), plus access to cutting-edge
+        AI tools for experimentation.</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 27pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Dynamic
+        Culture</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">: Join a small, no-ego
+        team passionate about trust, innovation, and making a difference in FinTech.</span></p>\n</li>\n</ul>\n<p
+        class=\"h2\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 32pt; margin-bottom: 0pt; padding: 0pt 0pt 18pt 0pt;\"><span style=\"color:
+        #000000; background-color: transparent; font-weight: bold; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">About Mitre Media\u2019s AI-Driven Platform</span></p>\n<p dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom:
+        0pt; padding: 0pt 0pt 18pt 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Mitre Media powers
+        premium financial brands like </span><a href=\"http://dividend.com/\" rel=\"nofollow\"
+        style=\"text-decoration: none;\"><span style=\"color: #1155cc; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        underline; -webkit-text-decoration-skip: none; text-decoration-skip-ink: none;
+        vertical-align: baseline; white-space: pre-wrap;\">Dividend.com</span></a><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\"> and </span><a href=\"http://mutualfunds.com/\" rel=\"nofollow\"
+        style=\"text-decoration: none;\"><span style=\"color: #1155cc; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        underline; -webkit-text-decoration-skip: none; text-decoration-skip-ink: none;
+        vertical-align: baseline; white-space: pre-wrap;\">MutualFunds.com</span></a><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\"> with the Mitre Platform. This platform integrates
+        traditional content management, financial data, first-party data, ad revenue,
+        and subscription tools, all enhanced by LLMs for rich, user-focused experiences.
+        Our data-derived insights delight users, while our advertising solutions deliver
+        unmatched performance for partners like BlackRock and Vanguard, leveraging
+        advanced targeting and first-party data.</span></p>\n<p class=\"h2\" dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom:
+        0pt; padding: 14pt 0pt 18pt 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">How
+        to Apply</span></p>\n<p>\u00a0</p>\n<p dir=\"ltr\" style=\"line-height: 1.38;
+        background-color: #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color:
+        #000000; background-color: transparent; font-weight: 400; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">Submit your resume, GitHub profile, and a brief note on why you\u2019re
+        excited about building AI-driven FinTech to jobs@mitremedia.com.</span></p>\n<img
+        src=\"https://remotive.com/job/track/2069746/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/2069746/logo"},
+        {"id": 2069747, "url": "https://remotive.com/remote-jobs/software-development/tech-lead-databricks-data-engineer-2069747",
+        "title": "Tech Lead Databricks Data Engineer", "company_name": "Mitre Media",
+        "company_logo": "https://remotive.com/job/2069747/logo", "category": "Software
+        Development", "tags": ["apache", "api", "AWS", "big data", "cloud", "java",
+        "python", "scala", "sql", "AI/ML", "documentation", "CAD", "CI/CD", "analytics",
+        "advertising", "spark", "tableau", "GCP", "ETL", "data engineering", "SOLID",
+        "fintech", "Micro services", "backbone", "github"], "job_type": "full_time",
+        "publication_date": "2026-04-14T21:01:37", "candidate_required_location":
+        "USA, Canada, USA timezones", "salary": "$160k - $180k", "description": "<div
+        class=\"h2\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 18pt; margin-bottom: 0pt; padding: 0pt 0pt 4pt 0pt;\"><span style=\"color:
+        #000000; background-color: transparent; font-weight: bold; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">About Mitre Media</span></div>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom: 0pt; padding:
+        8pt 0pt 12pt 0pt;\"><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Mitre Media is redefining
+        FinTech with AI-driven tools that empower millions of investors. Our portfolio,
+        including Dividend.com and MutualFunds.com, leverages LLMs to deliver novel
+        data insights and visually rich user experiences. For over a decade, we\u2019ve
+        served individual investors, financial advisors, and top asset managers like
+        BlackRock and Vanguard through our premium data, tools, and advertising solutions.
+        If you\u2019re excited by the intersection of big data, AI, and investing,
+        join our lean, entrepreneurial team from anywhere within \u00b13 hours of
+        Eastern Time.</span></p>\n<div class=\"h2\" dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom: 0pt; padding:
+        6pt 0pt 4pt 0pt;\"><span style=\"color: #000000; background-color: transparent;
+        font-weight: bold; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">About the Role</span></div>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 0pt; padding: 8pt 0pt 12pt 0pt;\"><span style=\"color:
+        #000000; background-color: transparent; font-weight: 400; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">As Tech Lead Data Engineer, you\u2019ll architect and maintain
+        the data backbone powering every feature across our product suite. Reporting
+        to the CTO, you will design Databricks-based ETL pipelines, model complex
+        investment data, and surface low-latency, high-quality datasets for both user-facing
+        features and internal AI/analytics workloads. You\u2019ll collaborate in a
+        remote-first hybrid culture that values in-person \u201cbursts\u201d of collaboration,
+        follow ShapeUp for project planning, and ship pragmatic solutions that favor
+        de-scoping over delays.</span></p>\n<div class=\"h2\" dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom: 4pt; padding:
+        6pt 0pt 0pt 0pt;\"><span style=\"color: #000000; background-color: transparent;
+        font-weight: bold; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Responsibilities</span></div>\n<ul
+        style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 12pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">Design, implement, and optimize large-scale ETL workflows
+        in Databricks (Apache Spark, Delta Lake, DBT).</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Develop algorithms
+        that transform raw market data into actionable insights.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Own
+        data quality and lineage, instituting tests, monitoring, and alerting for
+        mission-critical pipelines.</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Evolve our cloud
+        data platform (AWS &amp; GCP) for scale, performance, and cost efficiency.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 12pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Mentor
+        engineers, championing best practices in code reviews, documentation, and
+        DevOps for data.</span></p>\n</li>\n</ul>\n<div class=\"h2\" dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 18pt; margin-bottom: 0pt; padding:
+        0pt 0pt 4pt 0pt;\"><span style=\"color: #000000; background-color: transparent;
+        font-weight: bold; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Required Technical
+        Skills</span></div>\n<div class=\"h3\" dir=\"ltr\" style=\"line-height: 1.38;
+        background-color: #ffffff; margin-top: 0pt; margin-bottom: 4pt; padding: 10pt
+        0pt 0pt 0pt;\"><span style=\"color: #000000; background-color: transparent;
+        font-weight: bold; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Data Engineering</span></div>\n<ul
+        style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 12pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: bold;
+        font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">Programming</span><span style=\"color:
+        #000000; background-color: transparent; font-weight: 400; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">: Expert in Python plus working knowledge of Scala or Java.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Databricks
+        &amp; Spark</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">: Hands-on with cluster
+        tuning, job orchestration, and Delta Tables.</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">SQL
+        &amp; DBT</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">: Strong analytical
+        SQL, modular data-model design, and CI/CD for transformations.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Cloud</span><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">: Production experience on AWS or GCP data services
+        (e.g., S3/GCS, EMR/Dataproc, Glue/Dataflow).</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">ETL
+        &amp; Orchestration</span><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">: Solid grasp of
+        EL(T) patterns, workflow scheduling, and incremental processing.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 12pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Data
+        Modeling</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">: Dimensional and
+        schema-on-read designs for analytics and AI.</span></p>\n</li>\n</ul>\n<div
+        class=\"h3\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 14pt; margin-bottom: 4pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">AI
+        &amp; Analytics Enablement</span></div>\n<ul style=\"\">\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 12pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Building feature
+        stores or inference-ready tables for ML/LLM workflows.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 12pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Familiarity
+        with vector databases or embedding pipelines</span></p>\n</li>\n</ul>\n<div
+        class=\"h2\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 18pt; margin-bottom: 4pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Nice-to-Have
+        Technical Skills</span></div>\n<ul style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        12pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Apache Airflow, Luigi,
+        or Dagster for DAG orchestration.</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Experience with Looker,
+        Tableau, or Stripe\u2019s Vizier-style visualization stacks.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Financial-markets
+        domain knowledge (equities, ETFs, mutual funds).</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 12pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Machine-learning
+        engineering or statistical-analysis background.</span></p>\n</li>\n</ul>\n<div
+        class=\"h2\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 18pt; margin-bottom: 4pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Required
+        Soft Skills</span></div>\n<ul style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        12pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Entrepreneurial mindset
+        with a passion for AI and FinTech innovation.</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Self-starter who
+        diagnoses problems, proposes trade-offs, and delivers.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Clear
+        communicator who thrives in distributed, cross-functional teams.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Mentorship
+        attitude\u2014uplifts peers through code reviews and knowledge-sharing.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 12pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Detail-oriented
+        and disciplined about data accuracy and documentation.</span></p>\n</li>\n</ul>\n<div
+        class=\"h2\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 18pt; margin-bottom: 4pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Why
+        Join Us?</span></div>\n<ul style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 12pt; margin-bottom:
+        0pt;\"><span style=\"color: #000000; background-color: transparent; font-weight:
+        bold; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">Impactful Work</span><span style=\"color:
+        #000000; background-color: transparent; font-weight: 400; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\"> \u2013 Your pipelines feed every insight we deliver to millions
+        of investors.</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom:
+        0pt;\"><span style=\"color: #000000; background-color: transparent; font-weight:
+        bold; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">Cutting-Edge Tech</span><span style=\"color:
+        #000000; background-color: transparent; font-weight: 400; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\"> \u2013 Databricks, Delta Lake, LLMs, Hotwire, and xAI\u2019s
+        API, all in a modern microservices stack.</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Autonomy
+        &amp; Influence</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\"> \u2013 Work directly
+        with the CEO &amp; CTO to shape our data and AI strategy.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Competitive
+        Compensation</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\"> \u2013 $150k \u2013
+        $185k CAD/USD plus benefits and performance bonuses.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Remote
+        Flexibility</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\"> \u2013 Remote-first
+        within \u00b13 hrs ET; optional collaboration hubs in Toronto and NYC.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 12pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Growth
+        Opportunities</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\"> \u2013 Budget for
+        conferences (e.g., Data+AI Summit, NeurIPS) and continuous learning.</span></p>\n</li>\n</ul>\n<div
+        class=\"h2\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 32pt; margin-bottom: 0pt; padding: 0pt 0pt 18pt 0pt;\"><span style=\"color:
+        #000000; background-color: transparent; font-weight: bold; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">About Mitre Media\u2019s AI-Driven Platform</span></div>\n<p dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom:
+        0pt; padding: 0pt 0pt 18pt 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Mitre Media powers
+        premium financial brands like </span><a href=\"http://dividend.com/\" rel=\"nofollow\"
+        style=\"text-decoration: none;\"><span style=\"color: #1155cc; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        underline; -webkit-text-decoration-skip: none; text-decoration-skip-ink: none;
+        vertical-align: baseline; white-space: pre-wrap;\">Dividend.com</span></a><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\"> and </span><a href=\"http://mutualfunds.com/\" rel=\"nofollow\"
+        style=\"text-decoration: none;\"><span style=\"color: #1155cc; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        underline; -webkit-text-decoration-skip: none; text-decoration-skip-ink: none;
+        vertical-align: baseline; white-space: pre-wrap;\">MutualFunds.com</span></a><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\"> with the Mitre Platform. This platform integrates
+        traditional content management, financial data, first-party data, ad revenue,
+        and subscription tools, all enhanced by LLMs for rich, user-focused experiences.
+        Our data-derived insights delight users, while our advertising solutions deliver
+        unmatched performance for partners like BlackRock and Vanguard, leveraging
+        advanced targeting and first-party data.</span></p>\n<div class=\"h2\" dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom:
+        0pt; padding: 14pt 0pt 18pt 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">How
+        to Apply</span></div>\n<p>\u00a0</p>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">Submit your resume, GitHub profile, and a brief note
+        on why you\u2019re excited about building AI-driven FinTech to jobs@mitremedia.com.</span></p>\n<img
+        src=\"https://remotive.com/job/track/2069747/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/2069747/logo"},
+        {"id": 2088710, "url": "https://remotive.com/remote-jobs/all-others/online-data-analyst-united-states-2088710",
+        "title": "Online Data Analyst United States", "company_name": "TELUS Digital",
+        "company_logo": "https://remotive.com/job/2088710/logo", "category": "All
+        others", "tags": ["go", "social media", "AI/ML", "research", "diversity"],
+        "job_type": "part_time", "publication_date": "2026-04-14T12:48:56", "candidate_required_location":
+        "USA", "salary": "", "description": "<p class=\"figma-padding-bottom-32 tw-border-b
+        tw-border-[#E3E6E8]\" style=\"border-bottom-width: 1px; border-color: rgb(227,
+        230, 232); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; --tw-border-opacity: 1; padding-bottom: 32px; color:
+        rgb(33, 37, 41); \"></p><p style=\"border-color: rgb(229, 231, 235); --tw-shadow:
+        0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">Are you a detail-oriented
+        individual with a passion for research and a good understanding of national
+        and local geography? This freelance opportunity allows you to work at your
+        own pace and from the comfort of your own home.</span></p><p style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; cursor: text; padding: 0px; counter-reset: list-1
+        0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><br
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ;\"></p><p style=\"border-color: rgb(229, 231, 235);
+        --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; font-weight: bolder; background-color: transparent;\">A
+        Day in the Life of an Online Data Analyst:</span></p><ul style=\"\"><li style=\"\"><span
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">In this role, you
+        will be working on a project aimed at enhancing the content and quality of
+        digital maps that are used by millions of people worldwide</span></li><li
+        style=\"\"><span style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0
+        0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; background-color: transparent;\">Completing research and evaluation tasks
+        in a web-based environment such as verifying and comparing data, and determining
+        the relevance and accuracy of information.</span></li></ul><p style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; cursor: text; padding: 0px; counter-reset: list-1
+        0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><br
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ;\"></p><p style=\"border-color: rgb(229, 231, 235);
+        --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">Join us today and
+        be part of a dynamic and innovative team that is making a difference in the
+        world!</span></p><p style=\"border-color: rgb(229, 231, 235); --tw-shadow:
+        0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><br style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ;\"></p><p style=\"border-color: rgb(229, 231, 235);
+        --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; font-weight: bolder; background-color: transparent;\">TELUS
+        Digital AI Community</span></p><p style=\"border-color: rgb(229, 231, 235);
+        --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">Our global AI Community
+        is a vibrant network of 1 million+ contributors from diverse backgrounds who
+        help our customers collect, enhance, train, translate, and localize content
+        to build better AI models. Become part of our growing community and make an
+        impact supporting the machine learning models of some of the world\u2019s
+        largest brands. </span></p><p class=\"pt-7 figma-padding-bottom-32 tw-border-b
+        tw-border-[#E3E6E8]\" style=\"border-bottom-width: 1px; border-color: rgb(227,
+        230, 232); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; --tw-border-opacity: 1; padding-bottom: 32px; color:
+        rgb(33, 37, 41);  padding-top: 2.5rem !important;\"></p><div class=\"h4\"
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; line-height: 1.75rem; color: rgb(65, 69, 71);  letter-spacing:
+        0px; --tw-text-opacity: 1; \">Qualification path</div><p style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; cursor: text; padding: 0px; counter-reset: list-1
+        0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">No previous professional
+        experience is required to apply to this role, however, working on this project
+        will require you to pass the basic requirements and go through a standard
+        assessment process. This is a part-time long-term project and your work will
+        be subject to our standard quality assurance checks during the term of this
+        agreement.\u00a0</span></p><p style=\"border-color: rgb(229, 231, 235); --tw-shadow:
+        0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><br style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ;\"></p><p style=\"border-color: rgb(229, 231, 235);
+        --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; font-weight: bolder; background-color: transparent;\">Basic
+        Requirements</span></p><ul style=\"\"><li style=\"\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">Full Professional
+        Proficiency in English language</span></li><li style=\"\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">Being a resident
+        in </span>United States f<span style=\"border-color: rgb(229, 231, 235); --tw-shadow:
+        0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; background-color: transparent;\">or the last 2 consecutive years and having
+        familiarity with current and historical business, media, sport, news, social
+        media, and cultural affairs in United States</span></li><li style=\"\"><span
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">Ability to follow
+        guidelines and conduct online research using search engines, online maps,
+        and website information</span></li><li style=\"\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">Flexibility to work
+        across a diverse set of task types, including maps, news, audio tasks, and
+        relevance</span></li><li style=\"\"><span style=\"border-color: rgb(229, 231,
+        235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px;
+        --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; background-color: transparent;\">Daily access to a broadband internet connection,
+        computer, and relevant software</span></li></ul><p style=\"border-color: rgb(229,
+        231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; cursor: text; padding: 0px; counter-reset: list-1
+        0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><br
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ;\"></p><p style=\"border-color: rgb(229, 231, 235);
+        --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; font-weight: bolder; background-color: transparent;\">Assessment</span></p><p
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; cursor: text; padding: 0px; counter-reset: list-1
+        0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">In order to be hired
+        into the program, you\u2019ll take an open book qualification exam that will
+        determine your suitability for the position and complete ID verification.
+        Our team will provide you with guidelines and learning materials before your
+        qualification exam. You will be required to complete the exam in a specific
+        timeframe but at your convenience.</span></p><p style=\"border-color: rgb(229,
+        231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; cursor: text; padding: 0px; counter-reset: list-1
+        0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><br
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ;\"></p><p style=\"border-color: rgb(229, 231, 235);
+        --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; font-weight: bolder;\">Equal Opportunity</span></p><p
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; cursor: text; padding: 0px; counter-reset: list-1
+        0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">All qualified applicants
+        will receive consideration for a contractual relationship without regard to
+        race, color, religion, sex, sexual orientation, gender identity, national
+        origin, disability, or protected veteran status. At TELUS Digital AI, we are
+        proud to offer equal opportunities and are committed to creating a diverse
+        and inclusive community. All aspects of selection are based on applicants\u2019
+        qualifications, merits, competence, and performance without regard to any
+        characteristic related to diversity.</span></p>\n<img src=\"https://remotive.com/job/track/2088710/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/2088710/logo"},
+        {"id": 1680495, "url": "https://remotive.com/remote-jobs/marketing/office-assistant-1680495",
+        "title": "Office Assistant", "company_name": "Coalition Technologies ", "company_logo":
+        "https://remotive.com/job/1680495/logo", "category": "Marketing", "tags":
+        ["CSS", "excel", "frontend", "git", "html", "illustrator", "magento", "photoshop",
+        "php", "shopify", "wordpress", "MySQL", "startup", "responsive", "themes",
+        "bootstrap", "insurance", "jQuery", "Ajax"], "job_type": "full_time", "publication_date":
+        "2026-04-11T20:16:26", "candidate_required_location": "Worldwide", "salary":
+        "$31,2k- $52k", "description": "<p class=\"h3\">WHY YOU SHOULD APPLY:</p>\n<p>\u00a0</p>\n<p>Coalition
+        Technologies is devoted to delivering clients the highest quality work while
+        providing our team a fun, thriving, and innovative environment. Along with
+        the opportunity for tremendous career growth and rapid advancement, CT offers:</p>\n<ul
+        style=\"\">\n<li style=\"\">The most competitive profit-sharing bonus plan
+        in the industry, paying up to 50% of company profits to full-time employees
+        each month!</li>\n<li style=\"\">A highly competitive Paid Time Off plan,
+        promoting quality work-life balance.</li>\n<li style=\"\">Subsidized gym memberships
+        to help team members feel their best.</li>\n<li style=\"\">Medical, dental,
+        vision, and life insurance packages for all US-based team members.</li>\n<li
+        style=\"\">International Health Insurance Reimbursement Program for all international
+        team members, a benefit unique to Coalition.</li>\n<li style=\"\">Device upgrade
+        and learning reimbursement programs.</li>\n<li style=\"\">Motivating career
+        development plans with clearly defined goals and rewards.</li>\n<li style=\"\">Additional
+        job-specific incentives and bonuses.<br><br></li>\n</ul>\n<p>Plus, 100% of
+        our team works remotely with the support of time tracking software. Our company
+        culture specializes in supporting remote team members, and we\u2019ve been
+        doing so for more than a decade. CT welcomes your application, wherever in
+        the world it''s coming from!</p>\n<p class=\"h3\">\u00a0</p>\n<p class=\"h3\">YOU
+        SHOULD HAVE:</p>\n<p>\u00a0</p>\n<ul style=\"\">\n<li style=\"\">Willingness
+        to learn, grow, and collaborate with the team and company as a whole.</li><li
+        style=\"\">Excellent verbal and written communication skills.</li><li style=\"\">A
+        high level of discretion, ethics, and trustworthiness.</li><li style=\"\">Intermediate
+        spreadsheet skills (preferred)</li><li style=\"\">Innovative thinking and
+        a willingness to challenge existing methods where improvement is possible.</li><li
+        style=\"\">Experience in bookkeeping / financial record keeping (preferred).</li><li
+        style=\"\">Experience with Google Sheets or Excel, Quickbooks Online, and
+        G-Suite (preferred).</li><li style=\"\">The availability to work 40 hours
+        per week from 9:00 am to 6:00 pm PST.</li><li style=\"\">A reliable space
+        to work remotely with a fast computer, quality internet, camera, microphone,
+        and speakers.</li>\n</ul>\n<p class=\"h3\">\u00a0</p>\n<p class=\"h3\">YOUR
+        DUTIES AND TASKS:</p>\n<p>\u00a0</p>\n<ul style=\"\">\n<li style=\"\">Answering
+        phones and emails.</li><li style=\"\">Completing entry-level bookkeeping,
+        including recording expenses, organizing receipts, and completing other transaction
+        records.</li><li style=\"\">Resolving billing issues with clients and internal
+        team members.</li><li style=\"\">Providing account access, usage reports,
+        data analysis, and other ad hoc requests for team members.</li><li style=\"\">Supporting
+        quality assurance checks of various internal and client facing reporting.</li><li
+        style=\"\">Organizing new client contracts, create invoices, and process client
+        payments.</li><li style=\"\">Contributing to internal database maintenance,
+        upkeep and data entry.</li><li style=\"\">Researching, ordering, &amp; distributing
+        company-wide gifts (2-3 times per year).</li><li style=\"\">Organizing company
+        events, competitions, and special projects throughout the year.</li><li style=\"\">Facilitating
+        company holiday, time off, and schedule variation calendars.</li>\n</ul>\n<p
+        class=\"h5\">\u00a0</p>\n<p class=\"h5\">We are looking for talented and diligent
+        candidates who excel in our skills tests, and will consider these candidates
+        even if past experience or educational background criteria aren''t met.</p>\n<p
+        class=\"h5\">\u00a0</p>\n<p>*California, New York, Washington, and Colorado:
+        starting base pay for this position ranges between $15 - $25 per hour.</p>\n<p>Compensation
+        may vary based on factors such as experience, qualifications, skills test
+        performance, geographic location, and seniority of the position offered. Outside
+        of California, New York, Washington, and Colorado compensation may fall outside
+        the above ranges.</p>\n<img src=\"https://remotive.com/job/track/1680495/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/1680495/logo"},
+        {"id": 2088708, "url": "https://remotive.com/remote-jobs/software-development/senior-staff-software-engineer-php-ts-rust-kotlin-m-w-d-2088708",
+        "title": "\ud83c\udde9\ud83c\uddea Senior/Staff Software Engineer PHP, TS,
+        Rust, Kotlin (m/w/d)", "company_name": "easybill GmbH", "company_logo": "https://remotive.com/job/2088708/logo",
+        "category": "Software Development", "tags": ["backend", "docker", "elasticsearch",
+        "frontend", "go", "java", "php", "react", "kotlin", "rust", "Typescript ",
+        "Redis", "MySQL", "Symfony", "debugging", "Micro services", "github"], "job_type":
+        "full_time", "publication_date": "2026-04-10T14:54:45", "candidate_required_location":
+        "Germany", "salary": "", "description": "<p><strong>\ud83c\udde9\ud83c\uddea
+        This job ad is written in German. \ud83c\udde9\ud83c\uddea</strong></p>\n<p><strong>easybill</strong>
+        ist eine cloudbasierte Rechnungssoftware, die sich durch einfache Anwendung,
+        umfassende Funktionalit\u00e4t und vielf\u00e4ltige Anbindungen \u00fcber
+        Schnittstellen schon seit mehr als 18 Jahren am Markt behauptet. Aktuell haben
+        wir mehr als 21.000 aktive Kunden und wachsen stetig weiter. Deshalb suchen
+        wir nach einer motivierten Verst\u00e4rkung f\u00fcr unser Team.</p>\n<p>Bei
+        easybill arbeiten wir Remote-First, dein Wohnort ist uns egal - wir suchen
+        die besten Kollegen*, nicht die sch\u00f6nste Stadt. Unsere festen Standorte
+        befinden sich in Hamburg und Willich. Bei regelm\u00e4\u00dfigen Team-Events
+        kommen wir trotzdem gerne zusammen, um uns auszutauschen und auch mal zu feiern.</p>\n<p>Das
+        ideale Profil: PHP-, TypeScript- und Rust-Expertise, Founding-Engineer-Vibes
+        und eine starke Pr\u00e4senz auf GitHub. Passt das Profil nicht vollst\u00e4ndig,
+        bist du aber ein au\u00dfergew\u00f6hnlich starker Engineer, bewirb dich trotzdem
+        und zeig uns, was du gebaut hast.</p>\n<div class=\"h2\">Aufgaben</div>\n<p>Wir
+        sind ein sehr motiviertes Team aus Softwareentwicklern. Als Teil des Teams
+        w\u00fcrdest du neue Features und/oder Skalierungsl\u00f6sungen entwickeln.
+        Ownership ist uns wichtig. Wir erwarten hohe Eigenverantwortung, die Motivation,
+        komplette Projekte umzusetzen, und den Willen, die E-Rechnungslandschaft mitzuformen.</p>\n<p>Die
+        Hauptanwendung ist in PHP / TypeScript geschrieben, wir entwickeln aber auch
+        in Kotlin und bevorzugt Rust. Wir nutzen intensiv MySQL (Percona XtraDB Cluster),
+        TiDB, Elasticsearch, Redis, MinIO, Docker und einiges mehr. Der Umgang mit
+        mehreren Programmiersprachen wird jedoch vorausgesetzt.</p>\n<ul style=\"\">\n<li
+        style=\"\">Eigenst\u00e4ndiges, motiviertes und selbstorganisiertes Arbeiten
+        \u2013 wir investieren gerne in unsere Kollegen, haben aber auch hohe Erwartungen.</li>\n<li
+        style=\"\">Backend-Entwicklung (PHP + Symfony)</li>\n<li style=\"\">Frontend-Entwicklung
+        (TypeScript + React + TanStack)</li>\n<li style=\"\">Entwicklung von Microservices
+        via Rust / Java</li>\n<li style=\"\">Migration von PHP-Code zu Rust.</li>\n<li
+        style=\"\">Migrationen von Daten, Refactoring</li>\n<li style=\"\">Fehleranalyse
+        und Debugging</li>\n<li style=\"\">Du musst verstanden haben, wie man KI als
+        Produktivit\u00e4tshebel verwendet. Wir erwarten intensiven Einsatz von Claude
+        Code.</li>\n<li style=\"\">ggf. Arbeiten an der Infrastruktur und lokalen
+        dockerisierten Entwicklungsumgebungen</li>\n</ul>\n<div class=\"h2\">Qualifikation</div>\n<p>Grunds\u00e4tzlich
+        musst du nicht alles k\u00f6nnen. Uns ist wichtig, dass du uns zeigen kannst,
+        dass du dich in deinem aktuellen Technologie-Stack richtig gut auskennst und
+        uns glaubhaft machen kannst, dass du bereit bist, unseren Stack z\u00fcgig
+        zu lernen.</p>\n<ul style=\"\">\n<li style=\"\">Tiefe Kenntnisse im Bereich
+        der Softwareentwicklung. Eingesetzt wird viel PHP und/oder je nach Schwerpunkt
+        TypeScript, zudem haben wir etwas Java sowie Rust im Stack. Bist du Experte
+        im Umgang mit Rust, Java, Go, Zig oder anderen Sprachen, lernen wir dich aber
+        auch gerne kennen.</li>\n<li style=\"\">Bonus: Erfahrung mit Rust, DSA, TS,
+        verteilten Systemen, datenlastigen Anwendungen</li>\n<li style=\"\">Bonus:
+        Open-Source-Contributions oder \u00f6ffentliche Experimente (GitHub)</li>\n<li
+        style=\"\">Sprache: Flie\u00dfend Deutsch und gute Englischkenntnisse</li>\n</ul>\n<div
+        class=\"h2\">Benefits</div>\n<ul style=\"\">\n<li style=\"\"><strong>Deutschlandweit</strong>
+        Remote-First Team \u2013 keine Bindung an einen Standort</li>\n<li style=\"\">Workation
+        auf Mallorca - Unsere Mitarbeiter* haben die M\u00f6glichkeit, die<br>angemietete
+        Villa auf Mallorca f\u00fcr eine inspirierende Kombination aus<br>Arbeit und
+        Erholung zu nutzen</li>\n<li style=\"\">Hoher Impact</li>\n<li style=\"\">Eine
+        inspirierende und flexible Arbeitsumgebung, die auf Vertrauen und Eigenverantwortung
+        basiert.</li>\n<li style=\"\">Wir sind ein offenes, motiviertes und nettes
+        Team mit flacher Hierarchie</li>\n<li style=\"\">Keine Sprints und k\u00fcnstlich
+        erzeugter Druck</li>\n<li style=\"\">Faire Verg\u00fctungspakete und Entwicklungsm\u00f6glichkeiten</li>\n<li
+        style=\"\">30 Tage Jahresurlaub und einen unbefristeten Arbeitsvertrag</li>\n<li
+        style=\"\">Arbeitszeiten sind flexibel und werden mit dem Team abgestimmt</li>\n<li
+        style=\"\">Freiwillige Mitarbeiter-Events</li>\n<li style=\"\">Aktuelle MacBook
+        Pros</li>\n<li style=\"\">Schulungen/Weiterbildungsm\u00f6glichkeiten im Wert
+        von bis zu 1.500 Euro pro Jahr</li>\n</ul>\n<p>Wir haben vielf\u00e4ltige
+        Herausforderungen und suchen einen motivierten Teamplayer! Wenn du dich hierin
+        wiedererkennst und eine neue Herausforderung suchst, freuen wir uns auf deine
+        Bewerbung.</p>\n<p>Wir freuen uns auf dich!</p>\n<img src=\"https://remotive.com/job/track/2088708/blank.gif?source=public_api\"
+        alt=\"\"/>"}, {"id": 1956455, "url": "https://remotive.com/remote-jobs/software-development/ios-developer-1956455",
+        "title": "iOS Developer", "company_name": "nooro", "company_logo": "https://remotive.com/job/1956455/logo",
+        "category": "Software Development", "tags": ["api", "backend", "git", "ios",
+        "security", "swift", "UI/UX", "Figma", "agile", "healthcare", "startup", "core
+        data", "github", "REST", "MVVM", "mobile development"], "job_type": "full_time",
+        "publication_date": "2026-04-09T21:15:48", "candidate_required_location":
+        "USA", "salary": "$60k-$130k (depending on experience)", "description": "<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\"><span style=\"box-sizing: inherit; margin:
+        var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        background: var(--artdeco-reset-base-background-transparent); outline: var(--artdeco-reset-base-outline-zero);\"><strong>WHO
+        ARE WE?</strong></span></p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">At nooro, we''re revolutionizing
+        pain management for seniors. Our platform is transforming how older adults
+        engage with pain management at home. We''re on a mission to make wellness
+        more accessible and effective through technology.</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">Check our website here: https://nooro-us.com/</p>\n<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">We''re a fast-moving startup
+        that works on quick iteration and bold decisions. Our team is lean, agile,
+        and empowered to make meaningful impacts daily. If you enjoy a dynamic environment
+        where ideas become a reality at lightning speed and you''re not afraid to
+        wear multiple hats, you''ll fit right in.</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\"><span style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        background: var(--artdeco-reset-base-background-transparent); outline: var(--artdeco-reset-base-outline-zero);\"><strong>WHAT
+        WILL YOU DO?</strong></span></p>\n<p style=\"box-sizing: inherit; margin:
+        var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">- Own and drive the development
+        of our iOS application</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Build elegant, performant features using
+        **Swift (We\u2019re 100% Swift!)** and **SwiftUI**</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">- Implement complex UI/UX designs
+        from **Figma** with pixel-perfect accuracy</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">- Ensure app performance, quality,
+        and responsiveness</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Collaborate with our backend team on API
+        integration</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Write clean, modular, and reusable code</p>\n<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Participate in code reviews and architectural
+        decisions</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Help shape our mobile development practices</p>\n<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\"><span style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        background: var(--artdeco-reset-base-background-transparent); outline: var(--artdeco-reset-base-outline-zero);\"><strong>HOW
+        TO APPLY? </strong></span></p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5;\"><span style=\"color: rgba(0, 0, 0, 0.9); font-weight:
+        var(--artdeco-reset-typography-font-weight-bold);\">If you believe we''re
+        the right fit, please fill in this form:\u00a0</span><a href=\"https://forms.gle/xeL6pPbdjMHo11A28\"
+        rel=\"nofollow\" target=\"_self\"><span style=\"color: #000000;\"><span style=\"letter-spacing:
+        0.75px;\"><strong>https://forms.gle/xeL6pPbdjMHo11A28</strong></span></span></a></p>\n<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\"><span style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        background: var(--artdeco-reset-base-background-transparent); outline: var(--artdeco-reset-base-outline-zero);\"><strong>WHAT
+        ARE THE REQUIREMENTS?</strong></span></p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">- 5+ years of professional
+        iOS development experience</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Strong expertise in Swift and SwiftUI</p>\n<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Deep understanding of iOS platform capabilities
+        and limitations</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Experience with iOS app architecture (MVVM
+        preferred)</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Experience with Core Data and local storage
+        solutions</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Proficiency in making RESTful API calls
+        and handling responses</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Experience with dependency injection on
+        iOS</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Strong version control skills with Git/GitHub</p>\n<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Experience with App Store deployment and
+        TestFlight</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Knowledge of iOS security best practices</p>\n<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\"><span style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        background: var(--artdeco-reset-base-background-transparent); outline: var(--artdeco-reset-base-outline-zero);\"><strong>APPLYING
+        PROCESS</strong></span></p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">STEP 1 | QUESTIONNAIRE: <span
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); background:
+        var(--artdeco-reset-base-background-transparent); outline: var(--artdeco-reset-base-outline-zero);\"><span
+        style=\"font-weight: var(--artdeco-reset-typography-font-weight-bold);\">If
+        you believe we''re the right fit, please fill in this form:\u00a0</span></span><a
+        href=\"https://forms.gle/xeL6pPbdjMHo11A28\" rel=\"nofollow\" style=\"color:
+        #394050; text-decoration: none; background-color: #ffffff;\" target=\"_self\"><span
+        style=\"color: #000000;\"><span style=\"letter-spacing: 0.75px;\"><span style=\"font-weight:
+        600;\">https://forms.gle/xeL6pPbdjMHo11A28</span></span></span></a></p>\n<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">STEP 2 | TEST: Once we review
+        your form submission, we will send you a test</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">STEP 3 | TECHNICAL INTERVIEW:
+        Once we review your test submission, you will have a call with our development
+        leader</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">STEP 4 | BEHAVIORAL INTERVIEW:
+        After the technical interview, you will have a call with our CEO to talk about
+        the way our company and team members operate in general</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\"><span style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        background: var(--artdeco-reset-base-background-transparent); outline: var(--artdeco-reset-base-outline-zero);\"><strong>WHAT
+        DO WE OFFER?</strong></span></p>\n<p style=\"box-sizing: inherit; margin:
+        var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">- 100% remote work environment</p>\n<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Competitive compensation</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">- Opportunity to make a meaningful
+        impact in healthcare technology</p>\n<p style=\"box-sizing: inherit; margin:
+        var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">- Collaborative, innovative
+        team culture</p>\n<img src=\"https://remotive.com/job/track/1956455/blank.gif?source=public_api\"
+        alt=\"\"/>"}, {"id": 2088707, "url": "https://remotive.com/remote-jobs/software-development/senior-frontend-developer-2088707",
+        "title": "Senior Frontend Developer", "company_name": "Sanctuary Computer",
+        "company_logo": "https://remotive.com/job/2088707/logo", "category": "Software
+        Development", "tags": ["api", "backend", "CSS", "ecommerce", "frontend", "fullstack",
+        "graphql", "postgresql", "redux", "security", "seo", "shopify", "open source",
+        "paas", "product management", "documentation", "mentoring", "Typescript ",
+        "Redis", "web applications", "cypress", "data visualization", "firebase",
+        "IoT", "engineering management", "runtime", "responsive", "prismic", "testing",
+        "next.js", "CMS", "jest", "REST", "web sockets", "performance optimization"],
+        "job_type": "contract", "publication_date": "2026-04-08T16:15:21", "candidate_required_location":
+        "LATAM, Asia", "salary": "$80k - $120k", "description": "<p><span style=\"color:
+        #050c26;\">We are hiring a contract-based\u00a0</span><span style=\"box-sizing:
+        inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; font-weight: 600; color: #050c26;\">Senior Frontend Developer</span><span
+        style=\"color: #050c26;\">\u00a0for the garden3d creative collective with
+        a focus on LATAM &amp; Asia candidates.</span></p>\n<p><span style=\"color:
+        #050c26;\">\u00a0</span></p>\n<p style=\"box-sizing: inherit; margin-bottom:
+        16px; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; padding: 0px; color: #050c26;\"><span style=\"box-sizing: inherit;
+        --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y:
+        0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y:
+        1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000;
+        --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; font-weight: 600;\">This job posting here in Remotive is for sharing
+        purposes only</span>\u00a0and does not serve as the direct application for
+        the role. To be considered, please complete our application form\u00a0<a href=\"https://garden3d.notion.site/1f1131fea2c78095922ec7e09bd96101?pvs=105\"
+        rel=\"nofollow\" target=\"_self\"><strong>here</strong></a>\u00a0to apply</p>\n<p
+        style=\"box-sizing: inherit; margin-bottom: 16px; --tw-border-spacing-x: 0;
+        --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px; color: #050c26;\"><span style=\"box-sizing: inherit; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\"><span
+        style=\"color: #143fcd;\"><span style=\"box-sizing: inherit; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\"><a href=\"https://garden3d.notion.site/Senior-Frontend-Developer-2c6131fea2c780dea224d76e942c6311?source=copy_link\"
+        rel=\"nofollow\" target=\"_self\">Original job posting link</a></span></span></span></p>\n<p
+        class=\"h2\" style=\"box-sizing: inherit; margin-top: 32px; margin-bottom:
+        16px; font-weight: bold; color: #050c26; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px;\">\ud83c\udf0e<span style=\"box-sizing: inherit; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">About\u00a0<a
+        href=\"https://garden3d.net/\" rel=\"nofollow\" style=\"box-sizing: inherit;
+        color: #143fcd; text-decoration: none; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\" target=\"_blank\">garden3d</a></span></p>\n<p
+        style=\"box-sizing: inherit; margin-bottom: 16px; --tw-border-spacing-x: 0;
+        --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px; color: #050c26;\">We are worker owned creative collective, innovating
+        on everything from brands and IRL communities to IoT devices and cross platform
+        apps. We share profit, open source everything, spin out new businesses, and
+        invest in exciting ideas through financial and/or in-kind contributions.</p>\n<p
+        style=\"box-sizing: inherit; margin-bottom: 16px; --tw-border-spacing-x: 0;
+        --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px; color: #050c26;\">Our client roster includes\u00a0<a href=\"https://www.google.com/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Google</a>,\u00a0<a href=\"https://stripe.com/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Stripe</a>,\u00a0<a href=\"https://www.figma.com/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Figma</a>,\u00a0<a href=\"https://hinge.co/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Hinge</a>,\u00a0<a href=\"https://blacksocialists.us/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Black Socialists in America</a>,\u00a0<a href=\"https://www.aclu.org/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">ACLU</a>,\u00a0<a href=\"https://www.pratt.edu/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Pratt</a>,\u00a0<a href=\"https://www.newschool.edu/parsons/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Parsons</a>,\u00a0<a href=\"https://www.mozilla.org/en-US/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Mozilla</a>,\u00a0<a href=\"https://www.nobelprize.org/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">The Nobel Prize</a>,\u00a0<a href=\"https://www.mit.edu/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">MIT</a>,\u00a0<a href=\"https://www.gnosis.io/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Gnosis</a>,\u00a0<a href=\"https://www.etsy.com/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Etsy</a>\u00a0&amp;\u00a0<a href=\"https://gagosian.com/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Gagosian</a>.</p>\n<p style=\"box-sizing: inherit;
+        margin-bottom: 16px; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; padding: 0px; color: #050c26;\">We\u2019re the software team behind
+        innovative products like\u00a0<a href=\"https://www.thelightphone.com/\" rel=\"nofollow\"
+        style=\"box-sizing: inherit; color: #143fcd; text-decoration: none; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\" target=\"_blank\">The
+        Light Phone</a>\u00a0&amp;\u00a0<a href=\"https://www.mill.com/\" rel=\"nofollow\"
+        style=\"box-sizing: inherit; color: #143fcd; text-decoration: none; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\" target=\"_blank\">Mill</a>,
+        and we operate a global, decentralized community space collective called\u00a0<a
+        href=\"https://www.index-space.org/\" rel=\"nofollow\" style=\"box-sizing:
+        inherit; color: #143fcd; text-decoration: none; --tw-border-spacing-x: 0;
+        --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\" target=\"_blank\">Index
+        Space</a>.</p>\n<p style=\"box-sizing: inherit; margin-bottom: 16px; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px; color: #050c26;\">We think of our garden3d as collective for creative
+        people, prioritizing a happy, talented, and diverse studio culture. We work
+        on projects that bring value to our world, and we balance deep care for the
+        work we do with a genuine curiosity about life outside of our jobs.</p>\n<p
+        class=\"h2\" style=\"box-sizing: inherit; margin-top: 32px; margin-bottom:
+        16px; font-weight: bold; color: #050c26; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px;\">\ud83d\udd2e\u00a0<span style=\"box-sizing: inherit; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Who we\u2019re
+        looking for:</span></p>\n<p style=\"box-sizing: inherit; margin-bottom: 16px;
+        --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y:
+        0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y:
+        1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000;
+        --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; padding: 0px; color: #050c26;\">We''re looking for a\u00a0<span
+        style=\"box-sizing: inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">Senior Frontend Developer</span>\u00a0who excels at building pixel-perfect
+        websites using modern frontend frameworks. You''ll collaborate with our team
+        to build elegant, performant, and visually stunning web experiences. Your
+        work will span a diverse range of client projects, from immersive brand websites
+        to complex web applications, all requiring a keen eye for detail and technical
+        excellence.</p>\n<p style=\"box-sizing: inherit; margin-bottom: 16px; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px; color: #050c26;\"><span style=\"box-sizing: inherit; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">This hiring effort will focus on Front-End Developers based in the
+        LATAM or ASIA.</span></p>\n<p style=\"box-sizing: inherit; margin-bottom:
+        16px; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; padding: 0px; color: #050c26;\">In this role, you\u2019ll work
+        on a variety of client projects to find cost-effective, high-quality, pragmatic
+        solutions to complex problems. Responsibilities will include:</p>\n<ul style=\"\">\n<li
+        style=\"\">Collaborating with Technical Lead to meet clients'' development
+        needs</li>\n<li style=\"\">Building and maintaining high-performance web applications
+        with modern frontend frameworks and tools</li>\n<li style=\"\">Implementing
+        responsive, accessible, and pixel-perfect user interfaces based on design
+        specifications</li>\n<li style=\"\">Integrating frontend applications with
+        headless CMS platforms, APIs, and third-party services</li>\n<li style=\"\">Optimizing
+        application performance, including bundle size, load times, and runtime efficiency</li>\n<li
+        style=\"\">Architecting scalable component libraries and design systems for
+        consistency across projects</li>\n<li style=\"\">Writing clear documentation
+        for code maintenance and usage</li>\n<li style=\"\">Participating in project
+        team meetings, including Sprint Planning, daily standups, and retrospectives</li>\n<li
+        style=\"\">Participating in code reviews, providing constructive feedback
+        to teammates and ensuring adherence to best practices</li>\n</ul>\n<p style=\"box-sizing:
+        inherit; margin-bottom: 16px; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px; color: #050c26;\">\u00a0</p>\n<p style=\"box-sizing: inherit; margin-bottom:
+        16px; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; padding: 0px; color: #050c26;\">The person we\u2019re looking for
+        is happy, relaxed and easy to get along with. They\u2019re flexible on anything
+        except conceits that will lower their usually outstanding work quality. They
+        work \u201csmart\u201d, by carefully managing their workflow and staggering
+        features that have dependencies intelligently \u2014 they prefer deep work
+        but are OK coming up to the surface now and then for top level / strategic
+        conversations.</p>\n<p style=\"box-sizing: inherit; margin-bottom: 16px; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px; color: #050c26;\">\u00a0</p>\n<p style=\"box-sizing: inherit; margin-bottom:
+        16px; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; padding: 0px; color: #050c26;\">We believe people with backgrounds
+        or interests in design, art, music, food or fashion tend to have a well rounded
+        sense of design &amp; quality \u2014 so a variety of hobbies or side projects
+        is a big nice to have!</p>\n<p style=\"box-sizing: inherit; margin-bottom:
+        16px; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; padding: 0px; color: #050c26;\"><span style=\"box-sizing: inherit;
+        --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y:
+        0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y:
+        1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000;
+        --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; font-weight: 600;\">Must Have Competencies:</span></p>\n<p style=\"box-sizing:
+        inherit; margin-bottom: 16px; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px; color: #050c26;\">We\u2019re always pitching for new and exciting technology
+        niches. Some of the areas below are relevant to us!</p>\n<ul style=\"\">\n<li
+        style=\"\">8+ years writing highly performant frontend code, an obsession
+        for 95+ Lighthouse scores</li>\n<li style=\"\">Expert level experience with
+        Typescript, and one of Next.js, Nuxt, Svelte, Vue</li>\n<li style=\"\">Extensive
+        experience with headless CMS like Sanity, Contentful, Prismic or more</li>\n<li
+        style=\"\">Fluency in industry standard PaaS like Vercel, Netlify, Firebase,
+        etc</li>\n<li style=\"\">Fluency in eCommerce technologies like Shopify (headless
+        &amp; liquid), Stripe, Swell and others</li>\n<li style=\"\">Experience building
+        accessible, responsive interfaces with attention to performance optimization
+        and SEO best practices</li>\n<li style=\"\">Strong understanding of modern
+        CSS methodologies (Tailwind, CSS Modules, etc) and animation libraries</li>\n<li
+        style=\"\">Experience with state management solutions (Redux, Zustand, Pinia)
+        and API integration patterns</li>\n<li style=\"\">Proficiency with testing
+        frameworks (Jest, Playwright, Cypress) and commitment to writing maintainable,
+        well-documented code</li>\n<li style=\"\">Experience with design systems and
+        component libraries, working closely with designers to ensure pixel-perfect
+        implementations</li>\n<li style=\"\"><span style=\"box-sizing: inherit; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Real-time
+        &amp; performance optimization</span>: experience with WebSockets for live
+        data updates, caching strategies (Redis, CDN-level caching), CDN configuration
+        and optimization (Cloudflare, Fastly), and image optimization techniques including
+        proxies and delivery networks</li>\n</ul>\n<p style=\"box-sizing: inherit;
+        margin-bottom: 16px; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; padding: 0px; color: #050c26;\"><span style=\"box-sizing: inherit;
+        --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y:
+        0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y:
+        1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000;
+        --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; font-weight: 600;\">\u00a0</span></p>\n<p style=\"box-sizing: inherit;
+        margin-bottom: 16px; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; padding: 0px; color: #050c26;\"><span style=\"box-sizing: inherit;
+        --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y:
+        0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y:
+        1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000;
+        --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; font-weight: 600;\">Nice to Have Competencies:</span></p>\n<p style=\"box-sizing:
+        inherit; margin-bottom: 16px; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px; color: #050c26;\">We\u2019re always pitching for new and exciting technology
+        niches. Some of the areas below are relevant to us!</p>\n<ul style=\"\">\n<li
+        style=\"\"><span style=\"box-sizing: inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">WebGL &amp; Canvas expertise</span>: experience building interactive
+        graphics, animations, and visualizations using WebGL, Three.js, or native
+        Canvas API</li>\n<li style=\"\"><span style=\"box-sizing: inherit; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">Data visualization</span>: creating compelling, interactive data visualizations
+        with libraries like Mapbox, D3.js, Chart.js, or similar tools</li>\n<li style=\"\"><span
+        style=\"box-sizing: inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">Full-stack development experience</span>: comfortable working across
+        the entire stack, from frontend to backend and database layers</li>\n<li style=\"\"><span
+        style=\"box-sizing: inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">PostgreSQL expertise</span>: strong experience with database design,
+        query optimization, and managing complex relational data structures</li>\n<li
+        style=\"\"><span style=\"box-sizing: inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">GraphQL &amp; API design</span>: building and maintaining GraphQL or
+        REST APIs with a focus on performance and developer experience</li>\n<li style=\"\"><span
+        style=\"box-sizing: inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">Real-time technologies</span>: experience with WebSockets, Server-Sent
+        Events, or similar technologies for building live, interactive features</li>\n<li
+        style=\"\"><span style=\"box-sizing: inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">Authentication &amp; security</span>: implementing secure authentication
+        flows (OAuth, JWT) and following security best practices</li>\n<li style=\"\"><span
+        style=\"box-sizing: inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">Client-facing experience</span>: working directly with customers to
+        gather requirements and provide technical solutions</li>\n<li style=\"\"><span
+        style=\"box-sizing: inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">Product management experience</span>: defining product roadmaps and
+        collaborating closely with stakeholders</li>\n<li style=\"\"><span style=\"box-sizing:
+        inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; font-weight: 600;\">Engineering management experience</span>: leading
+        teams, setting technical direction, and mentoring developers</li>\n</ul>\n<p
+        class=\"h2\" style=\"color: #532a21;\">\u00a0</p>\n<p class=\"h2\" style=\"color:
+        #532a21;\">\ud83d\udcb8\u00a0<span style=\"font-weight: 600; color: #000000;
+        letter-spacing: 0.75px;\">Compensation</span></p>\n<p>Our pay scale ranges
+        from\u00a0<code>$35p/hr</code>\u00a0to\u00a0<code>$95p/hr\u00a0</code>pending
+        seniority (&amp; team leadership experience), and our projects are rarely
+        less than 8 full time weeks at 40 hours per week.</p>\n<p>We prefer long standing
+        relationships with highly accountable and communicative team members, so we
+        encourage candidates to expect longer term engagements.</p>\n<p>\u00a0</p>\n<p
+        class=\"h2\" style=\"color: #532a21;\">\ud83c\udfa4\u00a0<span style=\"font-weight:
+        600; color: #000000; letter-spacing: 0.75px;\">How we interview:</span></p>\n<p>Our
+        interview process starts with a call where you get to meet a few members of
+        our team. From there we\u2019ll ask appropriate candidates to take part in
+        a technical exercise which helps illustrate skill level and comfort.</p>\n<p>\u00a0</p>\n<p
+        class=\"h2\" style=\"color: #532a21;\">\ud83d\udc69\u200d\ud83c\udfed\u00a0<span
+        style=\"font-weight: 600; color: #000000; letter-spacing: 0.75px;\">How we
+        work:</span></p>\n<p>We believe that there\u2019s a better balance between
+        the poles of freelancing &amp; full time, and for that reason Sanctuary works
+        differently to most shops:</p>\n<ul style=\"\">\n<li style=\"\"><a href=\"https://sanctucompu.substack.com/p/our-open-source-2020-profit-and-loss\"
+        rel=\"nofollow\"><span style=\"font-weight: 600; color: #000000; letter-spacing:
+        0.75px;\">Transparency &amp; Ownership:</span></a>\u00a0We release out Profit
+        &amp; Loss statements to the community each year, open source our best ideas,
+        and talk business &amp; money with everyone in the company. We\u2019re proud
+        to run our business with integrity, and for that reason we share everything
+        with our team &amp; community.</li>\n<li style=\"\"><a href=\"https://negative.sanctuary.computer/\"
+        rel=\"nofollow\"><strong>150% Carbon Negative:</strong></a>\u00a0Our studio
+        offsets 150% of the carbon we use to do business each year, dated back to
+        our founding in 2015. We turn down work that is not in-line with our morals,
+        and we encourage our peers to do the same.\u00a0<a href=\"https://twitter.com/sanctucompu/status/1385282161197060100\"
+        rel=\"nofollow\">We have been certified climate neutral since 2021</a>.</li>\n<li
+        style=\"\"><a href=\"https://sanctucompu.substack.com/p/our-moral-compass\"
+        rel=\"nofollow\"><strong>Strong Morals:</strong></a>\u00a0Since our founding,
+        we''ve turned down somewhere between $1mm - $2mm of work that didn''t meet
+        our moral standards. (Most of that was DTC brands that can''t show a valid
+        sustainability initiative).</li>\n<li style=\"\"><span style=\"font-weight:
+        600; color: #000000; letter-spacing: 0.75px;\">Async &amp; Decentralized:</span>\u00a0We
+        use tools optimized for calm, thoughtful communication, and opt for async
+        whenever possible. We fight hard to maintain our focus time.</li>\n<li style=\"\"><span
+        style=\"font-weight: 600; color: #000000; letter-spacing: 0.75px;\">Remote
+        Friendly:</span>\u00a0Our company is fluent in remote work, making our workplace
+        more decentralized, and democratized in the process.</li>\n<li style=\"\"><span
+        style=\"font-weight: 600; color: #000000; letter-spacing: 0.75px;\">Ideas
+        &amp; Products:</span>\u00a0In our spare studio time, we work to build our
+        own open source or internal products to diversify &amp; bolster our income.
+        We create amazing technology products for our clients, so why not for the
+        studio?</li>\n</ul>\n<p><span style=\"font-weight: 600; color: #000000; letter-spacing:
+        0.75px;\">\u2192 Read more on our\u00a0<a href=\"https://sanctucompu.substack.com/\"
+        rel=\"nofollow\">Substack, over here</a>, or our\u00a0<a href=\"https://medium.com/sanctuary-computer-inc\"
+        rel=\"nofollow\">Medium, over there</a>.</span></p>\n<img src=\"https://remotive.com/job/track/2088707/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/2088707/logo"},
+        {"id": 2088706, "url": "https://remotive.com/remote-jobs/software-development/fullstack-developer-us-et-2088706",
+        "title": "Fullstack Developer (US - ET)", "company_name": "Chooose", "company_logo":
+        "https://remotive.com/job/2088706/logo", "category": "Software Development",
+        "tags": ["api", "azure", "fullstack", "python", "react", "saas", "AI/ML",
+        "project management", "documentation", "Typescript ", "computer science",
+        "diversity", "insurance"], "job_type": "full_time", "publication_date": "2026-04-08T12:36:43",
+        "candidate_required_location": "USA", "salary": "", "description": "<p>\u00a0</p>\n<p>Chooose
+        builds software to enable the lower carbon fuel value chain.</p>\n<p>Companies
+        like Delta Air Lines, Cathay Pacific, British Airways, and Microsoft use the
+        Chooose platform to build, operate, and scale their lower carbon fuel programs
+        (typically referred to as Sustainable Aviation Fuel, or SAF), and to advance
+        voluntary and compliance carbon management initiatives.</p>\n<p>With offices
+        in Miami and Oslo, and remote employees across the US and Europe, Chooose
+        is relentlessly focused on delivering enterprise software products to enable
+        our customers to drive lower carbon fuel adoption. The company has raised
+        $50M from leading venture capital and strategic investors.</p>\n<p><strong>The
+        role</strong></p>\n<p>We are looking for a person who is open to new technologies,
+        is not afraid to experiment, and is eager to learn. The ideal candidate will
+        be self-driven and able to take charge and make decisions. You will develop
+        internal applications to drive efficiency within the Chooose organization
+        leveraging your development skills and modern AI technologies, build-out back-end
+        services for our customers, and support our Commercial team through technical
+        implementation with customer facing opportunities.\u00a0</p>\n<p>\u00a0</p>\n<p><strong>This
+        is a remote role that must be based in Massachusetts, New York, Pennsylvania,
+        Maryland, or Florida</strong></p>\n<p>\u00a0</p>\n<p><strong>What you''ll
+        do</strong></p>\n<ul style=\"\">\n<li style=\"\">Maintain and scale complex
+        front-end (React, Typescript) and back-end architecture (C#/.net)</li>\n<li
+        style=\"\">Work directly with external clients</li>\n<li style=\"\">Develop
+        and maintain Python-based data processing pipelines and command-line interface
+        (CLI) tools.</li>\n<li style=\"\">Develop and integrate AI/ML solutions into
+        company processes and external facing products</li>\n<li style=\"\">Have a
+        hand in the technical implementation of our Platform and Solutions and support
+        our Commercial team</li>\n<li style=\"\">Creation of unit tests or integration
+        tests (Vitest)</li>\n<li style=\"\">Maintain and scale complex services</li>\n<li
+        style=\"\">Drive efficiency internally through scalable processes and applications</li>\n</ul>\n<p><strong>What
+        you''ll bring to the table</strong></p>\n<ul style=\"\">\n<li style=\"\">5+
+        years of hands-on experience</li>\n<li style=\"\">Strong organizational and
+        project management skills.</li>\n<li style=\"\">Excellent verbal communication
+        skills. A bonus if you have managed external facing clients previously.\u00a0</li>\n<li
+        style=\"\">Critical problem-solving skills.</li>\n<li style=\"\">Meticulous
+        attention to detail.</li>\n<li style=\"\">Degree in computer science, engineering
+        or equivalent.</li>\n<li style=\"\">Must be based in Massachusetts, New York,
+        Pennsylvania, Maryland, or Florida</li>\n</ul>\n<p><strong>You''ll stand out
+        if you have knowledge of</strong></p>\n<ul style=\"\">\n<li style=\"\">Azure
+        (Azure functions)</li>\n<li style=\"\">Integrations</li>\n<li style=\"\">Python
+        (Fast API)</li>\n<li style=\"\">You have some experience incorporating AI
+        features into SaaS products.</li>\n</ul>\n<p><strong>The interview process</strong></p>\n<p>\u00a0</p>\n<p>At
+        Chooose, we prioritize transparency throughout our interview process. If your
+        qualifications look like a fit, we\u2019ll begin with a 2-3 introductory conversations
+        where you''ll have the chance to discuss your experience and learn more about
+        our company. The second phase varies depending on the role and will most likely
+        involve a practical exercise or live session so you can show your work. The
+        third and final phase consists of a one-on-one in-person conversation with
+        a member of our executive team. The process should take approx. 4 weeks. While
+        we strive to keep to this timeline, the occasional adjustment may occur; we\u2019re
+        focused on ensuring for enough time to get to know one another.</p>\n<p>\u00a0</p>\n<p><strong>Pay,
+        perks, &amp; more</strong></p>\n<p>\u00a0</p>\n<p>We offer a competitive salary,
+        a comprehensive benefits package including medical, dental, and vision insurance,
+        voluntary 401k contributions, paid parental leave, a robust PTO package, the
+        option to participate in our employee equity program, flexible work hours,
+        and access to ''Spaces'' coworking space.</p>\n<p>\u00a0</p>\n<p>We value
+        diversity and believe forming teams in which everyone can be their authentic
+        self is key to our success. We encourage people from underrepresented backgrounds
+        and different industries to apply.</p>\n<p>\u00a0</p>\n<p><strong>Compensation
+        will be based on experience and skill, commensurate with market rates, and
+        will include both salary and equity in Chooose.</strong></p>\n<p>\u00a0</p>\n<p><strong>Chooose
+        is an equal opportunity employer and does not discriminate based on race,
+        color, religion (creed), gender, gender expression, age, national origin (ancestry),
+        disability, marital status, sexual orientation, or military status. We are
+        committed to providing an inclusive and welcoming environment to our employees
+        and welcome input from candidates and employees on how we can enhance our
+        inclusiveness.</strong></p>\n<p>\u00a0</p>\n<p><em>Prerequisite for Employment:
+        Chooose may request to conduct background checks on prospective applicants
+        to verify the information provided in the CV, transcripts, and other documentation.
+        This background check may be carried out by our partner and will not be conducted
+        without the applicant''s prior consent. Prospective applicants will receive
+        more information about this.</em></p>\n<img src=\"https://remotive.com/job/track/2088706/blank.gif?source=public_api\"
+        alt=\"\"/>"}, {"id": 2088704, "url": "https://remotive.com/remote-jobs/all-others/online-data-analyst-united-states-spanish-speakers-2088704",
+        "title": "Online Data Analyst (United States/Spanish speakers)", "company_name":
+        "TELUS Digital", "company_logo": "https://remotive.com/job/2088704/logo",
+        "category": "All others", "tags": ["go", "social media", "AI/ML", "research",
+        "diversity"], "job_type": "part_time", "publication_date": "2026-04-07T14:40:01",
+        "candidate_required_location": "USA", "salary": "", "description": "<p style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">Are you a detail-oriented individual with a passion for research and
+        a good understanding of national and local geography? This freelance opportunity
+        allows you to work at your own pace and from the comfort of your own home.</p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><strong>A Day in
+        the Life of an Online Data Analyst:</strong></p>\n<ul style=\"\">\n<li style=\"\">In
+        this role, you will be working on a project aimed at enhancing the content
+        and quality of digital maps that are used by millions of people worldwide</li>\n<li
+        style=\"\">Completing research and evaluation tasks in a web-based environment
+        such as verifying and comparing data, and determining the relevance and accuracy
+        of information.</li>\n</ul>\n<p style=\"border-color: #e5e7eb; --tw-shadow:
+        0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\">\u00a0</p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">Join us today and be part of a dynamic and innovative team that is making
+        a difference in the world!</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow:
+        0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\">\u00a0</p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\"><strong>TELUS Digital AI Community</strong></p>\n<p style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">Our global AI Community is a vibrant network of 1 million+ contributors
+        from diverse backgrounds who help our customers collect, enhance, train, translate,
+        and localize content to build better AI models. Become part of our growing
+        community and make an impact supporting the machine learning models of some
+        of the world\u2019s largest brands.</p>\n<p class=\"h4\" style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; line-height: 1.75rem; color: #414547;
+        letter-spacing: 0px; --tw-text-opacity: 1;\">Qualification path</p>\n<p style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">No previous professional experience is required to apply to this role,
+        however, working on this project will require you to pass the basic requirements
+        and go through a standard assessment process. This is a part-time long-term
+        project and your work will be subject to our standard quality assurance checks
+        during the term of this agreement.\u00a0</p>\n<p style=\"border-color: #e5e7eb;
+        --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><strong>Basic Requirements</strong></p>\n<ul
+        style=\"\">\n<li style=\"\">Full Professional Proficiency in Spanish language</li>\n<li
+        style=\"\">Being a resident in United States for the last 2 consecutive years
+        and having familiarity with current and historical business, media, sport,
+        news, social media, and cultural affairs in United States</li>\n<li style=\"\">Ability
+        to follow guidelines and conduct online research using search engines, online
+        maps, and website information</li>\n<li style=\"\">Flexibility to work across
+        a diverse set of task types, including maps, news, audio tasks, and relevance</li>\n<li
+        style=\"\">Daily access to a broadband internet connection, computer, and
+        relevant software</li>\n</ul>\n<p style=\"border-color: #e5e7eb; --tw-shadow:
+        0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\">\u00a0</p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\"><strong>Assessment</strong></p>\n<p style=\"border-color: #e5e7eb; --tw-shadow:
+        0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\">In order to be
+        hired into the program, you\u2019ll take an open book qualification exam that
+        will determine your suitability for the position and complete ID verification.
+        Our team will provide you with guidelines and learning materials before your
+        qualification exam. You will be required to complete the exam in a specific
+        timeframe but at your convenience.</p>\n<p style=\"border-color: #e5e7eb;
+        --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\">Equal Opportunity</p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">All qualified applicants will receive consideration for a contractual
+        relationship without regard to race, color, religion, sex, sexual orientation,
+        gender identity, national origin, disability, or protected veteran status.
+        At TELUS Digital AI, we are proud to offer equal opportunities and are committed
+        to creating a diverse and inclusive community. All aspects of selection are
+        based on applicants\u2019 qualifications, merits, competence, and performance
+        without regard to any characteristic related to diversity.</p>\n<img src=\"https://remotive.com/job/track/2088704/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/2088704/logo"},
+        {"id": 1185979, "url": "https://remotive.com/remote-jobs/writing/freelance-writer-1185979",
+        "title": "Freelance Writer", "company_name": "IAPWE", "company_logo": "https://remotive.com/job/1185979/logo",
+        "category": "Writing", "tags": ["REST"], "job_type": "freelance", "publication_date":
+        "2026-04-04T17:01:43", "candidate_required_location": "Worldwide", "salary":
+        "$50-$75 /hour", "description": "<p class=\"p1\" style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-stretch: normal; line-height:
+        normal; color: #000000;\">Our organization is seeking content writers to create
+        articles and blog posts on a variety of topics.</p>\n<p class=\"p1\" style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-stretch: normal; line-height:
+        normal; color: #000000;\">\u00a0</p>\n<p class=\"p1\" style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-stretch: normal; line-height:
+        normal; color: #000000;\">The rate of pay is $20 per 100 words (this comes
+        out to approximately $100 per article or $50 per hour).</p>\n<p>\u00a0</p>\n<p
+        class=\"p1\" style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; font-stretch: normal; line-height: normal; color: #000000;\">Some
+        topics you may be asked to write about include the following (you can always
+        turn down a topic if you do not feel comfortable writing about it, however
+        if you have experience or expertise in a specific area, please let us know):</p>\n<p>\u00a0</p>\n<ul
+        class=\"ul1\" style=\"\">\n<li class=\"li1\" style=\"\">Health &amp; beauty</li>\n<li
+        class=\"li1\" style=\"\">Fitness</li>\n<li class=\"li1\" style=\"\">Home Decor</li>\n<li
+        class=\"li1\" style=\"\">Fashion</li>\n<li class=\"li1\" style=\"\">Sports</li>\n<li
+        class=\"li1\" style=\"\">Do it yourself</li>\n<li class=\"li1\" style=\"\">Finance</li>\n<li
+        class=\"li1\" style=\"\">Legal</li>\n<li class=\"li1\" style=\"\">Medical</li>\n<li
+        class=\"li1\" style=\"\">Family/Parenting</li>\n<li class=\"li1\" style=\"\">Relationships</li>\n<li
+        class=\"li1\" style=\"\">Real Estate</li>\n<li class=\"li1\" style=\"\">Restaurants</li>\n<li
+        class=\"li1\" style=\"\">Contracting (plumbing, pool building, remodeling,
+        etc.)</li>\n</ul>\n<p>\u00a0</p>\n<p><span style=\"color: #000000;\">These
+        are just some of the more general industries and topics that we cover.</span></p>\n<p>\u00a0</p>\n<p><span
+        style=\"font-weight: 600; color: #000000; letter-spacing: 0.75px;\">Requirements</span><span
+        style=\"color: #000000;\">:</span></p>\n<ul style=\"\">\n<li style=\"\">We
+        ask that all work be completed using a word processor such as Microsoft Word
+        or Open Office</li>\n<li style=\"\">A reliable internet connection and the
+        ability to meet deadlines</li>\n<li style=\"\">Good communication skills and
+        respond in a timely manner to editorial staff when they ask for updates on
+        tasks, etc</li>\n<li style=\"\">Work well as a team member with the rest of
+        our content management and editorial staff</li>\n</ul>\n<p><br><br><em><strong>Note</strong>:
+        Applicants to this job signaled that accessing some writing tasks may require
+        payment.</em></p>\n<img src=\"https://remotive.com/job/track/1185979/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/1185979/logo"},
+        {"id": 1749306, "url": "https://remotive.com/remote-jobs/writing/copywriter-1749306",
+        "title": "Copywriter", "company_name": "Coalition Technologies ", "company_logo":
+        "https://remotive.com/job/1749306/logo", "category": "Writing", "tags": ["accounting",
+        "excel", "research", "data analysis", "bookkeeping", "google sheets", "quickbooks",
+        "data entry", "insurance", "G Suite"], "job_type": "freelance", "publication_date":
+        "2026-04-02T20:01:09", "candidate_required_location": "Worldwide", "salary":
+        "$20k -$35k", "description": "<p class=\"h3\">\u00a0</p>\n<div class=\"h3\">WHO
+        WE''RE LOOKING FOR</div>\n<div class=\"h3\">The ideal copywriter has excellent
+        English writing skills and is excited to write high-quality, SEO-driven content
+        that aligns with detailed, client-specific guidelines. Projects most commonly
+        include writing web pages for eCommerce and lead generation business sites
+        such as category pages, product descriptions, and blog posts. Our clientele
+        is constantly evolving. We produce content for these and many other industry
+        verticals:</div>\n<div class=\"h3\">\u00a0</div>\n<div class=\"h3\">Fashion
+        (both mass-market and luxury)</div>\n<div class=\"h3\">Skincare &amp; Beauty</div>\n<div
+        class=\"h3\">Tech &amp; Software**</div>\n<div class=\"h3\">Finance &amp;
+        Investing**</div>\n<div class=\"h3\">Law (family law, product liability, divorce,
+        etc.)**</div>\n<div class=\"h3\">Education</div>\n<div class=\"h3\">Home Improvement</div>\n<div
+        class=\"h3\">Automobiles &amp; Motorcycles (OEM and aftermarket accessories)</div>\n<div
+        class=\"h3\">Health and Wellness**</div>\n<div class=\"h3\">Medical / Clinical**</div>\n<div
+        class=\"h3\">Digital Marketing</div>\n<div class=\"h3\">SEO / PR / Advertising
+        / Marketing**</div>\n<div class=\"h3\">**Writers with a background in these
+        highly specialized fields are strongly encouraged to apply.</div>\n<div class=\"h3\">The
+        ideal candidate for this position is a multifaceted technical and creative
+        writer with at least two to four years of professional, non-academic experience.
+        Candidates should understand how to write content that effortlessly blends
+        SEO best practices and brand priorities for finished work that\u2019s engaging,
+        creative, and ROI-driven. Candidates should also be willing and able to complete
+        careful research in order to gain a strong understanding of various industries.
+        Candidates should be prepared to provide portfolios featuring published work.
+        Once an offer has been extended, writers will be asked to take a brief training
+        course.</div>\n<div class=\"h3\">\u00a0</div>\n<div class=\"h3\">Compensation</div>\n<div
+        class=\"h3\">Writers are paid on a per-word basis. The rate is assessed according
+        to our KPI rubric (key performance indicators) with an automatic raise after
+        400 and 800 pages have gone live on our client''s websites.</div>\n<div class=\"h3\">Initial
+        compensation is up to $0.06 per word with $0.034 per word being the most typical
+        compensation level. This is $30 or $17 per page of 500 words.</div>\n<div
+        class=\"h3\">After 400 pages live, the top marginal rate increases to $0.064
+        per word with the most typical rate of $0.038 per word, or $32 and $19 per
+        page. After 800 pages live, the top marginal rate increases to $0.07 per word
+        with $0.044 per word being the most typical, or $35 and $22 per page.</div>\n<img
+        src=\"https://remotive.com/job/track/1749306/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/1749306/logo"},
+        {"id": 2088697, "url": "https://remotive.com/remote-jobs/customer-service/customer-success-team-lead-german-speaking-2088697",
+        "title": "Customer Success Team Lead (German Speaking)", "company_name": "Filestage",
+        "company_logo": "https://remotive.com/job/2088697/logo", "category": "Customer
+        Service", "tags": ["react", "hardware", "account management", "onboarding",
+        "startup", "risk management", "team lead", "travel", "REST"], "job_type":
+        "full_time", "publication_date": "2026-03-31T10:37:01", "candidate_required_location":
+        "Europe, EMEA", "salary": "", "description": "<div class=\"h1\"><strong><span
+        style=\"color: #00c261;\">About Filestage</span></strong></div>\n<p><span
+        style=\"color: #434343;\">Filestage frees people from chaotic approval processes,
+        making work more joyful and productive. From large enterprises to independent
+        agencies, our review and approval platform helps teams share, discuss, and
+        approve all their files, all in one place \u2013 including documents, designs,
+        images, videos, and audio files.</span></p>\n<p><span style=\"color: #434343;\">We''re
+        a fully remote team with people working in home offices, co-working spaces,
+        and coffee shops all over the world. Together, we''re on a mission to create
+        a seamless approval process that helps people deliver their best work.\u00a0</span></p>\n<p><span
+        style=\"color: #434343;\">We''ve raised our Series A and have over half a
+        million users across 500+ companies, including AB InBev, LG, Havas, GroupM,
+        and Emirates. So if you''re looking for a fast-growing startup in a booming
+        market, you''ve found it!</span></p>\n<p><span style=\"color: #434343;\">\u2b50
+        This role is fully remote and we are only able to consider candidates</span><strong><span
+        style=\"color: #434343;\"> who speak fluent German and are based in a European
+        time zone.</span></strong></p>\n<p>\u00a0</p>\n<div class=\"h1\"><strong><span
+        style=\"color: #00c261;\">Your mission: Architecting the future of CS</span></strong></div>\n<p><span
+        style=\"color: #434343;\">This is a pivotal moment for Filestage. We are currently
+        evolving our commercial structure by separating Customer Success (adoption
+        &amp; outcomes) from Account Management (renewals &amp; expansion).</span></p>\n<p><span
+        style=\"color: #434343;\">As our CS Team Lead, you will be the architect of
+        the Customer Success side of this transition. While Account Management handles
+        the commercials, you will define what a world-class \"Success\" journey looks
+        like. You\u2019ll act as a player-coach: leading by example with your own
+        high-touch DACH portfolio while building the operational standards the rest
+        of the team will follow.<br></span></p>\n<ul style=\"\">\n<li style=\"\">\n<p><strong><span
+        style=\"color: #434343;\">You define the CS operating system:</span></strong><span
+        style=\"color: #434343;\"> In partnership with RevOps, you\u2019ll refine
+        the foundation for onboarding, enablement, and health-score management. You\u2019ll
+        ensure the CS/AM \"handshake\" is seamless: no gaps, no double-touches, and
+        clear ownership at every stage.</span></p>\n</li>\n<li style=\"\">\n<p><strong><span
+        style=\"color: #434343;\">You standardize value delivery: </span></strong><span
+        style=\"color: #434343;\">You\u2019ll turn day-to-day execution into team-wide
+        standards. This means perfecting the \"Value Narrative\" in QBRs, shortening
+        Time-to-Value in onboarding, and enabling champions within our largest accounts.</span></p>\n</li>\n<li
+        style=\"\">\n<p><strong><span style=\"color: #434343;\">You proactively manage
+        retention &amp; risk: </span></strong><span style=\"color: #434343;\">You
+        won\u2019t just react to churn; you\u2019ll build the systems to predict it.
+        You\u2019ll monitor health signals and run structured recovery plans, ensuring
+        we protect Gross Revenue Retention (GRR) before it\u2019s ever at risk.</span></p>\n</li>\n<li
+        style=\"\">\n<p><strong><span style=\"color: #434343;\">You cultivate a high-performance
+        team: </span></strong><span style=\"color: #434343;\">You\u2019ll lead weekly
+        cadences such as portfolio reviews, risk assessments, and enablement sessions.
+        Your goal is to coach our CSMs toward a proactive, data-driven approach that
+        frees up human time for the conversations that move the needle.</span></p>\n</li>\n<li
+        style=\"\">\n<p><strong><span style=\"color: #434343;\">You are the voice
+        of the customer: </span></strong><span style=\"color: #434343;\">You\u2019ll
+        act as the strategic bridge to our Product team, translating customer bottlenecks
+        and feedback into actionable insights that shape our roadmap.</span></p>\n</li>\n</ul>\n<p>\u00a0</p>\n<div
+        class=\"h1\"><strong><span style=\"color: #00c261;\">Life at Filestage</span></strong></div>\n<p><span
+        style=\"color: #434343;\">We believe people are more productive when they
+        can choose their own schedule. So we\u2019re proud to offer fully-remote roles
+        that give you the perfect balance between work and life.</span></p>\n<p><span
+        style=\"color: #434343;\">Here are some of the benefits you can look forward
+        to at Filestage:</span></p>\n<ul style=\"\">\n<li style=\"\">\n<p><strong><span
+        style=\"color: #434343;\">\ud83c\udfe1 Work from where you''re happiest and
+        enjoy a flexible schedule. </span></strong><span style=\"color: #434343;\">We''ve
+        been fully remote from the start, giving you the opportunity to meet people
+        all over the world and broaden your horizons.</span></p>\n</li>\n<li style=\"\">\n<p><strong><span
+        style=\"color: #434343;\">\ud83c\udf0d Meet up in real life. </span></strong><span
+        style=\"color: #434343;\">We all travel together at least once a year at our
+        team retreat to have fun and get to know each other.</span></p>\n</li>\n<li
+        style=\"\">\n<p><strong><span style=\"color: #434343;\">\ud83d\udc65 Enjoy
+        a strong team culture. </span></strong><span style=\"color: #434343;\">We''re
+        a group of knowledge seekers, reflective thinkers, clear communicators, goal
+        owners, problem solvers, and team players. These are the values we strive
+        for to help us achieve our mission.</span></p>\n</li>\n<li style=\"\">\n<p><strong><span
+        style=\"color: #434343;\">\ud83d\ude0a Join a happy team. </span></strong><span
+        style=\"color: #434343;\">We''ve been rated five stars on Glassdoor by our
+        lovely team.</span></p>\n</li>\n<li style=\"\">\n<p><strong><span style=\"color:
+        #434343;\">\ud83d\udcbb Create a workspace that suits you. </span></strong><span
+        style=\"color: #434343;\">You''ll get a \u20ac1,500 budget for hardware, as
+        well as \u20ac500 for your home office \u2014 including a computer, webcam,
+        or standing desk.</span></p>\n</li>\n<li style=\"\">\n<p><strong><span style=\"color:
+        #434343;\">\ud83c\udf34 Get 38 days of holiday</span></strong><span style=\"color:
+        #434343;\">. Plenty of time for city breaks, summer escapes, and everything
+        in between. You''ll also get a half day on your birthday to celebrate!</span></p>\n</li>\n<li
+        style=\"\">\n<p><strong><span style=\"color: #434343;\">\ud83d\udc50 Volunteer/Charity
+        Day. </span></strong><span style=\"color: #434343;\">Enjoy a dedicated day
+        to support a cause close to your heart.</span></p>\n</li>\n<li style=\"\">\n<p><strong><span
+        style=\"color: #434343;\">\ud83d\udcda Continue to grow and develop your career</span></strong><span
+        style=\"color: #434343;\">. After six months, you''ll get a personal development
+        budget to invest in yourself.</span></p>\n</li>\n<li style=\"\">\n<p><strong><span
+        style=\"color: #434343;\">\ud83d\udde3\ufe0f Make your voice heard.</span></strong><span
+        style=\"color: #434343;\"> We trust our team members to make the best decisions
+        to achieve their goals \u2014 no micromanagers here.</span></p>\n</li>\n<li
+        style=\"\">\n<p><strong><span style=\"color: #434343;\">\ud83d\udcc5 Say goodbye
+        to pointless meetings. </span></strong><span style=\"color: #434343;\">Flat
+        hierarchies, fast iterations, and no bullshit meetings.</span></p>\n</li>\n</ul>\n<p>\u00a0</p>\n<p>\u00a0</p>\n<div
+        class=\"h1\"><strong><span style=\"color: #00c261;\">What you\u2019ll bring
+        to the role</span></strong></div>\n<ul style=\"\">\n<li style=\"\">\n<p><span
+        style=\"color: #434343;\">\ud83c\udfc6 </span><strong><span style=\"color:
+        #434343;\">You''ve been here before.</span></strong><span style=\"color: #434343;\">
+        You have 3\u20135 years of experience in Customer Success, with a proven track
+        record of owning GRR, running QBRs, and growing a high-value book of business.
+        You''ve outperformed retention targets, and you know what it takes.</span></p>\n</li>\n<li
+        style=\"\">\n<p><span style=\"color: #434343;\">\ud83d\udc65 </span><strong><span
+        style=\"color: #434343;\">You want to take the next step in leadership.</span></strong><span
+        style=\"color: #434343;\"> You understand the core principles of managing
+        a CS team because you have hands-on experience, remote experience, and ideally
+        experience during a period of growth or transition. You are ready to lift
+        people up, bring clarity to uncertainty, and set standards others want to
+        follow.</span></p>\n</li>\n<li style=\"\">\n<p><span style=\"color: #434343;\">\ud83d\udcca</span><strong><span
+        style=\"color: #434343;\"> You think like a business partner, not just a relationship
+        manager. </span></strong><span style=\"color: #434343;\">You understand revenue
+        strategy, GRR vs NRR, and how CS influences commercial outcomes. You can translate
+        product outcomes and user adoption into measurable business KPIs.\u00a0</span></p>\n</li>\n<li
+        style=\"\">\n<p><span style=\"color: #434343;\">\ud83d\udd0d </span><strong><span
+        style=\"color: #434343;\">You get ahead of problems. </span></strong><span
+        style=\"color: #434343;\">You''re analytical, process-oriented, and proactive.
+        You monitor health signals, build structured recovery plans, and prevent escalations
+        rather than reacting to them. Silent churn doesn''t stand a chance.</span></p>\n</li>\n<li
+        style=\"\">\n<p><span style=\"color: #434343;\">\ud83d\udee0\ufe0f</span><strong><span
+        style=\"color: #434343;\"> You build things that scale.</span></strong><span
+        style=\"color: #434343;\"> You''ve developed or improved CS playbooks \u2014
+        risk management, churn prevention, AM/CS handover, account monitoring \u2014
+        and you understand how to create a repeatable, scalable operating model.</span></p>\n</li>\n<li
+        style=\"\">\n<p><span style=\"color: #434343;\">\ud83e\udd1d </span><strong><span
+        style=\"color: #434343;\">You''re a team player with high EQ</span></strong><span
+        style=\"color: #434343;\">. You combine strong empathy with clear leadership.
+        You''re fair, honest, and collaborative \u2014 and you know that our success
+        as a business depends on the success of the people around you.</span></p>\n</li>\n<li
+        style=\"\">\n<p><span style=\"color: #434343;\">\ud83c\udf0d </span><strong><span
+        style=\"color: #434343;\">You''re fluent in German and English</span></strong><span
+        style=\"color: #434343;\">. Professional proficiency in both is essential
+        for this role. Spanish or French is a nice bonus.</span></p>\n</li>\n<li style=\"\">\n<p><span
+        style=\"color: #434343;\">\ud83c\udfe0 </span><strong><span style=\"color:
+        #434343;\">You''re built for remote</span></strong><span style=\"color: #434343;\">.
+        You''ve worked remotely for 2+ years and managed a team remotely for at least
+        a year. You''re self-motivated, async-friendly, and comfortable working independently
+        in an international environment.</span></p>\n</li>\n</ul>\n<p>\u00a0</p>\n<img
+        src=\"https://remotive.com/job/track/2088697/blank.gif?source=public_api\"
+        alt=\"\"/>"}, {"id": 2088696, "url": "https://remotive.com/remote-jobs/customer-service/technical-support-operator-2088696",
+        "title": "Technical Support Operator", "company_name": "KnownHost", "company_logo":
+        "https://remotive.com/job/2088696/logo", "category": "Customer Service", "tags":
+        ["apache", "drupal", "magento", "perl", "php", "python", "ruby/rails", "wordpress",
+        "bash", "dns", "web hosting", "helpdesk", "MySQL", "technical support", "chat",
+        "troubleshooting", "Linux/Unix", "shell", "REST", "insurance"], "job_type":
+        "full_time", "publication_date": "2026-03-27T09:51:22", "candidate_required_location":
+        "USA", "salary": "$30k - $40k", "description": "<p style=\"text-align: justify;\"><strong>THIS
+        IS WHO YOU ARE\u2026</strong></p>\n<p>You are our front line in the battle
+        for exceptional customer experience at the 24/7/365 help desk.</p>\n<p>Ideally,
+        you have experienced terrible web hosting customer service and have vowed
+        that will never happen on your watch!</p>\n<p>You are responsible for seeing
+        that our customers have excellent customer service by doing what you do every
+        day -&gt; exceeding customer expectations.</p>\n<p><strong>WHAT DO WE NEED
+        FROM YOU?</strong> Well, you should be customer focused, great under pressure,
+        and ready to engage a problem with your superior analytic skills. Can you
+        do several things at a time with amazing efficiency? Good! If you are a super
+        ninja with web hosting applications and platforms -&gt; we need to talk.</p>\n<p><strong>MORE
+        ABOUT THE POSITION</strong>. These will be your primary responsibilities in
+        your daily goal to fight bad web hosting:</p>\n<p>Hiring for day shift employees
+        CST.\u00a0<br>Provide customers support via our 24/7 helpdesk.<br>Troubleshooting
+        email delivery issues<br>Troubleshooting cPanel, Plesk, and DirectAdmin related
+        issues<br>Troubleshooting DNS, FTP, SSL, Apache, and other service-related
+        issues.</p>\n<p>Ensuring customer satisfaction</p>\n<p>You must know Linux
+        like your favorite cheeseburger and fries\u2019 combo! Here are your other
+        amazing attributes:</p>\n<p>Must be customer-focused, and willing to do whatever
+        it takes to resolve customer issues. Going above and beyond is the standard
+        at KnownHost. Our customer reviews reflect this.</p>\n<p>Excellent written
+        English. Technical Support Operators currently primarily provide support over
+        email, but may occasionally be asked to pitch in with live chat and phone
+        support.</p>\n<p>Must be familiar with Linux shell (bash), Apache, PHP, MySQL,
+        email (POP3/IMAP/SMTP), FTP, DNS, and other standard web hosting applications
+        and protocols.</p>\n<p>Must be able to work under pressure when bad stuff
+        happens and get the job done.</p>\n<p>Multi-tasking is a must. KnownHost has
+        a lot going on, and multiple brands.</p>\n<p>Must be able to ask customers
+        for complete error message or derive the context of their problem if they
+        provide insufficient information.</p>\n<p>Must have working knowledge of one
+        of the following control panels, cPanel/WHM, Plesk, and DirectAdmin is required.\u00a0</p>\n<p>Knowledge
+        of PHP, Python, Perl, and Ruby on Rail a bonus.\u00a0</p>\n<p>Working Knowledge
+        of Iptables firewalls (CSF, APF, etc.)</p>\n<p>Common customer website apps,
+        like Drupal, WordPress, MediaWiki, Magento, ZenCart, etc</p>\n<p>MySQL commands
+        for support or troubleshooting, like importing/dumping a database, simple
+        SELECT statements or \"SHOW PROCESSLIST\"</p>\n<p><strong>WHY IS KNOWNHOST
+        THE RIGHT FIT FOR YOU?</strong> We are seeking extraordinary people in a world
+        of mediocrity. You must live and breathe web hosting. To attract and retain
+        top-level talent, we are prepared to treat you like a VIP.</p>\n<p>With plush
+        benefits, paid vacation time,\u00a0and competitive pay, we believe that KnownHost
+        can be your next home away from home. Here is how we let you know that you
+        are valued on our red carpet:</p>\n<ul style=\"\">\n<li style=\"\">Competitive
+        pay between $14 to $20 per hour (depending on experience)</li>\n<li style=\"\">Comprehensive
+        health, dental, and vision insurance plans (US only)</li>\n<li style=\"\">Flexible
+        scheduling, &amp; paid vacation benefits.\u00a0</li>\n<li style=\"\">A variety
+        of other perks and benefits</li>\n</ul>\n<p>All our positions are full-time
+        employment, so we expect KnownHost to be your only hosting related job.</p>\n<p>All
+        you should do is know your field from every position, pass the background/
+        drug test, and let us do the rest!</p>\n<p>Apply today and let us get to know
+        you! \u00a0</p>\n<img src=\"https://remotive.com/job/track/2088696/blank.gif?source=public_api\"
+        alt=\"\"/>"}, {"id": 2088663, "url": "https://remotive.com/remote-jobs/project-management/junior-project-coordinator-2088663",
+        "title": "Junior Project Coordinator", "company_name": "C4Media Inc.", "company_logo":
+        "https://remotive.com/job/2088663/logo", "category": "Project Management",
+        "tags": ["html", "Figma", "research", "onboarding", "data entry", "infrastructure",
+        "travel"], "job_type": "full_time", "publication_date": "2026-03-24T09:43:07",
+        "candidate_required_location": "Brazil, Argentina", "salary": "", "description":
+        "<p dir=\"ltr\" style=\"line-height: 1.38; margin-top: 12pt; margin-bottom:
+        12pt;\"><span style=\"color: #000000; background-color: #ffffff; font-weight:
+        bold; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">C4Media, Inc.</span><span style=\"color:
+        #000000; background-color: transparent; font-weight: 400; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\"> is seeking a motivated, fully remote </span><span style=\"color:
+        #000000; background-color: transparent; font-weight: bold; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">Junior Project Coordinator (contractor)</span><span style=\"color:
+        #000000; background-color: transparent; font-weight: 400; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\"> to join our global team. In this role, you will provide essential
+        support for our expanding online learning and certification cohorts.</span></p>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 12pt; margin-bottom: 12pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">As a Junior Project Coordinator, you will assist
+        the team in planning and executing our virtual learning programs for software
+        professionals. This is a foundational, entry-level role designed for someone
+        who thrives on organization, clear communication, and the \"behind-the-scenes\"
+        work.</span></p>\n<p dir=\"ltr\" style=\"line-height: 1.38; margin-top: 12pt;
+        margin-bottom: 12pt;\"><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">You will work under
+        the close guidance of our program leads, learning the operational \"ins and
+        outs\" of professional education in a highly collaborative environment.</span></p>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 14pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: bold;
+        font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">What You\u2019ll Do</span></p>\n<p dir=\"ltr\"
+        style=\"line-height: 1.38; margin-top: 12pt; margin-bottom: 12pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">Working as part of a team, you will assist with the
+        daily operations of our online learning cohorts:</span></p>\n<ul style=\"\">\n<ul
+        style=\"\">\n<li style=\"\"><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        font-weight: bold; vertical-align: baseline; white-space-collapse: preserve;\">Customer
+        Service:</span><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        vertical-align: baseline; white-space-collapse: preserve;\"> Act as a first
+        point of contact for learners. You\u2019ll help distribute onboarding materials,
+        answer inquiries, and follow up to ensure participants have a smooth experience.</span></li>\n<li
+        style=\"\"><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        font-weight: bold; vertical-align: baseline; white-space-collapse: preserve;\">Logistics
+        Assistance:</span><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        vertical-align: baseline; white-space-collapse: preserve;\"> Help maintain
+        our digital learning environments, including Zoom room administration, Google
+        Drive organization, and coordinating Slack communications.</span></li>\n<li
+        style=\"\"><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        font-weight: bold; vertical-align: baseline; white-space-collapse: preserve;\">Editorial
+        Pipeline Support:</span><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        vertical-align: baseline; white-space-collapse: preserve;\"> Support the coordination
+        of \"Capstone\" learning projects by collecting participant bios, tracking
+        deadlines, and sharing information with our internal editorial team.</span></li>\n<li
+        style=\"\"><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        font-weight: bold; vertical-align: baseline; white-space-collapse: preserve;\">Trainer
+        Coordination:</span><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        vertical-align: baseline; white-space-collapse: preserve;\"> Provide administrative
+        support to facilitators by ensuring session materials are organized and sessions
+        are ready to launch.</span></li>\n<li style=\"\"><span style=\"background-color:
+        transparent; font-variant-numeric: normal; font-variant-east-asian: normal;
+        font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #000000; font-weight: bold; vertical-align: baseline; white-space-collapse:
+        preserve;\">Data Entry &amp; Tracking:</span><span style=\"background-color:
+        transparent; font-variant-numeric: normal; font-variant-east-asian: normal;
+        font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #000000; vertical-align: baseline; white-space-collapse: preserve;\">
+        Assist in keeping our databases accurate. You\u2019ll help track attendance,
+        distribute feedback surveys, and compile results for program reports.</span></li>\n<li
+        style=\"\"><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        font-weight: bold; vertical-align: baseline; white-space-collapse: preserve;\">Ad-Hoc
+        Team Support:</span><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        vertical-align: baseline; white-space-collapse: preserve;\"> Help with research
+        tasks and small operational details, such as tracking costs or coordinating
+        with Finance and Marketing.</span></li>\n</ul>\n</ul>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: #ffffff; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">\u00a0</span></p>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: #ffffff; font-weight: bold; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">Job Requirements</span></p>\n<p><strong>\u00a0</strong></p>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: #ffffff; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\"><strong>Professional
+        Experience, Skills &amp; Education:</strong></span></p>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: #ffffff; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">\u00a0</span></p>\n<ul
+        style=\"\">\n<ul style=\"\">\n<li style=\"\">Excellent English proficiency
+        (written &amp; spoken) with the ability to communicate professionally with
+        a global audience.</li>\n<li style=\"\">A customer-first mindset\u2014you
+        are naturally helpful, patient, and supportive.</li>\n<li style=\"\">Sharp
+        attention to detail and exceptional organizational skills.</li>\n<li style=\"\">Comfort
+        with remote productivity tools such as Google Workspace and Slack.</li>\n<li
+        style=\"\">Technology curiosity: A desire to learn new software. Experience
+        with CRMs, Figma, or basic HTML is a plus, but not required.</li>\n<li style=\"\">A
+        recent degree or 1-2 years of experience in an administrative or customer-facing
+        role.</li>\n<li style=\"\">A proactive, solution-oriented mindset with a strong
+        willingness to help.</li>\n</ul>\n</ul>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: #ffffff; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">\u00a0</span></p>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: #ffffff; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\"><strong>Setup
+        Requirements:</strong></span></p>\n<p dir=\"ltr\" style=\"line-height: 1.38;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        #ffffff; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">\u00a0</span></p>\n<ul
+        style=\"\">\n<ul style=\"\">\n<li style=\"\">Able to work in a full-time remote
+        position</li>\n<li style=\"\">Must reside in Argentina or Brazil</li>\n<li
+        style=\"\">Able to work as an independent contractor</li>\n<li style=\"\">Able
+        to work in overlap with our core global office hours (9 AM - 1 PM EST)</li>\n<li
+        style=\"\">Quiet home office and ability to work comfortably from home</li>\n<li
+        style=\"\">Reliable infrastructure: Access to high-speed internet and a modern
+        computer</li>\n<li style=\"\">Able and willing to travel to locations in the
+        USA or Europe 1 - 3 times per year, with an average stay of 4-8 days each,
+        to attend our software conferences and annual company meetings</li>\n</ul>\n</ul>\n<p><strong>\u00a0</strong></p>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;\"><span
+        style=\"color: #25044e; background-color: #ffffff; font-weight: 400; font-style:
+        italic; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">Only candidates who submit their </span><span style=\"color:
+        #25044e; background-color: #ffffff; font-weight: bold; font-style: italic;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">applications in English</span><span style=\"color: #25044e; background-color:
+        #ffffff; font-weight: 400; font-style: italic; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\"> will be considered
+        for this role (including resume).</span></p>\n<p dir=\"ltr\" style=\"line-height:
+        1.2; background-color: #ffffff; margin-top: 30pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: bold;
+        font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">Why work at C4Media</span></p>\n<ul style=\"\">\n<ul
+        style=\"\">\n<li style=\"\"><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #212121; background-color: transparent; font-weight: bold;
+        vertical-align: baseline; white-space-collapse: preserve;\">Work from home
+        - always</span><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #212121; background-color: transparent; vertical-align: baseline;
+        white-space-collapse: preserve;\">: We are a remote-first and remote-always
+        team who has been successfully operating on a work-from-home basis since 2007.
+        And we have no intention of changing that.</span></li>\n<li style=\"\"><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates:
+        normal; font-variant-position: normal; font-variant-emoji: normal; color:
+        #212121; background-color: transparent; font-weight: bold; vertical-align:
+        baseline; white-space-collapse: preserve;\">Travel the world:</span><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates:
+        normal; font-variant-position: normal; font-variant-emoji: normal; color:
+        #212121; background-color: transparent; vertical-align: baseline; white-space-collapse:
+        preserve;\"> C4Media offers an opportunity to travel 3-4 times a year at our
+        expense to NYC, SF, London, and other fun, global locations for conferences
+        &amp; team building. We also got you covered to add a sightseeing day to the
+        end of the trip.</span></li>\n<li style=\"\"><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #212121;
+        background-color: transparent; font-weight: bold; vertical-align: baseline;
+        white-space-collapse: preserve;\">Take care of each other:</span><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #212121;
+        background-color: transparent; vertical-align: baseline; white-space-collapse:
+        preserve;\"> We look out for one another and prioritize respect, fairness,
+        support, and well-being. Check out our core values on our careers page.</span></li>\n<li
+        style=\"\"><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #212121; background-color: transparent; font-weight: bold;
+        vertical-align: baseline; white-space-collapse: preserve;\">Learn something
+        new:</span><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #212121; background-color: transparent; vertical-align: baseline;
+        white-space-collapse: preserve;\"> C4Media\u2019s culture is one of learning
+        &amp; mastering. Everyone has a training and education budget for professional
+        growth every year and is encouraged to use it.</span></li>\n<li style=\"\"><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates:
+        normal; font-variant-position: normal; font-variant-emoji: normal; color:
+        #212121; background-color: transparent; font-weight: bold; vertical-align:
+        baseline; white-space-collapse: preserve;\">Make friends across the world</span><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates:
+        normal; font-variant-position: normal; font-variant-emoji: normal; color:
+        #212121; background-color: transparent; vertical-align: baseline; white-space-collapse:
+        preserve;\">: Be a part of a leading, fast-growing international company and
+        build a network of international friends and colleagues for life.</span></li>\n<li
+        style=\"\"><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #212121; background-color: transparent; font-weight: bold;
+        vertical-align: baseline; white-space-collapse: preserve;\">Support wellbeing:</span><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates:
+        normal; font-variant-position: normal; font-variant-emoji: normal; color:
+        #212121; background-color: transparent; vertical-align: baseline; white-space-collapse:
+        preserve;\"> In an effort to make physical activity more readily accessible,
+        we offer staff an annual subsidy towards fitness and wellness.</span></li>\n<li
+        style=\"\"><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #212121; background-color: transparent; font-weight: bold;
+        vertical-align: baseline; white-space-collapse: preserve;\">Generous paid
+        time off:</span><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #212121; background-color: transparent; vertical-align: baseline;
+        white-space-collapse: preserve;\"> In addition to 25 paid days off in the
+        1st year and 30 paid days off in every subsequent year, we provide 1 paid
+        day off for birthdays (or a similar special day) and 2 paid days for continuing
+        education.</span></li>\n<li style=\"\"><span style=\"background-color: transparent;
+        font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates:
+        normal; font-variant-position: normal; font-variant-emoji: normal; color:
+        #212121; font-weight: bold; vertical-align: baseline; white-space-collapse:
+        preserve;\">Mentorship</span><span style=\"background-color: transparent;
+        font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates:
+        normal; font-variant-position: normal; font-variant-emoji: normal; color:
+        #000000; vertical-align: baseline; white-space-collapse: preserve;\">: Receive
+        direct guidance and professional development from experienced project leads.</span></li>\n<li
+        style=\"\"><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #212121;
+        font-weight: bold; vertical-align: baseline; white-space-collapse: preserve;\">Global
+        Exposure</span><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        vertical-align: baseline; white-space-collapse: preserve;\">: Interact with
+        tech professionals and world-class trainers daily.</span></li>\n<li style=\"\"><span
+        style=\"background-color: transparent; font-variant-numeric: normal; font-variant-east-asian:
+        normal; font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #212121; font-weight: bold; vertical-align: baseline; white-space-collapse:
+        preserve;\">Event Experience</span><span style=\"background-color: transparent;
+        font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates:
+        normal; font-variant-position: normal; font-variant-emoji: normal; color:
+        #000000; vertical-align: baseline; white-space-collapse: preserve;\">: Gain
+        a front-row seat to how major international conferences are run, with potential
+        opportunities to support in-person events.</span></li>\n</ul>\n</ul>\n<p>\u00a0</p>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        italic; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">Qualified candidates are to submit their applications
+        on our C4Media website.</span></p>\n<img src=\"https://remotive.com/job/track/2088663/blank.gif?source=public_api\"
+        alt=\"\"/>"}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - '*'
+      Age:
+      - '35500'
+      CF-RAY:
+      - 9f10dc4fecfe4c24-MIA
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2026 00:06:11 GMT
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=E2MBGg72J%2FrnfMqEkbNF7OtsFt4zdtiIV6tUDlHTqfkA3hZz8IR9wObMfbNtdsYX%2FflSR1DXMR9U%2Fe7eC%2FtAjGULjqDdX9dfnd9qgpiKxNh1voGHKhFrPfELL9GWuA%3D%3D"}]}'
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      cf-cache-status:
+      - HIT
+      last-modified:
+      - Thu, 23 Apr 2026 14:14:56 GMT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/sources/remotive/cassettes/test_remotive_integration/test_pages_with_category_filter.yaml
+++ b/tests/sources/remotive/cassettes/test_remotive_integration/test_pages_with_category_filter.yaml
@@ -1,0 +1,4190 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.1
+    method: GET
+    uri: https://remotive.com/api/remote-jobs?limit=3&category=software-dev
+  response:
+    body:
+      string: '{"00-warning": "Remotive main domain moved to remotive.com ! Please
+        make your API calls on remotive.com/api/remote-jobs instead of remotive.io
+        now ;) Legacy endpoint remotive.io/api/remote-jobs will be terminated in June
+        2022. Thank you!", "0-legal-notice": "Legal warning - Hey, thanks for using
+        Remotive''s API, we appreciate it! Please note that API documentation and
+        access is granted so that developers can share our jobs further. Please do
+        not submit Remotive jobs to third Party websites, including but not limited
+        to: Jooble, Neuvoo, Google Jobs, LinkedIn Jobs. Please link back to the URL
+        found on Remotive AND mention Remotive as a source in order to Remotive to
+        get traffic from your listing. If you don''t do that, we''ll terminate your
+        API access, sorry! Jobs displayed are delayed by 24 hours, the goal being
+        that jobs are attributed to Remotive on various platforms. Displaying our
+        jobs in order to collect signups/email addresses to show a listing constitutes
+        a breach of our terms of services. We offer a private, paid-for API, please
+        email us at hello(at)remotive(dot)io for more information (starting budget
+        is $5k/mo). Please find out terms of services on https://remotive.com/api-documentation.
+        Please note that there is absolutely no need to request Remotive Job data
+        too frequently. Typically, you only need to GET Remotive job data through
+        this API a couple of times a day (we advise max. 4 times a day). Our data
+        is not changing much faster than that anyway. Note that excessive requests
+        will be blocked. Many thanks (Rodolphe & the Remotive team!)", "job-count":
+        22, "total-job-count": 22, "jobs": [{"id": 2089990, "url": "https://remotive.com/remote-jobs/all-others/content-reviewer-us-2089990",
+        "title": "Content Reviewer - US", "company_name": "TELUS Digital", "company_logo":
+        "https://remotive.com/job/2089990/logo", "category": "All others", "tags":
+        ["android", "go", "ios", "social media", "AI/ML", "diversity"], "job_type":
+        "part_time", "publication_date": "2026-04-21T12:46:23", "candidate_required_location":
+        "USA", "salary": "$14/hour", "description": "<p class=\"figma-padding-bottom-32
+        tw-border-b tw-border-[#E3E6E8]\" style=\"border-width: 0px 0px 1px; border-color:
+        #e3e6e8; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; --tw-border-opacity: 1; padding-bottom:
+        32px; color: #212529;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow:
+        0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">Looking
+        for a freelance opportunity where you can make an impact on technology from
+        the comfort of your home? If you are dynamic, tech-savvy, and always online
+        to learn more, this part-time flexible project is the perfect fit for you!\u00a0</span></p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; font-weight: bolder; background-color:
+        transparent;\">A Day in the Life of a </span>Content Reviewer - US<span style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; font-weight: bolder; background-color:
+        transparent;\">:</span></p>\n<ul style=\"\">\n<li style=\"\"><span style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">In
+        this role, you\u2019ll be analyzing and providing feedback on texts, pages,
+        images, and other types of information for top search engines, using an online
+        tool</span></li>\n<li style=\"\"><span style=\"border-color: #e5e7eb; --tw-shadow:
+        0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; background-color: transparent;\">Through reviewing and rating search
+        results for relevance and quality, you\u2019ll be helping to improve the overall
+        user experience for millions of search engine users, including yourself.</span></li>\n</ul>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">Join
+        our team today and start putting your skills to work for one of the world''s
+        leading search engines.</span></p>\n<p style=\"border-color: #e5e7eb; --tw-shadow:
+        0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\">\u00a0</p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\"><span style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">The
+        estimated hourly earnings for this role are\u00a014 USD</span> per hour.\u00a0</p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; color: #26282a;\">Please note only
+        one member per household can work on this program. If at a later stage it
+        is identified that more than one person in your household is working on the
+        TELUS Digital Rating Program, it will result in removal from the program.</span></p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\">\u00a0</p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\"><span style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; font-weight: bolder; background-color:
+        transparent;\">TELUS Digital AI Community</span></p>\n<p style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\"><span style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">Our
+        global AI Community is a vibrant network of 1 million+ contributors from diverse
+        backgrounds who help our customers collect, enhance, train, translate, and
+        localize content to build better AI models. Become part of our growing community
+        and make an impact supporting the machine learning models of some of the world\u2019s
+        largest brands.</span></p>\n<p class=\"pt-7 figma-padding-bottom-32 tw-border-b
+        tw-border-[#E3E6E8]\" style=\"border-width: 0px 0px 1px; border-color: #e3e6e8;
+        --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; --tw-border-opacity: 1; padding-bottom:
+        32px; color: #212529; padding-top: 2.5rem !important;\">\u00a0</p>\n<div class=\"h4\"
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; line-height: 1.75rem; color: #414547;
+        letter-spacing: 0px; --tw-text-opacity: 1;\">Qualification path</div>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\"><span style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">No
+        previous professional experience is required to apply to this role, however,
+        working on this project will require you to pass the basic requirements and
+        go through a standard assessment process. This is a part-time long-term project
+        and your work will be subject to our standard quality assurance checks during
+        the term of this agreement.\u00a0</span></p>\n<p style=\"border-color: #e5e7eb;
+        --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; font-weight: bolder; background-color:
+        transparent;\">Basic Requirements</span></p>\n<ul style=\"\">\n<li style=\"\"><span
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">Working
+        as a freelancer with excellent communication skills in English</span></li>\n<li
+        style=\"\"><span style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">Bein</span>g
+        a resident in the United States for the last 3 consecutive years and having
+        familiarity with current and historical business, media, sport, news, social
+        media, and cultural affairs in the US.</li>\n<li style=\"\">Active use of
+        Gmail and other forms of social media and experience in the use of web browsers
+        to navigate and interact with a variety of content</li>\n<li style=\"\">Daily
+        access to a broadband internet connection, a smartphone (Android 5.0, iOS
+        14 or higher), and a personal computer to work on.</li>\n</ul>\n<p style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; font-weight: bolder;\">Assessment</span></p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">In order to be hired into the program, you\u2019ll take a language assessment
+        and an\u00a0<span style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">open
+        book qualification exam that will determine your suitability for the position
+        and complete ID verification. Don\u2019t worry, our team will provide you
+        with guidelines and learning materials before your exam. You will be required
+        to complete the exam in a specific timeframe but at your convenience!</span></p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; font-weight: bolder;\">Equal Opportunity</span></p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\"><span style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; background-color: transparent;\">All
+        qualified applicants will receive consideration for a contractual relationship
+        without regard to race, color, religion, sex, sexual orientation, gender identity,
+        national origin, disability, or protected veteran status. At TELUS Digital
+        AI, we are proud to offer equal opportunities and are committed to creating
+        a diverse and inclusive community. All aspects of selection are based on applicants\u2019
+        qualifications, merits, competence, and performance without regard to any
+        characteristic related to diversity</span></p>\n<img src=\"https://remotive.com/job/track/2089990/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/2089990/logo"},
+        {"id": 2089958, "url": "https://remotive.com/remote-jobs/ai-ml/ai-engineer-2089958",
+        "title": "AI Engineer", "company_name": "Dry Ground AI", "company_logo": "https://remotive.com/job/2089958/logo",
+        "category": "AI / ML", "tags": ["api", "cloud", "fullstack", "python", "AI/ML",
+        "automation", "research", "CI/CD", "TensorFlow", "spark", "NLP", "CMS", "Pytorch",
+        "REST"], "job_type": "full_time", "publication_date": "2026-04-21T08:16:20",
+        "candidate_required_location": "Brazil, Colombia, Philippines", "salary":
+        "$40- $60k", "description": "<p class=\"MsoNormal\">We are seeking a versatile
+        and highly skilled AI Engineer to join our fast-growing Full-Stack AI Solutions
+        company. This role blends the expertise of building cutting-edge AI/ML models
+        with the practical know-how of automation and agentic system integrations.
+        You will design, develop, deploy, and optimize intelligent solutions that
+        leverage the power of generative AI, automation platforms, and agent-based
+        systems to enhance client operations, streamline workflows, and deliver measurable
+        results.</p>\n<p class=\"MsoNormal\">This is a unique opportunity to work
+        across a diverse range of technologies\u2014from fine-tuning transformer models
+        to building real-world AI-powered automation stacks. If you\u2019re passionate
+        about pushing the boundaries of AI while creating real value through systems
+        thinking and practical implementation, this role is for you.</p>\n<p class=\"MsoNormal\">\u00a0</p>\n<div
+        class=\"h3\">Key Responsibilities</div>\n<p class=\"MsoNormal\"><strong>AI/ML
+        Development:</strong></p>\n<p>\u00a0</p>\n<ul style=\"\" type=\"disc\">\n<li
+        class=\"MsoNormal\" style=\"\">Design, build, and deploy machine learning
+        and generative AI models for custom use cases.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Fine-tune and optimize large language models
+        (e.g., GPT, BERT) using frameworks like Hugging Face Transformers.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Conduct ongoing research to stay ahead of advancements
+        in AI/ML, including LLMs, generative AI, and transformer-based architectures.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Develop data pipelines for preprocessing, feature
+        engineering, and model training.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\"
+        style=\"\">Test, validate, and monitor model performance in real-world scenarios;
+        iterate for reliability and accuracy.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\"
+        style=\"\">Collaborate with cross-functional teams to embed AI into products,
+        platforms, and services.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\" style=\"\">Mentor
+        junior engineers and contribute to technical leadership.\n<p>\u00a0</p>\n</li>\n</ul>\n<p
+        class=\"MsoNormal\"><strong>Automation &amp; Agentic Systems:</strong></p>\n<p>\u00a0</p>\n<ul
+        style=\"\" type=\"disc\">\n<li class=\"MsoNormal\" style=\"\">Design, implement,
+        and maintain automation workflows using tools such as:\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">LangChain, LangGraph, LangSmith, LangFuse n8n,
+        ElevenLabs, and CMS integrations.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\"
+        style=\"\">Engineer system-to-system integrations using APIs to enable intelligent
+        process automation.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\" style=\"\">Apply
+        prompt and context engineering techniques to enhance the performance of conversational
+        AI tools.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\" style=\"\">Implement
+        prompt management and QA processes for agents and assistants.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Explore and deploy Microsoft Copilot Studio,
+        PowerApps, and PowerAutomate solutions (preferred but not required).\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Continuously evaluate emerging AI and automation
+        tools and assess their applicability in client use cases.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Collaborate with clients and internal teams
+        to scope, deliver, and maintain agentic and automation solutions aligned with
+        business goals.\n<p>\u00a0</p>\n</li>\n</ul>\n<div class=\"h3\"><strong>Qualifications</strong></div>\n<p
+        class=\"MsoNormal\">\u00a0</p>\n<p class=\"MsoNormal\"><strong>Required</strong></p>\n<p>\u00a0</p>\n<ul
+        style=\"\" type=\"disc\">\n<li class=\"MsoNormal\" style=\"\">2+ years of
+        hands-on experience in AI/ML development, including training and deploying
+        models in production.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\" style=\"\">Strong
+        programming skills in Python, with proficiency in frameworks such as TensorFlow,
+        PyTorch, Scikit-learn, and Hugging Face Transformers.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Experience working with AI tools like Langchain,
+        OpenAI, or Stable Diffusion.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\"
+        style=\"\">Practical experience with automation platforms and AI agent builders
+        (as listed above).\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\" style=\"\">Deep
+        understanding of machine learning algorithms, neural networks, and NLP concepts.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Proficiency in using REST APIs for tool and
+        platform integrations.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\" style=\"\">Familiarity
+        with cloud-based AI/ML platforms.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\"
+        style=\"\">Strong analytical skills and the ability to translate business
+        problems into technical AI/automation solutions.\n<p>\u00a0</p>\n</li>\n</ul>\n<p
+        class=\"MsoNormal\"><strong>Preferred</strong></p>\n<p>\u00a0</p>\n<ul style=\"\"
+        type=\"disc\">\n<li class=\"MsoNormal\" style=\"\">Experience working with
+        Agentic AI frameworks, voice automation, and prompt tuning systems.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Exposure to MLOps best practices, including
+        model versioning, CI/CD, and monitoring.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\"
+        style=\"\">Knowledge of reinforcement learning, GANs, or edge AI deployments.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Familiarity with distributed computing frameworks
+        such as Spark or Ray.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\" style=\"\">Background
+        in AI agency workflows and client-facing solution delivery.\n<p>\u00a0</p>\n</li>\n</ul>\n<div
+        class=\"h3\">Work Environment &amp; Benefits</div>\n<p>\u00a0</p>\n<ul style=\"\"
+        type=\"disc\">\n<li class=\"MsoNormal\" style=\"\">Competitive salary and
+        performance-based incentives.\n<p>\u00a0</p>\n</li>\n<li class=\"MsoNormal\"
+        style=\"\">Flexible work environment: Remote-first.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Collaborative, innovation-driven culture with
+        a commitment to personal and professional growth.\n<p>\u00a0</p>\n</li>\n<li
+        class=\"MsoNormal\" style=\"\">Opportunity to work at the forefront of AI
+        innovation across industries and verticals.</li>\n</ul>\n<img src=\"https://remotive.com/job/track/2089958/blank.gif?source=public_api\"
+        alt=\"\"/>"}, {"id": 2088659, "url": "https://remotive.com/remote-jobs/finance/crypto-trader-full-training-provided-2088659",
+        "title": "Crypto Trader (Full Training Provided)", "company_name": "Elemental
+        Terra Capital Ltd", "company_logo": "https://remotive.com/job/2088659/logo",
+        "category": "Finance", "tags": ["crypto", "research", "market research", "trading",
+        "onboarding"], "job_type": "part_time", "publication_date": "2026-04-20T16:00:51",
+        "candidate_required_location": "Worldwide", "salary": "$48k - $60k", "description":
+        "<p style=\"color: #333333;\">Elemental Terra is an international company
+        working with digital assets, market research, and data-driven trading solutions.
+        We are building a team of specialists who want to understand how crypto markets
+        operate in practice and develop professional skills in a real market environment.</p>\n<p
+        style=\"color: #333333;\">We are opening a Crypto Trader position for candidates
+        who are at the beginning of their professional journey and are interested
+        in trading, market analysis, and data-driven decision-making. This role involves
+        independent trading activity with structured training and ongoing support
+        from experienced professionals. No prior professional experience is required
+        - full training is provided.</p>\n<p style=\"color: #333333;\"><strong><br>Your
+        Responsibilities</strong></p>\n<p style=\"color: #333333;\">\u00a0</p>\n<ul
+        style=\"\">\n<li style=\"\">Execute trades on digital asset markets using
+        company strategies and guidelines.</li>\n<li style=\"\">Monitor price movements,
+        liquidity, and market conditions in real time.</li>\n<li style=\"\">Analyze
+        charts, indicators, and market signals to support trading decisions.</li>\n<li
+        style=\"\">Manage positions and assess potential risks.</li>\n<li style=\"\">Review
+        crypto news and its impact on market behavior.</li>\n<li style=\"\">Work with
+        professional trading platforms and analytical tools.</li>\n<li style=\"\">Track
+        and report personal trading performance.</li>\n<li style=\"\">Continuously
+        improve trading skills and market understanding.</li>\n</ul>\n<p style=\"color:
+        #333333;\"><br><strong>What We Offer</strong></p>\n<p style=\"color: #333333;\">\u00a0</p>\n<ul
+        style=\"\">\n<li style=\"\">Opportunity to join an early-stage international
+        company.</li>\n<li style=\"\">Fully remote work - no location restrictions.</li>\n<li
+        style=\"\">Flexible workload and schedule.</li>\n<li style=\"\">Structured
+        onboarding and full training provided at the company''s expense.</li>\n<li
+        style=\"\">Work on official, professional trading platforms.</li>\n<li style=\"\">Access
+        to real market data and advanced analytical tools.</li>\n<li style=\"\">Step-by-step
+        development with increasing responsibility.</li>\n<li style=\"\">Continuous
+        support from experienced market specialists.</li>\n<li style=\"\">Compensation
+        based on your trading performance and results.</li>\n</ul>\n<p style=\"color:
+        #333333;\"><br><strong>Interview Process</strong></p>\n<p style=\"color: #333333;\">\u00a0</p>\n<ul
+        style=\"\">\n<li style=\"\">A scheduled phone call with our representative
+        - we will contact you directly, so please be available to answer.</li>\n<li
+        style=\"\">Detailed interview with an HR manager.</li>\n<li style=\"\">Practical
+        training session with one of our trading specialists.</li>\n</ul>\n<img src=\"https://remotive.com/job/track/2088659/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/2088659/logo"},
+        {"id": 2088656, "url": "https://remotive.com/remote-jobs/customer-service/customer-retention-manager-2088656",
+        "title": "Customer Retention Manager", "company_name": "AutoHDR", "company_logo":
+        "https://remotive.com/job/2088656/logo", "category": "Customer Service", "tags":
+        ["AI/ML", "editing", "startup"], "job_type": "full_time", "publication_date":
+        "2026-04-16T21:16:09", "candidate_required_location": "USA", "salary": "",
+        "description": "<div class=\"h5\"><strong>Role: </strong>Customer Success
+        Representative</div>\n<p>AutoHDR is the fastest growing AI startup in real
+        estate media. We train custom image editing models for real estate, and are
+        currently editing 25% of all US real estate listings!</p>\n<p>Join our team
+        and work with an exceptional team to build cutting edge products and continue
+        growing 20% month over month!</p>\n<p>Our vision is to produce the majority
+        of media for the real estate industry - and you can join early on.</p>\n<div
+        class=\"h5\">\u00a0</div>\n<div class=\"h5\"><strong>The role:</strong></div>\n<ul
+        style=\"\">\n<li style=\"\">\n<p>Own customer retention; build systems, automations,
+        and build relationships to ensure a customer never leaves once using the platform.</p>\n</li>\n<li
+        style=\"\">\n<p>Call un-subscribed customers to collect feedback and conduct
+        our winback process</p>\n</li>\n<li style=\"\">\n<p>Call customers who report
+        low quality ratings in realtime to proactively prevent churn. Consult them
+        on how to prevent the issue &amp; share upcoming product updates.</p>\n</li>\n<li
+        style=\"\">\n<p>Proactively call existing users to collect feedback and proactively
+        mitigate any churn risks.</p>\n</li>\n</ul>\n<div class=\"h5\">\u00a0</div>\n<div
+        class=\"h5\"><strong>Your key responsibility:</strong></div>\n<ul style=\"\">\n<li
+        style=\"\">\n<p>Make sure 100% of tickets from un-subscribed customers and
+        low quality ratings are called through every single day. Come up with ideas
+        and systematic, data-driven approaches for churn prevention.</p>\n</li>\n</ul>\n<div
+        class=\"h5\">\u00a0</div>\n<div class=\"h5\"><strong>Requirements:</strong></div>\n<ul
+        style=\"\">\n<li style=\"\">\n<p>Background working with real estate photographers
+        or editing companies</p>\n</li>\n<li style=\"\">\n<p>Understanding of HDR
+        or flambient real estate photo workflows</p>\n</li>\n<li style=\"\">\n<p>Perfect
+        English fluency and no accent</p>\n</li>\n</ul>\n<div class=\"h5\">\u00a0</div>\n<div
+        class=\"h5\"><strong>Schedule:</strong></div>\n<ul style=\"\">\n<li style=\"\">\n<p>Full-time
+        (US Business Hours)</p>\n</li>\n</ul>\n<div class=\"h5\"><strong>AutoHDR Core
+        Values:</strong></div>\n<p>Our core values are the fuel for our continuous
+        20% month over month growth. Iron sharpens iron in our office, and the entire
+        dev team is bought in to winning together.</p>\n<div class=\"h5\">\u00a0</div>\n<div
+        class=\"h5\"><strong>Persistence</strong></div>\n<p>You believe anything is
+        possible - the only variable is how long it will take. You will always continue
+        trying to solve a problem, look for new solutions, and figure it out at all
+        costs through continous effort - even when most would give up.</p>\n<div class=\"h5\"><strong>Optimism</strong></div>\n<p>You
+        believe strongly that you can accomplish anything you want - regardless of
+        the odds. Even when the worst case scenario happens, and everything is on
+        fire, you never doubt your ability to pull through and win at what you set
+        out to do.</p>\n<div class=\"h5\"><strong>Competitive greatness</strong></div>\n<p>Every
+        individual on our team wants to be the best in the world at what they do.
+        We are extremely compeitive, and will settle for nothing other than being
+        the #1 player for AI real estate editing.</p>\n<img src=\"https://remotive.com/job/track/2088656/blank.gif?source=public_api\"
+        alt=\"\"/>"}, {"id": 2088655, "url": "https://remotive.com/remote-jobs/customer-service/customer-support-representative-2088655",
+        "title": "Customer Support Representative", "company_name": "AutoHDR", "company_logo":
+        "https://remotive.com/job/2088655/logo", "category": "Customer Service", "tags":
+        ["saas", "AI/ML", "editing", "technical support", "onboarding", "responsive"],
+        "job_type": "full_time", "publication_date": "2026-04-16T21:00:55", "candidate_required_location":
+        "USA", "salary": "", "description": "<div class=\"h3\">Company Description</div>\n<p>\u00a0</p>\n<p>AutoHDR
+        is an AI real estate photo editing platform. We launched less than a year
+        ago and already edit 25% of U.S. real estate listings.</p>\n<p>\u00a0</p>\n<p>We\u2019re
+        building a category-defining product and looking for people who want to help
+        us scale it fast. This is an early hire on a small team of A players changing
+        the industry.</p>\n<p>\u00a0</p>\n<div class=\"h3\">Role Description</div>\n<p>\u00a0</p>\n<p>We\u2019re
+        hiring a Customer Support Rep to own inbound support and make sure the product
+        is delivered well to users.</p>\n<p>\u00a0</p>\n<p>This is not a passive support
+        role. We want someone fast, sharp, calm under pressure, and great with people.
+        Your job is to respond quickly, solve problems clearly, and make sure every
+        customer gets the right outcome fast.</p>\n<p>\u00a0</p>\n<p>You\u2019ll handle
+        inbound questions, quality issues, flagged shoots, human edit requests, and
+        account-related problems. You\u2019ll also be responsible for spotting when
+        something is actually a bug, a churn risk, a sales opportunity, or an onboarding
+        issue, and routing it correctly.</p>\n<p>\u00a0</p>\n<p>We want someone who
+        can think clearly, communicate well, and use judgment. You should be able
+        to solve what can be solved, escalate what needs escalation, and always leave
+        the customer feeling taken care of.</p>\n<p>\u00a0</p>\n<p>You should also
+        be constantly thinking about how support can be faster, smarter, and more
+        scalable over time.</p>\n<p>\u00a0</p>\n<div class=\"h3\">Requirements</div>\n<p>\u00a0</p>\n<p>You
+        love helping people and communicating clearly.</p>\n<p>You are fast, organized,
+        and highly responsive.</p>\n<p>You have strong judgment and know how to solve
+        problems without overcomplicating them.</p>\n<p>You are high-agency and take
+        ownership instead of waiting around.</p>\n<p>You can stay calm under pressure
+        and handle urgent issues well.</p>\n<p>You pay close attention to detail and
+        care about quality.</p>\n<p>You are good at figuring out whether something
+        is a support issue, a bug, a churn risk, or a sales opportunity.</p>\n<p>You
+        think in systems and naturally look for ways to improve workflows over time.</p>\n<p>You
+        are comfortable working quickly across inboxes, tickets, Slack, and internal
+        tools.</p>\n<p>\u00a0</p>\n<div class=\"h3\">Bonus if you:</div>\n<p>\u00a0</p>\n<p>Have
+        worked in customer support, operations, or a fast-paced SaaS environment.</p>\n<p>Have
+        experience in real estate media or real estate photography.</p>\n<p>Have experience
+        handling quality control, escalations, or technical support.</p>\n<p>Have
+        used AI tools to improve workflows or automate repetitive wor</p>\n<img src=\"https://remotive.com/job/track/2088655/blank.gif?source=public_api\"
+        alt=\"\"/>"}, {"id": 1919266, "url": "https://remotive.com/remote-jobs/software-development/senior-independent-ai-engineer-architect-1919266",
+        "title": "Senior Independent AI Engineer / Architect", "company_name": "A.Team",
+        "company_logo": "https://remotive.com/job/1919266/logo", "category": "Software
+        Development", "tags": ["go", "UI/UX", "wordpress", "chat", "apple", "testing",
+        "catalyst"], "job_type": "contract", "publication_date": "2026-04-16T10:16:01",
+        "candidate_required_location": "Americas, Europe, Israel", "salary": "$120
+        - $170 /hour", "description": "<p class=\"my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block
+        [&amp;_strong:has(+br)]:pb-2\" style=\"border-color: oklch(0.3039 0.04 213.68
+        / 0.16); scrollbar-color: initial; scrollbar-width: initial; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\"><span
+        style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial;
+        scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Location:</span>\u00a0Americas,
+        Europe, or Israel</p>\n<div class=\"h2\" style=\"border-color: oklch(0.3039
+        0.04 213.68 / 0.16); scrollbar-color: initial; scrollbar-width: initial; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        1rem; line-height: 1.5rem;\">The Opportunity</div>\n<p class=\"my-2 [&amp;+p]:mt-4
+        [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\" style=\"border-color:
+        oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial; scrollbar-width:
+        initial; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow:
+        0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Join A.Team\u2019s invite-only
+        network of senior builders and access exclusive missions with Fortune 500s
+        and top startups. This isn\u2019t client work or employment\u2014it\u2019s
+        a vetted collective where you\u2019re matched to impactful projects.<br style=\"border-color:
+        oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial; scrollbar-width:
+        initial; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow:
+        0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">At A.Team, you won\u2019t just
+        implement someone else\u2019s plan. You\u2019ll be the technical decision-maker,
+        owning everything from model design to enterprise integration.</p>\n<div class=\"h2\"
+        style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial;
+        scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        1rem; line-height: 1.5rem;\">Why A.Team</div>\n<ul class=\"marker:text-quiet
+        list-disc\" style=\"\">\n<li class=\"py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0
+        [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2
+        [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\"
+        style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial;
+        scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        0px; padding-top: 0px;\"><span style=\"border-color: oklch(0.3039 0.04 213.68
+        / 0.16); scrollbar-color: initial; scrollbar-width: initial; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Elite
+        peers</span>: ex-OpenAI, Google, Meta, Amazon.</p>\n</li>\n<li class=\"py-0
+        my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2
+        [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block
+        [&amp;_strong:has(+br)]:pb-2\" style=\"border-color: oklch(0.3039 0.04 213.68
+        / 0.16); scrollbar-color: initial; scrollbar-width: initial; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        0px; padding-top: 0px;\"><span style=\"border-color: oklch(0.3039 0.04 213.68
+        / 0.16); scrollbar-color: initial; scrollbar-width: initial; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Precision
+        matching</span>: Missions in LLMs, CV, NLP, ML infra, fine-tuning.</p>\n</li>\n<li
+        class=\"py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0
+        [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2 [&amp;+p]:mt-4
+        [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\" style=\"border-color:
+        oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial; scrollbar-width:
+        initial; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow:
+        0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top: 0px; padding-top: 0px;\"><span
+        style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial;
+        scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Compensation</span>:
+        $120\u2013$170/hr, biweekly payouts, you keep 100%.</p>\n</li>\n<li class=\"py-0
+        my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2
+        [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block
+        [&amp;_strong:has(+br)]:pb-2\" style=\"border-color: oklch(0.3039 0.04 213.68
+        / 0.16); scrollbar-color: initial; scrollbar-width: initial; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        0px; padding-top: 0px;\"><span style=\"border-color: oklch(0.3039 0.04 213.68
+        / 0.16); scrollbar-color: initial; scrollbar-width: initial; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Autonomy</span>:
+        Choose only missions that excite you\u2014no small gigs, no chasing.</p>\n</li>\n</ul>\n<div
+        class=\"h2\" style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color:
+        initial; scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        1rem; line-height: 1.5rem;\">What You\u2019ll Do</div>\n<ul class=\"marker:text-quiet
+        list-disc\" style=\"\">\n<li class=\"py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0
+        [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2
+        [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\"
+        style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial;
+        scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        0px; padding-top: 0px;\">Lead the design, deployment, and scaling of production
+        AI systems.</p>\n</li>\n<li class=\"py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0
+        [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2
+        [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\"
+        style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial;
+        scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        0px; padding-top: 0px;\">Build ambitious software 0\u21921 in small, senior
+        teams (3\u20135 people).</p>\n</li>\n<li class=\"py-0 my-0 prose-p:pt-0 prose-p:mb-2
+        prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0\" style=\"\">\n<p
+        class=\"my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\"
+        style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial;
+        scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        0px; padding-top: 0px;\">Scope, propose, and execute solutions with real ownership.</p>\n</li>\n<li
+        class=\"py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0
+        [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2 [&amp;+p]:mt-4
+        [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\" style=\"border-color:
+        oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial; scrollbar-width:
+        initial; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow:
+        0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top: 0px; padding-top: 0px;\">Partner
+        with founders, CTOs, and product leaders to deliver outcomes that matter.</p>\n</li>\n</ul>\n<div
+        class=\"h2\" style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color:
+        initial; scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        1rem; line-height: 1.5rem;\">Who Thrives Here</div>\n<ul class=\"marker:text-quiet
+        list-disc\" style=\"\">\n<li class=\"py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0
+        [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2
+        [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\"
+        style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial;
+        scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        0px; padding-top: 0px;\">Senior AI/ML Engineers with production systems live.</p>\n</li>\n<li
+        class=\"py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0
+        [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2 [&amp;+p]:mt-4
+        [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\" style=\"border-color:
+        oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial; scrollbar-width:
+        initial; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow:
+        0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top: 0px; padding-top: 0px;\">AI
+        Architects who\u2019ve built enterprise AI stacks.</p>\n</li>\n<li class=\"py-0
+        my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2
+        [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block
+        [&amp;_strong:has(+br)]:pb-2\" style=\"border-color: oklch(0.3039 0.04 213.68
+        / 0.16); scrollbar-color: initial; scrollbar-width: initial; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        0px; padding-top: 0px;\">Tech Leaders balancing architecture with business
+        outcomes.</p>\n</li>\n<li class=\"py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0
+        [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0\" style=\"\">\n<p class=\"my-2
+        [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\"
+        style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial;
+        scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        0px; padding-top: 0px;\">Specialists in LLMs, CV, NLP, or infra with proven
+        depth.</p>\n</li>\n</ul>\n<p><strong><em>Not a fit</em></strong>: under 4
+        years\u2019 experience, simple website builders, or small gig seekers.</p>\n<div
+        class=\"h2\" style=\"border-color: oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color:
+        initial; scrollbar-width: initial; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top:
+        1rem; line-height: 1.5rem;\">Proof in the Network</div>\n<p class=\"my-2 [&amp;+p]:mt-4
+        [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2\" style=\"border-color:
+        oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial; scrollbar-width:
+        initial; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow:
+        0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Your peers have scaled apps to
+        millions, built enterprise AI platforms, shipped AI at unicorns, and deployed
+        infra handling billions/day.</p>\n<div class=\"h2\" style=\"border-color:
+        oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial; scrollbar-width:
+        initial; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow:
+        0 0 #0000; --tw-shadow-colored: 0 0 #0000; margin-top: 1rem; line-height:
+        1.5rem;\">How to Apply</div>\n<p class=\"my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block
+        [&amp;_strong:has(+br)]:pb-2\" style=\"border-color: oklch(0.3039 0.04 213.68
+        / 0.16); scrollbar-color: initial; scrollbar-width: initial; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Apply
+        once at\u00a0<a href=\"http://a.team/ai-talent?utm_source=remotive&amp;utm_medium=post&amp;utm_campaign=welikeremotiveAI\"
+        rel=\"nofollow\" target=\"_self\">build.a.team/apply-ai</a>.<br style=\"border-color:
+        oklch(0.3039 0.04 213.68 / 0.16); scrollbar-color: initial; scrollbar-width:
+        initial; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow:
+        0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Short, rigorous process\u2014we
+        care more about what you\u2019ve built than lengthy forms.</p>\n<p>\u00a0</p>\n<img
+        src=\"https://remotive.com/job/track/1919266/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/1919266/logo"},
+        {"id": 1919265, "url": "https://remotive.com/remote-jobs/software-development/senior-independent-software-developer-1919265",
+        "title": "Senior Independent Software Developer", "company_name": "A.Team",
+        "company_logo": "https://remotive.com/job/1919265/logo", "category": "Software
+        Development", "tags": ["go", "wordpress", "chat", "apple", "testing", "catalyst"],
+        "job_type": "contract", "publication_date": "2026-04-16T10:15:53", "candidate_required_location":
+        "Americas, Europe, Israel", "salary": "$90 - $150 /hour", "description": "<p
+        style=\"text-size-adjust: 100%; overflow-wrap: break-word;\"><em>You must
+        be located in the Americas, Europe, or Israel to apply.<br></em><br><br><a
+        href=\"https://build.a.team/remotivereferral\" rel=\"nofollow\">A\u00b7Team</a>
+        is a VC-backed, stealth, application-only home on the internet for senior
+        independent software builders to team up with hand-picked, high-growth companies
+        on their next big thing.\u00a0</p>\n<p style=\"text-size-adjust: 100%; overflow-wrap:
+        break-word;\">After talking with hundreds of independent engineers, designers,
+        and product folks, we heard over and over that finding vetted, high-quality,
+        consistent clients is hard, and projects are often too small to be rewarding.
+        A\u00b7Team matches small teams of the most talented builders in the world
+        with companies backed by a16z, YC, Softbank, General Catalyst, etc. on a contract
+        basis for many of their most important initiatives. We quietly launched in
+        May 2020, and have helped A\u00b7Teamers earn $85+ million since.</p>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 12pt; margin-bottom: 12pt;\"><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; vertical-align:
+        baseline;\"><em>As part of A\u00b7Team, you can expect:</em></span></p>\n<ul
+        style=\"\">\n<li style=\"\"><strong>High-paying, meaningful missions with
+        the most audacious companies</strong> sent your way; generally $90-$150+/hr,
+        with vetted, fascinating clients doing work that matters. We''re picky about
+        who we partner with; new clients only come in via trusted referral. We''ve
+        worked with Lyft, McGraw Hill, ClearCo, Pepsi, Walmart, the former CEO of
+        Waze, the leading vaccine production software, several new unicorns we can''t
+        say here, and dozens of startups backed by a16z/YC/Softbank/Insight/Tiger/etc.</li>\n<li
+        style=\"\"><strong>Work alongside friends old &amp; new: </strong>our niche
+        is small/diverse product teams, since clients with larger budgets and higher-impact
+        work tell us they want teams, not individuals. Of course, we keep friends
+        together whenever we can.</li>\n<li style=\"\"><strong>Full autonomy:</strong>
+        say \"no\" to things that don''t excite you. The most talented builders often
+        juggle a few things at once, so there''s never pressure to join an A\u00b7Team
+        mission if you don''t have the bandwidth. If we''re no longer a fit, it''s
+        easy to leave or pause too.\u00a0</li>\n<li style=\"\"><strong>Small, curated,
+        off-the-record gatherings:</strong> for conversations hard to have elsewhere.
+        Long-term, we''re creating micro-communities for the world''s top builders
+        to become friends around the things they care about.</li>\n<li style=\"\"><strong>Keep
+        100% of what you earn: </strong>if you charge $120/hr, you get $120/hr. A\u00b7Team
+        makes money by charging a small, flat, transparent platform fee on <em>top</em>
+        of your rate.</li>\n</ul>\n<p>\u00a0</p>\n<p>\u00a0</p>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; margin-top: 12pt; margin-bottom: 12pt;\"><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; vertical-align: baseline;\"><strong>How
+        to apply:</strong></span></p>\n<p dir=\"ltr\" style=\"line-height: 1.38; margin-top:
+        12pt; margin-bottom: 12pt;\"><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; vertical-align: baseline;\">Go here:\u00a0<a href=\"https://build.a.team/remotivereferral\"
+        rel=\"nofollow\">https://build.a.team/remotivereferral</a>\u00a0+ mention
+        Remotive.\u00a0</span>We respect your time so the application is short. We''re
+        also much more interested in seeing what you''ve made, and excited to chat
+        more if there\u2019s a fit.</p>\n<p dir=\"ltr\" style=\"line-height: 1.38;
+        margin-top: 12pt; margin-bottom: 12pt;\"><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; vertical-align: baseline;\"><strong>What
+        you\u2019ll do:</strong></span></p>\n<ul style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 12pt; margin-bottom: 0pt;\"><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; vertical-align:
+        baseline;\">Once part of A.Team, you\u2019ll regularly be invited to impactful
+        missions that match your interests. Find the right pick from early-stage incubations
+        with world-class founders, to fast-growing super-funded companies, to old
+        school non-tech incumbents looking to build as a tech giant would</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; margin-top:
+        0pt; margin-bottom: 0pt;\"><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; vertical-align: baseline;\">Missions usually involve building an ambitious
+        piece of software from 0 to 1 as part of a small 3-4 person team.\u00a0</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; margin-top:
+        0pt; margin-bottom: 12pt;\"><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; vertical-align: baseline;\">You\u2019ll be paid to scope it out, give
+        the client options, guide strategy, and execute on the selected solution.
+        Sometimes the client has a clear vision, sometimes not; which is why A.Team
+        builders tend to be senior folks who can work together to find the right direction.\u00a0</span></p>\n</li>\n</ul>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 12pt; margin-bottom: 12pt;\"><strong><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; vertical-align:
+        baseline;\">Who A</span><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; vertical-align: baseline;\">\u00b7</span><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; vertical-align: baseline;\">Team
+        is for:</span></strong></p>\n<ul style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 12pt; margin-bottom: 0pt;\"><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; vertical-align:
+        baseline;\">Senior software developers who left large companies and high-growth
+        startups to pursue their craft with autonomy.</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; margin-top: 0pt; margin-bottom:
+        0pt;\"><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; vertical-align: baseline;\">Those who prefer consistent contract work
+        over a full-time role, who want to create a variety of new products alongside
+        other top-tier builders.</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 0pt; margin-bottom: 12pt;\"><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; vertical-align:
+        baseline;\">The majority of A.Teamers spend most of their time doing independent
+        work, but a sizeable percentage are either employed full-time (but testing
+        out client work), bootstrapping a side project, or looking for their next
+        big thing</span></p>\n</li>\n</ul>\n<p dir=\"ltr\" style=\"line-height: 1.38;
+        margin-top: 12pt; margin-bottom: 12pt;\"><strong><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; vertical-align: baseline;\">Who A</span><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; vertical-align:
+        baseline;\">\u00b7</span><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; vertical-align: baseline;\">Team is </span><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; vertical-align: baseline;\">not</span><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; vertical-align:
+        baseline;\"> for:</span></strong></p>\n<ul style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 12pt; margin-bottom: 0pt;\"><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; vertical-align:
+        baseline;\">People looking for small gigs</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; margin-top: 0pt; margin-bottom:
+        0pt;\"><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; vertical-align: baseline;\">Folks looking to build simple wordpress/wix/squarespace-style
+        websites</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height:
+        1.38; margin-top: 0pt; margin-bottom: 12pt;\"><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; vertical-align: baseline;\">Those
+        still early in their careers (&lt;4 years) and recent university/bootcamp
+        grads (at least not yet)</span></p>\n</li>\n</ul>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; margin-top: 12pt; margin-bottom: 12pt;\"><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; vertical-align: baseline;\"><strong>Our
+        long-term vision:</strong></span></p>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; margin-top: 12pt; margin-bottom: 12pt;\"><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; vertical-align: baseline;\"><a href=\"https://build.a.team/remotivereferral\"
+        rel=\"nofollow\">A\u00b7Team</a> is a new type of company for a new kind of
+        independent software builder. We call them \"unhirables\": people who traditional
+        companies couldn\u2019t hire full-time even if they wanted to, but who want
+        to do their most meaningful work with their favorite people in small, autonomous,
+        distributed expert teams.\u00a0</span></p>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; margin-top: 12pt; margin-bottom: 12pt;\"><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; vertical-align: baseline;\">To help
+        us secure amazing missions, we raised $60 million+\u00a0 from Insight Partenrs,
+        Tiger Global, NFX, RocNation, along with the former CEO of Upwork, the founders
+        of Fiverr and Lemonade, Apple''s Global Head of Recruiting, YC Partner Aaron
+        Harris, Wharton''s Adam Grant, and Duke''s Dan Ariely.</span></p>\n<img src=\"https://remotive.com/job/track/1919265/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/1919265/logo"},
+        {"id": 2088711, "url": "https://remotive.com/remote-jobs/software-development/senior-full-stack-react-developer-2088711",
+        "title": "Senior Full-stack React Developer", "company_name": "Lemon.io",
+        "company_logo": "https://remotive.com/job/2088711/logo", "category": "Software
+        Development", "tags": [".Net", "android", "AWS", "azure", "backend", "C",
+        "C#", "C++", "data science", "fullstack", "golang", "ios", "java", "javascript",
+        "node.js", "php", "python", "react", "react js", "ruby/rails", "shopify",
+        "video", "blockchain", "AI/ML", "react native", "rust", "unity", "spring",
+        "data analysis", "laravel", "solidity", "flask", "Typescript ", "angular ",
+        "GCP", "data engineering", "Symfony", "startup", "marketplace", "next.js"],
+        "job_type": "contract", "publication_date": "2026-04-15T14:19:37", "candidate_required_location":
+        "Americas, Europe, Asia, Oceania", "salary": "", "description": "<p>Are you
+        a talented Senior Developer looking for a remote job that lets you show your
+        skills and get decent compensation? Look no further than <a href=\"https://lemon.io/for-developers/?utm_source=remotive&amp;utm_medium=job_ad&amp;utm_campaign=supply_en_react_python/golang_apr_2026_job_ad\"
+        rel=\"nofollow\" target=\"_self\">Lemon.io</a> \u2014 the marketplace that
+        connects you with hand-picked startups in the US and Europe.</p>\n<p><strong>\u00a0</strong></p>\n<p><strong>What
+        we offer:</strong></p>\n<ul style=\"\">\n<li style=\"\">The rate depends on
+        your seniority level, skills and experience. We''ve already paid out over
+        $11M to our engineers.</li>\n<li style=\"\">No more hunting for clients or
+        negotiating rates \u2014 let us handle the business side of things so you
+        can focus on what you do best.</li>\n<li style=\"\">We''ll manually find the
+        best project for you according to your skills and preferences.</li>\n<li style=\"\">Choose
+        a schedule that works best for you. It\u2019s possible to communicate async
+        or minimally overlap within team working hours.</li>\n<li style=\"\">We respect
+        your seniority so you can expect no micromanagement or screen trackers.</li>\n<li
+        style=\"\">Communicate directly with the clients. Most of them have technical
+        backgrounds. Sounds good, yeah?</li>\n<li style=\"\">We will support you from
+        the time you submit the application throughout all cooperation stages.</li>\n<li
+        style=\"\">Most of our projects involve working in a fast-paced startup environment.
+        We hope you like it as much as we do.</li>\n</ul>\n<div class=\"h4\">\n<ul
+        style=\"\">\n<li style=\"\">Through our community, we will connect you with
+        the best developers from more than 71 countries.</li>\n</ul>\n<br>We have
+        several open positions for Full-Stack React.js Developers - please see the
+        details below. We also have some backend positions; the full list is included
+        below as well.</div>\n<div class=\"h3\"><strong>\u00a0</strong></div>\n<div
+        class=\"h3\"><strong>Requirements for the Senior React &amp; Python Position:</strong></div>\n<ul
+        style=\"\">\n<li style=\"\">4+ years of software development experience</li>\n</ul>\n<p><strong>Commercial
+        experience:</strong></p>\n<ul style=\"\">\n<li style=\"\">React.js 3+ years
+        and Python 3+ years <strong>OR</strong> React.js 2+ years and Python 5+ years
+        <strong>OR</strong> React.js 5+ years and Python 2+ years</li>\n<li style=\"\">Experience
+        with AWS, GCP, or Azure is required</li>\n</ul>\n<div class=\"h3\"><strong>\u00a0</strong></div>\n<div
+        class=\"h3\"><strong>Requirements for the Senior Python Position:</strong></div>\n<ul
+        style=\"\">\n<li style=\"\">5+ years of software development experience</li>\n<li
+        style=\"\">5+ years of commercial experience with Python</li>\n<li style=\"\">3+
+        years of commercial experience with Flask</li>\n</ul>\n<div class=\"h3\"><strong>\u00a0</strong></div>\n<div
+        class=\"h3\"><strong>Requirements for the Senior Golang &amp; React Position:</strong></div>\n<ul
+        style=\"\">\n<li style=\"\">4+ years of software development experience</li>\n<li
+        style=\"\">React.js 3+ years and Golang 3+ years <strong>OR</strong> React.js
+        2+ years and Golang 5+ years <strong>OR</strong> React.js 5+ years and Golang
+        2+ years</li>\n</ul>\n<div class=\"h3\"><strong>\u00a0</strong></div>\n<div
+        class=\"h3\"><strong>Requirements for the Senior Golang Position:</strong></div>\n<ul
+        style=\"\">\n<li style=\"\">5+ years of software development experience</li>\n<li
+        style=\"\">5+ years of commercial experience with Golang</li>\n</ul>\n<p><strong>\u00a0</strong></p>\n<p><strong>Other
+        requirements:</strong></p>\n<ul style=\"\">\n<li style=\"\">Strong technical
+        skills: as a Senior Developer, you are expected to be able to create projects
+        from scratch and have a deep understanding of application architecture.</li>\n<li
+        style=\"\">Clear and effective communication in English \u2014 advanced ability
+        to discuss business tasks, justify decisions, and communicate issues. Good
+        self-presentation is also essential for upcoming client calls.</li>\n<li style=\"\">Strong
+        self-organizational skills \u2014 ability to work full-time remotely with
+        no supervision.</li>\n<li style=\"\">Reliability \u2014 we want to trust you
+        and expect that you won\u2019t let us and the client down.</li>\n<li style=\"\">Adaptability
+        and Flexibility \u2014 the ability to onboard the project promptly after accepting
+        it and start delivering results quickly.</li>\n</ul>\n<p>\u00a0</p>\n<p>Sounds
+        good for you? Apply now and join the <a href=\"https://lemon.io/for-developers/?utm_source=remotive&amp;utm_medium=job_ad&amp;utm_campaign=supply_en_react_python/golang_apr_2026_job_ad\"
+        rel=\"nofollow\" target=\"_self\">Lemon.io</a> community!</p>\n<p><strong>\u00a0</strong></p>\n<p><strong>NOT
+        YOUR TECH STACK?</strong></p>\n<p>We have multiple projects available for
+        Senior Developers. If you have 4+ years of commercial software development
+        experience and are proficient in any of the following areas:\u00a0React &amp;
+        Node, React &amp; Ruby, PHP &amp; Angular, PHP &amp; Vue, Vue &amp; Node.js,
+        React &amp; .NET, Android &amp; iOS, Angular &amp; .NET, Angular &amp; Node.js,
+        Vue &amp; .NET, Python &amp; Vue, MLOps, React &amp; Java, Data Science, Blockchain
+        (Web3/Solidity/Solana), Symfony &amp; React, Symfony &amp; Vue, Symfony &amp;
+        Angular, Symfony &amp; JavaScript &amp; Next.js &amp; TypeScript, Data Analysis,
+        React &amp; PHP, Data Engineering, AI Engineering, Data Annotation, DevOps,
+        Svelte &amp; Python, Svelte &amp; Node, Svelte &amp; TypeScript, Rust, Shopify
+        &amp; JavaScript, Vue &amp; Nuxt, Python &amp; Node, Angular &amp; TypeScript,
+        Ruby &amp; Ruby on Rails, React Native &amp; Ruby, React Native &amp; Python,
+        PHP &amp; Laravel, .NET &amp; C#, Java &amp; Spring, Unreal Engine &amp; C++,
+        Python &amp; LLM, Unity, Machine Learning Engineering\u00a0\u2014 we\u2019d
+        be happy to connect and match you with a suitable project.</p>\n<p>\u00a0</p>\n<p><strong>If
+        your experience matches our requirements, be ready for the next steps:</strong></p>\n<ul
+        style=\"\">\n<li style=\"\">VideoAsk \u2014 watch a short video about our
+        startup, up to 10 minutes</li>\n<li style=\"\">Complete your profile on our
+        website</li>\n<li style=\"\">Screening call</li>\n<li style=\"\">Technical
+        interview</li>\n<li style=\"\">Feedback</li>\n<li style=\"\">Magic Box (we
+        are looking for the best project for you).</li>\n</ul>\n<p>\u00a0</p>\n<p>We
+        do not provide visa assistance, and our cooperation model does not include
+        the benefits typically offered with direct hire.</p>\n<p>\u00a0</p>\n<p>P.S.
+        <strong>We work with developers from 71+ countries in different regions:</strong>
+        Europe, LATAM, the U.S (if you are an owner of W-9 ben form), Canada, Asia
+        (Japan, Singapore, South Korea, Philippines, Indonesia), Oceania (Australia,
+        New Zealand, Papua New Guinea), and the the UK. However, we have some exceptions.</p>\n<p><strong>\u00a0</strong></p>\n<p><strong>At
+        the moment, we don\u2019t have a legal basis to accept applicants from the
+        following countries:</strong></p>\n<ul style=\"\">\n<li style=\"\">European:
+        Hungary, Iceland, Liechtenstein, Kosovo, Belarus, Russia, and Serbia.</li>\n<li
+        style=\"\">Latin America: Cuba and Nicaragua</li>\n<li style=\"\">Most Asian
+        countries and Africa.</li>\n</ul>\n<p>We expand and shorten the list of exemptions
+        regularly.</p>\n<p><!-- notionvc: 49abefed-fba6-4833-8e6d-3554e2c38fc5 --></p>\n<p>\u00a0</p>\n<p>Do
+        you represent a company with engineers who match the description and want
+        to collaborate with us through staff augmentation? Then register <a href=\"https://lemon.io/for-developers/?utm_source=remotive&amp;utm_medium=job_ad&amp;utm_campaign=supply_en_react_python/golang_apr_2026_job_ad\"
+        rel=\"nofollow\" target=\"_self\">here</a>.</p>\n<img src=\"https://remotive.com/job/track/2088711/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/2088711/logo"},
+        {"id": 2069746, "url": "https://remotive.com/remote-jobs/software-development/tech-lead-full-stack-rails-engineer-2069746",
+        "title": "Tech Lead Full-Stack Rails Engineer", "company_name": "Mitre Media",
+        "company_logo": "https://remotive.com/job/2069746/logo", "category": "Software
+        Development", "tags": ["api", "CSS", "docker", "elasticsearch", "fullstack",
+        "html", "javascript", "kubernetes", "postgresql", "react", "ror", "ruby/rails",
+        "AI/ML", "CAD", "advertising", "Redis", "ES6", "web applications", "MySQL",
+        "NLP", "fintech", "Micro services", "github", "system architecture"], "job_type":
+        "full_time", "publication_date": "2026-04-14T21:01:45", "candidate_required_location":
+        "USA, Canada, USA timezones", "salary": "$170k - $200k", "description": "<p
+        class=\"h1\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 24pt; margin-bottom: 0pt; padding: 0pt 0pt 6pt 0pt;\"><span style=\"color:
+        #000000; font-weight: bold; white-space-collapse: preserve;\">About Mitre
+        Media</span></p>\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt; padding: 0pt 0pt 18pt 0pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">Mitre Media is redefining FinTech with AI-driven
+        tools that empower millions of investors. Our portfolio, including Dividend.com
+        and MutualFunds.com, leverages LLMs to deliver novel data insights and visually
+        rich user experiences. For over a decade, we\u2019ve served individual investors,
+        financial advisors, and top asset managers like BlackRock and Vanguard through
+        our premium data, tools, and advertising solutions. Join our lean, entrepreneurial
+        team to shape the future of AI-powered investing from your location \u00b13
+        hours from Eastern Time.</span></p>\n<p dir=\"ltr\" style=\"line-height: 1.38;
+        background-color: #ffffff; margin-top: 0pt; margin-bottom: 0pt; padding: 0pt
+        0pt 18pt 0pt;\"><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Our users are deeply
+        engaged, spending over 5 minutes per visit with a bounce rate below 10%, researching
+        investments across hundreds of different categories. With 40 million brokerage
+        accounts in the U.S., we take pride in building tools that make a real impact,
+        fostering a culture of trust, innovation, and dynamism. If you\u2019re passionate
+        about financial technology and AI, we\u2019d love to connect!</span></p>\n<p
+        class=\"h2\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt; padding: 14pt 0pt 18pt 0pt;\"><span style=\"color:
+        #000000; background-color: transparent; font-weight: bold; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">About the Role</span></p>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom: 0pt; padding:
+        0pt 0pt 18pt 0pt;\"><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">As a Full-Stack Rails
+        Tech Lead, you\u2019ll architect and implement LLM-powered web applications
+        within our microservices-based Rails 8 platform. Reporting directly to our
+        CTO, you\u2019ll collaborate with a small, high-impact team to deliver user
+        experiences across Dividend.com, MutualFunds.com and other brands within our
+        portfolio. This role combines expert Ruby on Rails skills with AI integration
+        expertise, requiring you to leverage LLMs in your development workflow, state
+        management and user interactions.</span></p>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom: 0pt; padding:
+        0pt 0pt 18pt 0pt;\"><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">You\u2019ll work
+        in a remote-first hybrid environment, which encourages in person collaboration,
+        using ShapeUp to manage projects that trade-off on-time delivery for de-scoped
+        outcomes. As a technical leader, you''ll have a seat at the table shaping
+        system architecture, implementing core features all while embracing an entrepreneurial
+        mindset and a \u201cget things done\u201d mentality.</span></p>\n<p class=\"h2\"
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 18pt; padding: 14pt 0pt 0pt 0pt;\"><span style=\"color:
+        #000000; background-color: transparent; font-weight: bold; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">Responsibilities</span></p>\n<ul style=\"\">\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 9pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Architect and maintain
+        Rails applications (Rails 8)</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Integrate LLMs into
+        our microservices architecture for state management and real-time user experiences.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Enhance
+        front-end experiences with Hotwire, StimulusJS, or React, ensuring seamless
+        AI-driven interactions.</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 27pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Optimize LLM inference
+        for low latency and cost, using caching and asynchronous processing.</span></p>\n</li>\n</ul>\n<p
+        class=\"h2\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 32pt; margin-bottom: 0pt; padding: 0pt 0pt 18pt 0pt;\"><span style=\"color:
+        #000000; background-color: transparent; font-weight: bold; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">Required Technical Skills</span></p>\n<p class=\"h3\" dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom:
+        9pt;\"><span style=\"color: #000000; background-color: transparent; font-weight:
+        bold; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">Back-End</span></p>\n<ul style=\"\">\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 9pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Ruby
+        (5+ years, expert-level)</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Ruby on Rails (Rails
+        6-8 preferred)</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom:
+        0pt;\"><span style=\"color: #000000; background-color: transparent; font-weight:
+        400; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">PostgreSQL (or MySQL)</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Elasticsearch</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Redis</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 27pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Docker</span></p>\n</li>\n</ul>\n<p
+        class=\"h3\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 22pt; margin-bottom: 9pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Front-End</span></p>\n<ul
+        style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 9pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">StimulusJS or JavaScript ES6</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Tailwind
+        CSS</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">HTML</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 27pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">HTTP</span></p>\n</li>\n</ul>\n<p
+        class=\"h3\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 22pt; margin-bottom: 9pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">AI
+        Integration</span></p>\n<ul style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 9pt; margin-bottom:
+        0pt;\"><span style=\"color: #000000; background-color: transparent; font-weight:
+        400; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">Experience integrating AI/ML models (e.g.,
+        LLMs, NLP) with web applications</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 27pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Familiarity with
+        LLM frameworks (e.g., LangChain, Hugging Face) or APIs (e.g., xAI, Anthropic)</span></p>\n</li>\n</ul>\n<p
+        class=\"h2\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 32pt; margin-bottom: 18pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Nice-to-Have
+        Technical Skills</span></p>\n<ul style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        9pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Kubernetes for microservices
+        orchestration</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom:
+        0pt;\"><span style=\"color: #000000; background-color: transparent; font-weight:
+        400; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">React for advanced front-end components</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Graph
+        databases for complex financial data</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 27pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Contributions to
+        open-source RoR or AI projects</span></p>\n</li>\n</ul>\n<p class=\"h2\" dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 32pt; margin-bottom:
+        18pt;\"><span style=\"color: #000000; background-color: transparent; font-weight:
+        bold; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">Required Soft Skills</span></p>\n<ul style=\"\">\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 9pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Entrepreneurial
+        mindset with a passion for AI and FinTech</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Natural leader who
+        mentors and inspires teammates</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Problem-solver with
+        a \u201cget things done\u201d mentality</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Excellent communication,
+        thriving in remote and cross-team collaboration</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Attention to detail,
+        ensuring clean, maintainable code</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 27pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Team player comfortable
+        as an individual contributor</span></p>\n</li>\n</ul>\n<p class=\"h2\" dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 32pt; margin-bottom:
+        18pt;\"><span style=\"color: #000000; background-color: transparent; font-weight:
+        bold; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">Why Join Us?</span></p>\n<ul style=\"\">\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 9pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Impactful
+        Work</span><span style=\"color: #000000; background-color: transparent; font-weight:
+        400; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">: Build AI-powered tools that help millions
+        of investors make informed decisions from data-driven insights.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Cutting-Edge
+        Tech</span><span style=\"color: #000000; background-color: transparent; font-weight:
+        400; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">: Work with Rails 8, LLMs, and modern tools
+        like Hotwire, Databricks, and xAI\u2019s API in a microservices architecture.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Autonomy
+        and Influence</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">: Collaborate directly
+        with our CEO and CTO to shape our AI-driven platform, with freedom to innovate.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Competitive
+        Compensation</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">: $160,000\u2013$200,000
+        CAD/USD (based on experience) and benefits.</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Remote
+        Flexibility</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">: Remote-first (\u00b13
+        hours from ET) with hybrid in office collaboration in Toronto or NYC</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Growth
+        Opportunities</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">: Budget for AI and
+        Rails conferences (e.g., NeurIPS, RailsConf), plus access to cutting-edge
+        AI tools for experimentation.</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 27pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Dynamic
+        Culture</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">: Join a small, no-ego
+        team passionate about trust, innovation, and making a difference in FinTech.</span></p>\n</li>\n</ul>\n<p
+        class=\"h2\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 32pt; margin-bottom: 0pt; padding: 0pt 0pt 18pt 0pt;\"><span style=\"color:
+        #000000; background-color: transparent; font-weight: bold; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">About Mitre Media\u2019s AI-Driven Platform</span></p>\n<p dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom:
+        0pt; padding: 0pt 0pt 18pt 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Mitre Media powers
+        premium financial brands like </span><a href=\"http://dividend.com/\" rel=\"nofollow\"
+        style=\"text-decoration: none;\"><span style=\"color: #1155cc; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        underline; -webkit-text-decoration-skip: none; text-decoration-skip-ink: none;
+        vertical-align: baseline; white-space: pre-wrap;\">Dividend.com</span></a><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\"> and </span><a href=\"http://mutualfunds.com/\" rel=\"nofollow\"
+        style=\"text-decoration: none;\"><span style=\"color: #1155cc; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        underline; -webkit-text-decoration-skip: none; text-decoration-skip-ink: none;
+        vertical-align: baseline; white-space: pre-wrap;\">MutualFunds.com</span></a><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\"> with the Mitre Platform. This platform integrates
+        traditional content management, financial data, first-party data, ad revenue,
+        and subscription tools, all enhanced by LLMs for rich, user-focused experiences.
+        Our data-derived insights delight users, while our advertising solutions deliver
+        unmatched performance for partners like BlackRock and Vanguard, leveraging
+        advanced targeting and first-party data.</span></p>\n<p class=\"h2\" dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom:
+        0pt; padding: 14pt 0pt 18pt 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">How
+        to Apply</span></p>\n<p>\u00a0</p>\n<p dir=\"ltr\" style=\"line-height: 1.38;
+        background-color: #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color:
+        #000000; background-color: transparent; font-weight: 400; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">Submit your resume, GitHub profile, and a brief note on why you\u2019re
+        excited about building AI-driven FinTech to jobs@mitremedia.com.</span></p>\n<img
+        src=\"https://remotive.com/job/track/2069746/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/2069746/logo"},
+        {"id": 2069747, "url": "https://remotive.com/remote-jobs/software-development/tech-lead-databricks-data-engineer-2069747",
+        "title": "Tech Lead Databricks Data Engineer", "company_name": "Mitre Media",
+        "company_logo": "https://remotive.com/job/2069747/logo", "category": "Software
+        Development", "tags": ["apache", "api", "AWS", "big data", "cloud", "java",
+        "python", "scala", "sql", "AI/ML", "documentation", "CAD", "CI/CD", "analytics",
+        "advertising", "spark", "tableau", "GCP", "ETL", "data engineering", "SOLID",
+        "fintech", "Micro services", "backbone", "github"], "job_type": "full_time",
+        "publication_date": "2026-04-14T21:01:37", "candidate_required_location":
+        "USA, Canada, USA timezones", "salary": "$160k - $180k", "description": "<div
+        class=\"h2\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 18pt; margin-bottom: 0pt; padding: 0pt 0pt 4pt 0pt;\"><span style=\"color:
+        #000000; background-color: transparent; font-weight: bold; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">About Mitre Media</span></div>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom: 0pt; padding:
+        8pt 0pt 12pt 0pt;\"><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Mitre Media is redefining
+        FinTech with AI-driven tools that empower millions of investors. Our portfolio,
+        including Dividend.com and MutualFunds.com, leverages LLMs to deliver novel
+        data insights and visually rich user experiences. For over a decade, we\u2019ve
+        served individual investors, financial advisors, and top asset managers like
+        BlackRock and Vanguard through our premium data, tools, and advertising solutions.
+        If you\u2019re excited by the intersection of big data, AI, and investing,
+        join our lean, entrepreneurial team from anywhere within \u00b13 hours of
+        Eastern Time.</span></p>\n<div class=\"h2\" dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom: 0pt; padding:
+        6pt 0pt 4pt 0pt;\"><span style=\"color: #000000; background-color: transparent;
+        font-weight: bold; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">About the Role</span></div>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 0pt; padding: 8pt 0pt 12pt 0pt;\"><span style=\"color:
+        #000000; background-color: transparent; font-weight: 400; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">As Tech Lead Data Engineer, you\u2019ll architect and maintain
+        the data backbone powering every feature across our product suite. Reporting
+        to the CTO, you will design Databricks-based ETL pipelines, model complex
+        investment data, and surface low-latency, high-quality datasets for both user-facing
+        features and internal AI/analytics workloads. You\u2019ll collaborate in a
+        remote-first hybrid culture that values in-person \u201cbursts\u201d of collaboration,
+        follow ShapeUp for project planning, and ship pragmatic solutions that favor
+        de-scoping over delays.</span></p>\n<div class=\"h2\" dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom: 4pt; padding:
+        6pt 0pt 0pt 0pt;\"><span style=\"color: #000000; background-color: transparent;
+        font-weight: bold; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Responsibilities</span></div>\n<ul
+        style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 12pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">Design, implement, and optimize large-scale ETL workflows
+        in Databricks (Apache Spark, Delta Lake, DBT).</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Develop algorithms
+        that transform raw market data into actionable insights.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Own
+        data quality and lineage, instituting tests, monitoring, and alerting for
+        mission-critical pipelines.</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Evolve our cloud
+        data platform (AWS &amp; GCP) for scale, performance, and cost efficiency.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 12pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Mentor
+        engineers, championing best practices in code reviews, documentation, and
+        DevOps for data.</span></p>\n</li>\n</ul>\n<div class=\"h2\" dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 18pt; margin-bottom: 0pt; padding:
+        0pt 0pt 4pt 0pt;\"><span style=\"color: #000000; background-color: transparent;
+        font-weight: bold; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Required Technical
+        Skills</span></div>\n<div class=\"h3\" dir=\"ltr\" style=\"line-height: 1.38;
+        background-color: #ffffff; margin-top: 0pt; margin-bottom: 4pt; padding: 10pt
+        0pt 0pt 0pt;\"><span style=\"color: #000000; background-color: transparent;
+        font-weight: bold; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Data Engineering</span></div>\n<ul
+        style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 12pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: bold;
+        font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">Programming</span><span style=\"color:
+        #000000; background-color: transparent; font-weight: 400; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">: Expert in Python plus working knowledge of Scala or Java.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Databricks
+        &amp; Spark</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">: Hands-on with cluster
+        tuning, job orchestration, and Delta Tables.</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">SQL
+        &amp; DBT</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">: Strong analytical
+        SQL, modular data-model design, and CI/CD for transformations.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Cloud</span><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">: Production experience on AWS or GCP data services
+        (e.g., S3/GCS, EMR/Dataproc, Glue/Dataflow).</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">ETL
+        &amp; Orchestration</span><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">: Solid grasp of
+        EL(T) patterns, workflow scheduling, and incremental processing.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 12pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Data
+        Modeling</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">: Dimensional and
+        schema-on-read designs for analytics and AI.</span></p>\n</li>\n</ul>\n<div
+        class=\"h3\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 14pt; margin-bottom: 4pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">AI
+        &amp; Analytics Enablement</span></div>\n<ul style=\"\">\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 12pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Building feature
+        stores or inference-ready tables for ML/LLM workflows.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 12pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Familiarity
+        with vector databases or embedding pipelines</span></p>\n</li>\n</ul>\n<div
+        class=\"h2\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 18pt; margin-bottom: 4pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Nice-to-Have
+        Technical Skills</span></div>\n<ul style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        12pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Apache Airflow, Luigi,
+        or Dagster for DAG orchestration.</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Experience with Looker,
+        Tableau, or Stripe\u2019s Vizier-style visualization stacks.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Financial-markets
+        domain knowledge (equities, ETFs, mutual funds).</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 12pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Machine-learning
+        engineering or statistical-analysis background.</span></p>\n</li>\n</ul>\n<div
+        class=\"h2\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 18pt; margin-bottom: 4pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Required
+        Soft Skills</span></div>\n<ul style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff; margin-top:
+        12pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Entrepreneurial mindset
+        with a passion for AI and FinTech innovation.</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Self-starter who
+        diagnoses problems, proposes trade-offs, and delivers.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Clear
+        communicator who thrives in distributed, cross-functional teams.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Mentorship
+        attitude\u2014uplifts peers through code reviews and knowledge-sharing.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 12pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Detail-oriented
+        and disciplined about data accuracy and documentation.</span></p>\n</li>\n</ul>\n<div
+        class=\"h2\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 18pt; margin-bottom: 4pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Why
+        Join Us?</span></div>\n<ul style=\"\">\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 12pt; margin-bottom:
+        0pt;\"><span style=\"color: #000000; background-color: transparent; font-weight:
+        bold; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">Impactful Work</span><span style=\"color:
+        #000000; background-color: transparent; font-weight: 400; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\"> \u2013 Your pipelines feed every insight we deliver to millions
+        of investors.</span></p>\n</li>\n<li dir=\"ltr\" style=\"\">\n<p dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom:
+        0pt;\"><span style=\"color: #000000; background-color: transparent; font-weight:
+        bold; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">Cutting-Edge Tech</span><span style=\"color:
+        #000000; background-color: transparent; font-weight: 400; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\"> \u2013 Databricks, Delta Lake, LLMs, Hotwire, and xAI\u2019s
+        API, all in a modern microservices stack.</span></p>\n</li>\n<li dir=\"ltr\"
+        style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Autonomy
+        &amp; Influence</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\"> \u2013 Work directly
+        with the CEO &amp; CTO to shape our data and AI strategy.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Competitive
+        Compensation</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\"> \u2013 $150k \u2013
+        $185k CAD/USD plus benefits and performance bonuses.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Remote
+        Flexibility</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\"> \u2013 Remote-first
+        within \u00b13 hrs ET; optional collaboration hubs in Toronto and NYC.</span></p>\n</li>\n<li
+        dir=\"ltr\" style=\"\">\n<p dir=\"ltr\" style=\"line-height: 1.38; background-color:
+        #ffffff; margin-top: 0pt; margin-bottom: 12pt;\"><span style=\"color: #000000;
+        background-color: transparent; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">Growth
+        Opportunities</span><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\"> \u2013 Budget for
+        conferences (e.g., Data+AI Summit, NeurIPS) and continuous learning.</span></p>\n</li>\n</ul>\n<div
+        class=\"h2\" dir=\"ltr\" style=\"line-height: 1.38; background-color: #ffffff;
+        margin-top: 32pt; margin-bottom: 0pt; padding: 0pt 0pt 18pt 0pt;\"><span style=\"color:
+        #000000; background-color: transparent; font-weight: bold; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">About Mitre Media\u2019s AI-Driven Platform</span></div>\n<p dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom:
+        0pt; padding: 0pt 0pt 18pt 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">Mitre Media powers
+        premium financial brands like </span><a href=\"http://dividend.com/\" rel=\"nofollow\"
+        style=\"text-decoration: none;\"><span style=\"color: #1155cc; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        underline; -webkit-text-decoration-skip: none; text-decoration-skip-ink: none;
+        vertical-align: baseline; white-space: pre-wrap;\">Dividend.com</span></a><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\"> and </span><a href=\"http://mutualfunds.com/\" rel=\"nofollow\"
+        style=\"text-decoration: none;\"><span style=\"color: #1155cc; background-color:
+        transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        underline; -webkit-text-decoration-skip: none; text-decoration-skip-ink: none;
+        vertical-align: baseline; white-space: pre-wrap;\">MutualFunds.com</span></a><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\"> with the Mitre Platform. This platform integrates
+        traditional content management, financial data, first-party data, ad revenue,
+        and subscription tools, all enhanced by LLMs for rich, user-focused experiences.
+        Our data-derived insights delight users, while our advertising solutions deliver
+        unmatched performance for partners like BlackRock and Vanguard, leveraging
+        advanced targeting and first-party data.</span></p>\n<div class=\"h2\" dir=\"ltr\"
+        style=\"line-height: 1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom:
+        0pt; padding: 14pt 0pt 18pt 0pt;\"><span style=\"color: #000000; background-color:
+        transparent; font-weight: bold; font-style: normal; font-variant: normal;
+        text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">How
+        to Apply</span></div>\n<p>\u00a0</p>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; background-color: #ffffff; margin-top: 0pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">Submit your resume, GitHub profile, and a brief note
+        on why you\u2019re excited about building AI-driven FinTech to jobs@mitremedia.com.</span></p>\n<img
+        src=\"https://remotive.com/job/track/2069747/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/2069747/logo"},
+        {"id": 2088710, "url": "https://remotive.com/remote-jobs/all-others/online-data-analyst-united-states-2088710",
+        "title": "Online Data Analyst United States", "company_name": "TELUS Digital",
+        "company_logo": "https://remotive.com/job/2088710/logo", "category": "All
+        others", "tags": ["go", "social media", "AI/ML", "research", "diversity"],
+        "job_type": "part_time", "publication_date": "2026-04-14T12:48:56", "candidate_required_location":
+        "USA", "salary": "", "description": "<p class=\"figma-padding-bottom-32 tw-border-b
+        tw-border-[#E3E6E8]\" style=\"border-bottom-width: 1px; border-color: rgb(227,
+        230, 232); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; --tw-border-opacity: 1; padding-bottom: 32px; color:
+        rgb(33, 37, 41); \"></p><p style=\"border-color: rgb(229, 231, 235); --tw-shadow:
+        0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">Are you a detail-oriented
+        individual with a passion for research and a good understanding of national
+        and local geography? This freelance opportunity allows you to work at your
+        own pace and from the comfort of your own home.</span></p><p style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; cursor: text; padding: 0px; counter-reset: list-1
+        0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><br
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ;\"></p><p style=\"border-color: rgb(229, 231, 235);
+        --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; font-weight: bolder; background-color: transparent;\">A
+        Day in the Life of an Online Data Analyst:</span></p><ul style=\"\"><li style=\"\"><span
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">In this role, you
+        will be working on a project aimed at enhancing the content and quality of
+        digital maps that are used by millions of people worldwide</span></li><li
+        style=\"\"><span style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0
+        0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; background-color: transparent;\">Completing research and evaluation tasks
+        in a web-based environment such as verifying and comparing data, and determining
+        the relevance and accuracy of information.</span></li></ul><p style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; cursor: text; padding: 0px; counter-reset: list-1
+        0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><br
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ;\"></p><p style=\"border-color: rgb(229, 231, 235);
+        --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">Join us today and
+        be part of a dynamic and innovative team that is making a difference in the
+        world!</span></p><p style=\"border-color: rgb(229, 231, 235); --tw-shadow:
+        0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><br style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ;\"></p><p style=\"border-color: rgb(229, 231, 235);
+        --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; font-weight: bolder; background-color: transparent;\">TELUS
+        Digital AI Community</span></p><p style=\"border-color: rgb(229, 231, 235);
+        --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">Our global AI Community
+        is a vibrant network of 1 million+ contributors from diverse backgrounds who
+        help our customers collect, enhance, train, translate, and localize content
+        to build better AI models. Become part of our growing community and make an
+        impact supporting the machine learning models of some of the world\u2019s
+        largest brands. </span></p><p class=\"pt-7 figma-padding-bottom-32 tw-border-b
+        tw-border-[#E3E6E8]\" style=\"border-bottom-width: 1px; border-color: rgb(227,
+        230, 232); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; --tw-border-opacity: 1; padding-bottom: 32px; color:
+        rgb(33, 37, 41);  padding-top: 2.5rem !important;\"></p><div class=\"h4\"
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; line-height: 1.75rem; color: rgb(65, 69, 71);  letter-spacing:
+        0px; --tw-text-opacity: 1; \">Qualification path</div><p style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; cursor: text; padding: 0px; counter-reset: list-1
+        0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">No previous professional
+        experience is required to apply to this role, however, working on this project
+        will require you to pass the basic requirements and go through a standard
+        assessment process. This is a part-time long-term project and your work will
+        be subject to our standard quality assurance checks during the term of this
+        agreement.\u00a0</span></p><p style=\"border-color: rgb(229, 231, 235); --tw-shadow:
+        0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><br style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ;\"></p><p style=\"border-color: rgb(229, 231, 235);
+        --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; font-weight: bolder; background-color: transparent;\">Basic
+        Requirements</span></p><ul style=\"\"><li style=\"\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">Full Professional
+        Proficiency in English language</span></li><li style=\"\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">Being a resident
+        in </span>United States f<span style=\"border-color: rgb(229, 231, 235); --tw-shadow:
+        0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; background-color: transparent;\">or the last 2 consecutive years and having
+        familiarity with current and historical business, media, sport, news, social
+        media, and cultural affairs in United States</span></li><li style=\"\"><span
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">Ability to follow
+        guidelines and conduct online research using search engines, online maps,
+        and website information</span></li><li style=\"\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">Flexibility to work
+        across a diverse set of task types, including maps, news, audio tasks, and
+        relevance</span></li><li style=\"\"><span style=\"border-color: rgb(229, 231,
+        235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px;
+        --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; background-color: transparent;\">Daily access to a broadband internet connection,
+        computer, and relevant software</span></li></ul><p style=\"border-color: rgb(229,
+        231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; cursor: text; padding: 0px; counter-reset: list-1
+        0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><br
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ;\"></p><p style=\"border-color: rgb(229, 231, 235);
+        --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; font-weight: bolder; background-color: transparent;\">Assessment</span></p><p
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; cursor: text; padding: 0px; counter-reset: list-1
+        0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">In order to be hired
+        into the program, you\u2019ll take an open book qualification exam that will
+        determine your suitability for the position and complete ID verification.
+        Our team will provide you with guidelines and learning materials before your
+        qualification exam. You will be required to complete the exam in a specific
+        timeframe but at your convenience.</span></p><p style=\"border-color: rgb(229,
+        231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; cursor: text; padding: 0px; counter-reset: list-1
+        0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><br
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ;\"></p><p style=\"border-color: rgb(229, 231, 235);
+        --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y:
+        ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position:
+        ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal:
+        ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction:
+        ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast:
+        ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia:
+        ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast:
+        ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert:
+        ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia:
+        ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style:
+        ; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3 0 list-4
+        0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span style=\"border-color:
+        rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset: ; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x:
+        ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity;
+        --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; font-weight: bolder;\">Equal Opportunity</span></p><p
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; cursor: text; padding: 0px; counter-reset: list-1
+        0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><span
+        style=\"border-color: rgb(229, 231, 235); --tw-shadow: 0 0 #0000; --tw-ring-inset:
+        ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness:
+        proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position:
+        ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing:
+        ; --tw-numeric-fraction: ; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness:
+        ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate:
+        ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness:
+        ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate:
+        ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate:
+        ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint:
+        ; --tw-contain-style: ; background-color: transparent;\">All qualified applicants
+        will receive consideration for a contractual relationship without regard to
+        race, color, religion, sex, sexual orientation, gender identity, national
+        origin, disability, or protected veteran status. At TELUS Digital AI, we are
+        proud to offer equal opportunities and are committed to creating a diverse
+        and inclusive community. All aspects of selection are based on applicants\u2019
+        qualifications, merits, competence, and performance without regard to any
+        characteristic related to diversity.</span></p>\n<img src=\"https://remotive.com/job/track/2088710/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/2088710/logo"},
+        {"id": 1680495, "url": "https://remotive.com/remote-jobs/marketing/office-assistant-1680495",
+        "title": "Office Assistant", "company_name": "Coalition Technologies ", "company_logo":
+        "https://remotive.com/job/1680495/logo", "category": "Marketing", "tags":
+        ["CSS", "excel", "frontend", "git", "html", "illustrator", "magento", "photoshop",
+        "php", "shopify", "wordpress", "MySQL", "startup", "responsive", "themes",
+        "bootstrap", "insurance", "jQuery", "Ajax"], "job_type": "full_time", "publication_date":
+        "2026-04-11T20:16:26", "candidate_required_location": "Worldwide", "salary":
+        "$31,2k- $52k", "description": "<p class=\"h3\">WHY YOU SHOULD APPLY:</p>\n<p>\u00a0</p>\n<p>Coalition
+        Technologies is devoted to delivering clients the highest quality work while
+        providing our team a fun, thriving, and innovative environment. Along with
+        the opportunity for tremendous career growth and rapid advancement, CT offers:</p>\n<ul
+        style=\"\">\n<li style=\"\">The most competitive profit-sharing bonus plan
+        in the industry, paying up to 50% of company profits to full-time employees
+        each month!</li>\n<li style=\"\">A highly competitive Paid Time Off plan,
+        promoting quality work-life balance.</li>\n<li style=\"\">Subsidized gym memberships
+        to help team members feel their best.</li>\n<li style=\"\">Medical, dental,
+        vision, and life insurance packages for all US-based team members.</li>\n<li
+        style=\"\">International Health Insurance Reimbursement Program for all international
+        team members, a benefit unique to Coalition.</li>\n<li style=\"\">Device upgrade
+        and learning reimbursement programs.</li>\n<li style=\"\">Motivating career
+        development plans with clearly defined goals and rewards.</li>\n<li style=\"\">Additional
+        job-specific incentives and bonuses.<br><br></li>\n</ul>\n<p>Plus, 100% of
+        our team works remotely with the support of time tracking software. Our company
+        culture specializes in supporting remote team members, and we\u2019ve been
+        doing so for more than a decade. CT welcomes your application, wherever in
+        the world it''s coming from!</p>\n<p class=\"h3\">\u00a0</p>\n<p class=\"h3\">YOU
+        SHOULD HAVE:</p>\n<p>\u00a0</p>\n<ul style=\"\">\n<li style=\"\">Willingness
+        to learn, grow, and collaborate with the team and company as a whole.</li><li
+        style=\"\">Excellent verbal and written communication skills.</li><li style=\"\">A
+        high level of discretion, ethics, and trustworthiness.</li><li style=\"\">Intermediate
+        spreadsheet skills (preferred)</li><li style=\"\">Innovative thinking and
+        a willingness to challenge existing methods where improvement is possible.</li><li
+        style=\"\">Experience in bookkeeping / financial record keeping (preferred).</li><li
+        style=\"\">Experience with Google Sheets or Excel, Quickbooks Online, and
+        G-Suite (preferred).</li><li style=\"\">The availability to work 40 hours
+        per week from 9:00 am to 6:00 pm PST.</li><li style=\"\">A reliable space
+        to work remotely with a fast computer, quality internet, camera, microphone,
+        and speakers.</li>\n</ul>\n<p class=\"h3\">\u00a0</p>\n<p class=\"h3\">YOUR
+        DUTIES AND TASKS:</p>\n<p>\u00a0</p>\n<ul style=\"\">\n<li style=\"\">Answering
+        phones and emails.</li><li style=\"\">Completing entry-level bookkeeping,
+        including recording expenses, organizing receipts, and completing other transaction
+        records.</li><li style=\"\">Resolving billing issues with clients and internal
+        team members.</li><li style=\"\">Providing account access, usage reports,
+        data analysis, and other ad hoc requests for team members.</li><li style=\"\">Supporting
+        quality assurance checks of various internal and client facing reporting.</li><li
+        style=\"\">Organizing new client contracts, create invoices, and process client
+        payments.</li><li style=\"\">Contributing to internal database maintenance,
+        upkeep and data entry.</li><li style=\"\">Researching, ordering, &amp; distributing
+        company-wide gifts (2-3 times per year).</li><li style=\"\">Organizing company
+        events, competitions, and special projects throughout the year.</li><li style=\"\">Facilitating
+        company holiday, time off, and schedule variation calendars.</li>\n</ul>\n<p
+        class=\"h5\">\u00a0</p>\n<p class=\"h5\">We are looking for talented and diligent
+        candidates who excel in our skills tests, and will consider these candidates
+        even if past experience or educational background criteria aren''t met.</p>\n<p
+        class=\"h5\">\u00a0</p>\n<p>*California, New York, Washington, and Colorado:
+        starting base pay for this position ranges between $15 - $25 per hour.</p>\n<p>Compensation
+        may vary based on factors such as experience, qualifications, skills test
+        performance, geographic location, and seniority of the position offered. Outside
+        of California, New York, Washington, and Colorado compensation may fall outside
+        the above ranges.</p>\n<img src=\"https://remotive.com/job/track/1680495/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/1680495/logo"},
+        {"id": 2088708, "url": "https://remotive.com/remote-jobs/software-development/senior-staff-software-engineer-php-ts-rust-kotlin-m-w-d-2088708",
+        "title": "\ud83c\udde9\ud83c\uddea Senior/Staff Software Engineer PHP, TS,
+        Rust, Kotlin (m/w/d)", "company_name": "easybill GmbH", "company_logo": "https://remotive.com/job/2088708/logo",
+        "category": "Software Development", "tags": ["backend", "docker", "elasticsearch",
+        "frontend", "go", "java", "php", "react", "kotlin", "rust", "Typescript ",
+        "Redis", "MySQL", "Symfony", "debugging", "Micro services", "github"], "job_type":
+        "full_time", "publication_date": "2026-04-10T14:54:45", "candidate_required_location":
+        "Germany", "salary": "", "description": "<p><strong>\ud83c\udde9\ud83c\uddea
+        This job ad is written in German. \ud83c\udde9\ud83c\uddea</strong></p>\n<p><strong>easybill</strong>
+        ist eine cloudbasierte Rechnungssoftware, die sich durch einfache Anwendung,
+        umfassende Funktionalit\u00e4t und vielf\u00e4ltige Anbindungen \u00fcber
+        Schnittstellen schon seit mehr als 18 Jahren am Markt behauptet. Aktuell haben
+        wir mehr als 21.000 aktive Kunden und wachsen stetig weiter. Deshalb suchen
+        wir nach einer motivierten Verst\u00e4rkung f\u00fcr unser Team.</p>\n<p>Bei
+        easybill arbeiten wir Remote-First, dein Wohnort ist uns egal - wir suchen
+        die besten Kollegen*, nicht die sch\u00f6nste Stadt. Unsere festen Standorte
+        befinden sich in Hamburg und Willich. Bei regelm\u00e4\u00dfigen Team-Events
+        kommen wir trotzdem gerne zusammen, um uns auszutauschen und auch mal zu feiern.</p>\n<p>Das
+        ideale Profil: PHP-, TypeScript- und Rust-Expertise, Founding-Engineer-Vibes
+        und eine starke Pr\u00e4senz auf GitHub. Passt das Profil nicht vollst\u00e4ndig,
+        bist du aber ein au\u00dfergew\u00f6hnlich starker Engineer, bewirb dich trotzdem
+        und zeig uns, was du gebaut hast.</p>\n<div class=\"h2\">Aufgaben</div>\n<p>Wir
+        sind ein sehr motiviertes Team aus Softwareentwicklern. Als Teil des Teams
+        w\u00fcrdest du neue Features und/oder Skalierungsl\u00f6sungen entwickeln.
+        Ownership ist uns wichtig. Wir erwarten hohe Eigenverantwortung, die Motivation,
+        komplette Projekte umzusetzen, und den Willen, die E-Rechnungslandschaft mitzuformen.</p>\n<p>Die
+        Hauptanwendung ist in PHP / TypeScript geschrieben, wir entwickeln aber auch
+        in Kotlin und bevorzugt Rust. Wir nutzen intensiv MySQL (Percona XtraDB Cluster),
+        TiDB, Elasticsearch, Redis, MinIO, Docker und einiges mehr. Der Umgang mit
+        mehreren Programmiersprachen wird jedoch vorausgesetzt.</p>\n<ul style=\"\">\n<li
+        style=\"\">Eigenst\u00e4ndiges, motiviertes und selbstorganisiertes Arbeiten
+        \u2013 wir investieren gerne in unsere Kollegen, haben aber auch hohe Erwartungen.</li>\n<li
+        style=\"\">Backend-Entwicklung (PHP + Symfony)</li>\n<li style=\"\">Frontend-Entwicklung
+        (TypeScript + React + TanStack)</li>\n<li style=\"\">Entwicklung von Microservices
+        via Rust / Java</li>\n<li style=\"\">Migration von PHP-Code zu Rust.</li>\n<li
+        style=\"\">Migrationen von Daten, Refactoring</li>\n<li style=\"\">Fehleranalyse
+        und Debugging</li>\n<li style=\"\">Du musst verstanden haben, wie man KI als
+        Produktivit\u00e4tshebel verwendet. Wir erwarten intensiven Einsatz von Claude
+        Code.</li>\n<li style=\"\">ggf. Arbeiten an der Infrastruktur und lokalen
+        dockerisierten Entwicklungsumgebungen</li>\n</ul>\n<div class=\"h2\">Qualifikation</div>\n<p>Grunds\u00e4tzlich
+        musst du nicht alles k\u00f6nnen. Uns ist wichtig, dass du uns zeigen kannst,
+        dass du dich in deinem aktuellen Technologie-Stack richtig gut auskennst und
+        uns glaubhaft machen kannst, dass du bereit bist, unseren Stack z\u00fcgig
+        zu lernen.</p>\n<ul style=\"\">\n<li style=\"\">Tiefe Kenntnisse im Bereich
+        der Softwareentwicklung. Eingesetzt wird viel PHP und/oder je nach Schwerpunkt
+        TypeScript, zudem haben wir etwas Java sowie Rust im Stack. Bist du Experte
+        im Umgang mit Rust, Java, Go, Zig oder anderen Sprachen, lernen wir dich aber
+        auch gerne kennen.</li>\n<li style=\"\">Bonus: Erfahrung mit Rust, DSA, TS,
+        verteilten Systemen, datenlastigen Anwendungen</li>\n<li style=\"\">Bonus:
+        Open-Source-Contributions oder \u00f6ffentliche Experimente (GitHub)</li>\n<li
+        style=\"\">Sprache: Flie\u00dfend Deutsch und gute Englischkenntnisse</li>\n</ul>\n<div
+        class=\"h2\">Benefits</div>\n<ul style=\"\">\n<li style=\"\"><strong>Deutschlandweit</strong>
+        Remote-First Team \u2013 keine Bindung an einen Standort</li>\n<li style=\"\">Workation
+        auf Mallorca - Unsere Mitarbeiter* haben die M\u00f6glichkeit, die<br>angemietete
+        Villa auf Mallorca f\u00fcr eine inspirierende Kombination aus<br>Arbeit und
+        Erholung zu nutzen</li>\n<li style=\"\">Hoher Impact</li>\n<li style=\"\">Eine
+        inspirierende und flexible Arbeitsumgebung, die auf Vertrauen und Eigenverantwortung
+        basiert.</li>\n<li style=\"\">Wir sind ein offenes, motiviertes und nettes
+        Team mit flacher Hierarchie</li>\n<li style=\"\">Keine Sprints und k\u00fcnstlich
+        erzeugter Druck</li>\n<li style=\"\">Faire Verg\u00fctungspakete und Entwicklungsm\u00f6glichkeiten</li>\n<li
+        style=\"\">30 Tage Jahresurlaub und einen unbefristeten Arbeitsvertrag</li>\n<li
+        style=\"\">Arbeitszeiten sind flexibel und werden mit dem Team abgestimmt</li>\n<li
+        style=\"\">Freiwillige Mitarbeiter-Events</li>\n<li style=\"\">Aktuelle MacBook
+        Pros</li>\n<li style=\"\">Schulungen/Weiterbildungsm\u00f6glichkeiten im Wert
+        von bis zu 1.500 Euro pro Jahr</li>\n</ul>\n<p>Wir haben vielf\u00e4ltige
+        Herausforderungen und suchen einen motivierten Teamplayer! Wenn du dich hierin
+        wiedererkennst und eine neue Herausforderung suchst, freuen wir uns auf deine
+        Bewerbung.</p>\n<p>Wir freuen uns auf dich!</p>\n<img src=\"https://remotive.com/job/track/2088708/blank.gif?source=public_api\"
+        alt=\"\"/>"}, {"id": 1956455, "url": "https://remotive.com/remote-jobs/software-development/ios-developer-1956455",
+        "title": "iOS Developer", "company_name": "nooro", "company_logo": "https://remotive.com/job/1956455/logo",
+        "category": "Software Development", "tags": ["api", "backend", "git", "ios",
+        "security", "swift", "UI/UX", "Figma", "agile", "healthcare", "startup", "core
+        data", "github", "REST", "MVVM", "mobile development"], "job_type": "full_time",
+        "publication_date": "2026-04-09T21:15:48", "candidate_required_location":
+        "USA", "salary": "$60k-$130k (depending on experience)", "description": "<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\"><span style=\"box-sizing: inherit; margin:
+        var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        background: var(--artdeco-reset-base-background-transparent); outline: var(--artdeco-reset-base-outline-zero);\"><strong>WHO
+        ARE WE?</strong></span></p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">At nooro, we''re revolutionizing
+        pain management for seniors. Our platform is transforming how older adults
+        engage with pain management at home. We''re on a mission to make wellness
+        more accessible and effective through technology.</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">Check our website here: https://nooro-us.com/</p>\n<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">We''re a fast-moving startup
+        that works on quick iteration and bold decisions. Our team is lean, agile,
+        and empowered to make meaningful impacts daily. If you enjoy a dynamic environment
+        where ideas become a reality at lightning speed and you''re not afraid to
+        wear multiple hats, you''ll fit right in.</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\"><span style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        background: var(--artdeco-reset-base-background-transparent); outline: var(--artdeco-reset-base-outline-zero);\"><strong>WHAT
+        WILL YOU DO?</strong></span></p>\n<p style=\"box-sizing: inherit; margin:
+        var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">- Own and drive the development
+        of our iOS application</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Build elegant, performant features using
+        **Swift (We\u2019re 100% Swift!)** and **SwiftUI**</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">- Implement complex UI/UX designs
+        from **Figma** with pixel-perfect accuracy</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">- Ensure app performance, quality,
+        and responsiveness</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Collaborate with our backend team on API
+        integration</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Write clean, modular, and reusable code</p>\n<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Participate in code reviews and architectural
+        decisions</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Help shape our mobile development practices</p>\n<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\"><span style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        background: var(--artdeco-reset-base-background-transparent); outline: var(--artdeco-reset-base-outline-zero);\"><strong>HOW
+        TO APPLY? </strong></span></p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5;\"><span style=\"color: rgba(0, 0, 0, 0.9); font-weight:
+        var(--artdeco-reset-typography-font-weight-bold);\">If you believe we''re
+        the right fit, please fill in this form:\u00a0</span><a href=\"https://forms.gle/xeL6pPbdjMHo11A28\"
+        rel=\"nofollow\" target=\"_self\"><span style=\"color: #000000;\"><span style=\"letter-spacing:
+        0.75px;\"><strong>https://forms.gle/xeL6pPbdjMHo11A28</strong></span></span></a></p>\n<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\"><span style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        background: var(--artdeco-reset-base-background-transparent); outline: var(--artdeco-reset-base-outline-zero);\"><strong>WHAT
+        ARE THE REQUIREMENTS?</strong></span></p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">- 5+ years of professional
+        iOS development experience</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Strong expertise in Swift and SwiftUI</p>\n<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Deep understanding of iOS platform capabilities
+        and limitations</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Experience with iOS app architecture (MVVM
+        preferred)</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Experience with Core Data and local storage
+        solutions</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Proficiency in making RESTful API calls
+        and handling responses</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Experience with dependency injection on
+        iOS</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Strong version control skills with Git/GitHub</p>\n<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Experience with App Store deployment and
+        TestFlight</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Knowledge of iOS security best practices</p>\n<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\"><span style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        background: var(--artdeco-reset-base-background-transparent); outline: var(--artdeco-reset-base-outline-zero);\"><strong>APPLYING
+        PROCESS</strong></span></p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">STEP 1 | QUESTIONNAIRE: <span
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); background:
+        var(--artdeco-reset-base-background-transparent); outline: var(--artdeco-reset-base-outline-zero);\"><span
+        style=\"font-weight: var(--artdeco-reset-typography-font-weight-bold);\">If
+        you believe we''re the right fit, please fill in this form:\u00a0</span></span><a
+        href=\"https://forms.gle/xeL6pPbdjMHo11A28\" rel=\"nofollow\" style=\"color:
+        #394050; text-decoration: none; background-color: #ffffff;\" target=\"_self\"><span
+        style=\"color: #000000;\"><span style=\"letter-spacing: 0.75px;\"><span style=\"font-weight:
+        600;\">https://forms.gle/xeL6pPbdjMHo11A28</span></span></span></a></p>\n<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">STEP 2 | TEST: Once we review
+        your form submission, we will send you a test</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">STEP 3 | TECHNICAL INTERVIEW:
+        Once we review your test submission, you will have a call with our development
+        leader</p>\n<p style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">STEP 4 | BEHAVIORAL INTERVIEW:
+        After the technical interview, you will have a call with our CEO to talk about
+        the way our company and team members operate in general</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\"><span style=\"box-sizing: inherit;
+        margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        background: var(--artdeco-reset-base-background-transparent); outline: var(--artdeco-reset-base-outline-zero);\"><strong>WHAT
+        DO WE OFFER?</strong></span></p>\n<p style=\"box-sizing: inherit; margin:
+        var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">\u00a0</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">- 100% remote work environment</p>\n<p
+        style=\"box-sizing: inherit; margin: var(--artdeco-reset-base-margin-zero);
+        padding: var(--artdeco-reset-base-padding-zero); border: var(--artdeco-reset-base-border-zero);
+        vertical-align: var(--artdeco-reset-base-vertical-align-baseline); line-height:
+        1.5; color: rgba(0, 0, 0, 0.9);\">- Competitive compensation</p>\n<p style=\"box-sizing:
+        inherit; margin: var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">- Opportunity to make a meaningful
+        impact in healthcare technology</p>\n<p style=\"box-sizing: inherit; margin:
+        var(--artdeco-reset-base-margin-zero); padding: var(--artdeco-reset-base-padding-zero);
+        border: var(--artdeco-reset-base-border-zero); vertical-align: var(--artdeco-reset-base-vertical-align-baseline);
+        line-height: 1.5; color: rgba(0, 0, 0, 0.9);\">- Collaborative, innovative
+        team culture</p>\n<img src=\"https://remotive.com/job/track/1956455/blank.gif?source=public_api\"
+        alt=\"\"/>"}, {"id": 2088707, "url": "https://remotive.com/remote-jobs/software-development/senior-frontend-developer-2088707",
+        "title": "Senior Frontend Developer", "company_name": "Sanctuary Computer",
+        "company_logo": "https://remotive.com/job/2088707/logo", "category": "Software
+        Development", "tags": ["api", "backend", "CSS", "ecommerce", "frontend", "fullstack",
+        "graphql", "postgresql", "redux", "security", "seo", "shopify", "open source",
+        "paas", "product management", "documentation", "mentoring", "Typescript ",
+        "Redis", "web applications", "cypress", "data visualization", "firebase",
+        "IoT", "engineering management", "runtime", "responsive", "prismic", "testing",
+        "next.js", "CMS", "jest", "REST", "web sockets", "performance optimization"],
+        "job_type": "contract", "publication_date": "2026-04-08T16:15:21", "candidate_required_location":
+        "LATAM, Asia", "salary": "$80k - $120k", "description": "<p><span style=\"color:
+        #050c26;\">We are hiring a contract-based\u00a0</span><span style=\"box-sizing:
+        inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; font-weight: 600; color: #050c26;\">Senior Frontend Developer</span><span
+        style=\"color: #050c26;\">\u00a0for the garden3d creative collective with
+        a focus on LATAM &amp; Asia candidates.</span></p>\n<p><span style=\"color:
+        #050c26;\">\u00a0</span></p>\n<p style=\"box-sizing: inherit; margin-bottom:
+        16px; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; padding: 0px; color: #050c26;\"><span style=\"box-sizing: inherit;
+        --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y:
+        0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y:
+        1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000;
+        --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; font-weight: 600;\">This job posting here in Remotive is for sharing
+        purposes only</span>\u00a0and does not serve as the direct application for
+        the role. To be considered, please complete our application form\u00a0<a href=\"https://garden3d.notion.site/1f1131fea2c78095922ec7e09bd96101?pvs=105\"
+        rel=\"nofollow\" target=\"_self\"><strong>here</strong></a>\u00a0to apply</p>\n<p
+        style=\"box-sizing: inherit; margin-bottom: 16px; --tw-border-spacing-x: 0;
+        --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px; color: #050c26;\"><span style=\"box-sizing: inherit; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\"><span
+        style=\"color: #143fcd;\"><span style=\"box-sizing: inherit; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\"><a href=\"https://garden3d.notion.site/Senior-Frontend-Developer-2c6131fea2c780dea224d76e942c6311?source=copy_link\"
+        rel=\"nofollow\" target=\"_self\">Original job posting link</a></span></span></span></p>\n<p
+        class=\"h2\" style=\"box-sizing: inherit; margin-top: 32px; margin-bottom:
+        16px; font-weight: bold; color: #050c26; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px;\">\ud83c\udf0e<span style=\"box-sizing: inherit; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">About\u00a0<a
+        href=\"https://garden3d.net/\" rel=\"nofollow\" style=\"box-sizing: inherit;
+        color: #143fcd; text-decoration: none; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\" target=\"_blank\">garden3d</a></span></p>\n<p
+        style=\"box-sizing: inherit; margin-bottom: 16px; --tw-border-spacing-x: 0;
+        --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px; color: #050c26;\">We are worker owned creative collective, innovating
+        on everything from brands and IRL communities to IoT devices and cross platform
+        apps. We share profit, open source everything, spin out new businesses, and
+        invest in exciting ideas through financial and/or in-kind contributions.</p>\n<p
+        style=\"box-sizing: inherit; margin-bottom: 16px; --tw-border-spacing-x: 0;
+        --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px; color: #050c26;\">Our client roster includes\u00a0<a href=\"https://www.google.com/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Google</a>,\u00a0<a href=\"https://stripe.com/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Stripe</a>,\u00a0<a href=\"https://www.figma.com/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Figma</a>,\u00a0<a href=\"https://hinge.co/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Hinge</a>,\u00a0<a href=\"https://blacksocialists.us/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Black Socialists in America</a>,\u00a0<a href=\"https://www.aclu.org/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">ACLU</a>,\u00a0<a href=\"https://www.pratt.edu/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Pratt</a>,\u00a0<a href=\"https://www.newschool.edu/parsons/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Parsons</a>,\u00a0<a href=\"https://www.mozilla.org/en-US/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Mozilla</a>,\u00a0<a href=\"https://www.nobelprize.org/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">The Nobel Prize</a>,\u00a0<a href=\"https://www.mit.edu/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">MIT</a>,\u00a0<a href=\"https://www.gnosis.io/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Gnosis</a>,\u00a0<a href=\"https://www.etsy.com/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Etsy</a>\u00a0&amp;\u00a0<a href=\"https://gagosian.com/\"
+        rel=\"nofollow\" style=\"box-sizing: inherit; color: #143fcd; text-decoration:
+        none; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000;\" target=\"_blank\">Gagosian</a>.</p>\n<p style=\"box-sizing: inherit;
+        margin-bottom: 16px; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; padding: 0px; color: #050c26;\">We\u2019re the software team behind
+        innovative products like\u00a0<a href=\"https://www.thelightphone.com/\" rel=\"nofollow\"
+        style=\"box-sizing: inherit; color: #143fcd; text-decoration: none; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\" target=\"_blank\">The
+        Light Phone</a>\u00a0&amp;\u00a0<a href=\"https://www.mill.com/\" rel=\"nofollow\"
+        style=\"box-sizing: inherit; color: #143fcd; text-decoration: none; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\" target=\"_blank\">Mill</a>,
+        and we operate a global, decentralized community space collective called\u00a0<a
+        href=\"https://www.index-space.org/\" rel=\"nofollow\" style=\"box-sizing:
+        inherit; color: #143fcd; text-decoration: none; --tw-border-spacing-x: 0;
+        --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\" target=\"_blank\">Index
+        Space</a>.</p>\n<p style=\"box-sizing: inherit; margin-bottom: 16px; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px; color: #050c26;\">We think of our garden3d as collective for creative
+        people, prioritizing a happy, talented, and diverse studio culture. We work
+        on projects that bring value to our world, and we balance deep care for the
+        work we do with a genuine curiosity about life outside of our jobs.</p>\n<p
+        class=\"h2\" style=\"box-sizing: inherit; margin-top: 32px; margin-bottom:
+        16px; font-weight: bold; color: #050c26; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px;\">\ud83d\udd2e\u00a0<span style=\"box-sizing: inherit; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Who we\u2019re
+        looking for:</span></p>\n<p style=\"box-sizing: inherit; margin-bottom: 16px;
+        --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y:
+        0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y:
+        1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000;
+        --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; padding: 0px; color: #050c26;\">We''re looking for a\u00a0<span
+        style=\"box-sizing: inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">Senior Frontend Developer</span>\u00a0who excels at building pixel-perfect
+        websites using modern frontend frameworks. You''ll collaborate with our team
+        to build elegant, performant, and visually stunning web experiences. Your
+        work will span a diverse range of client projects, from immersive brand websites
+        to complex web applications, all requiring a keen eye for detail and technical
+        excellence.</p>\n<p style=\"box-sizing: inherit; margin-bottom: 16px; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px; color: #050c26;\"><span style=\"box-sizing: inherit; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">This hiring effort will focus on Front-End Developers based in the
+        LATAM or ASIA.</span></p>\n<p style=\"box-sizing: inherit; margin-bottom:
+        16px; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; padding: 0px; color: #050c26;\">In this role, you\u2019ll work
+        on a variety of client projects to find cost-effective, high-quality, pragmatic
+        solutions to complex problems. Responsibilities will include:</p>\n<ul style=\"\">\n<li
+        style=\"\">Collaborating with Technical Lead to meet clients'' development
+        needs</li>\n<li style=\"\">Building and maintaining high-performance web applications
+        with modern frontend frameworks and tools</li>\n<li style=\"\">Implementing
+        responsive, accessible, and pixel-perfect user interfaces based on design
+        specifications</li>\n<li style=\"\">Integrating frontend applications with
+        headless CMS platforms, APIs, and third-party services</li>\n<li style=\"\">Optimizing
+        application performance, including bundle size, load times, and runtime efficiency</li>\n<li
+        style=\"\">Architecting scalable component libraries and design systems for
+        consistency across projects</li>\n<li style=\"\">Writing clear documentation
+        for code maintenance and usage</li>\n<li style=\"\">Participating in project
+        team meetings, including Sprint Planning, daily standups, and retrospectives</li>\n<li
+        style=\"\">Participating in code reviews, providing constructive feedback
+        to teammates and ensuring adherence to best practices</li>\n</ul>\n<p style=\"box-sizing:
+        inherit; margin-bottom: 16px; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px; color: #050c26;\">\u00a0</p>\n<p style=\"box-sizing: inherit; margin-bottom:
+        16px; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; padding: 0px; color: #050c26;\">The person we\u2019re looking for
+        is happy, relaxed and easy to get along with. They\u2019re flexible on anything
+        except conceits that will lower their usually outstanding work quality. They
+        work \u201csmart\u201d, by carefully managing their workflow and staggering
+        features that have dependencies intelligently \u2014 they prefer deep work
+        but are OK coming up to the surface now and then for top level / strategic
+        conversations.</p>\n<p style=\"box-sizing: inherit; margin-bottom: 16px; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px; color: #050c26;\">\u00a0</p>\n<p style=\"box-sizing: inherit; margin-bottom:
+        16px; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; padding: 0px; color: #050c26;\">We believe people with backgrounds
+        or interests in design, art, music, food or fashion tend to have a well rounded
+        sense of design &amp; quality \u2014 so a variety of hobbies or side projects
+        is a big nice to have!</p>\n<p style=\"box-sizing: inherit; margin-bottom:
+        16px; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; padding: 0px; color: #050c26;\"><span style=\"box-sizing: inherit;
+        --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y:
+        0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y:
+        1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000;
+        --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; font-weight: 600;\">Must Have Competencies:</span></p>\n<p style=\"box-sizing:
+        inherit; margin-bottom: 16px; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px; color: #050c26;\">We\u2019re always pitching for new and exciting technology
+        niches. Some of the areas below are relevant to us!</p>\n<ul style=\"\">\n<li
+        style=\"\">8+ years writing highly performant frontend code, an obsession
+        for 95+ Lighthouse scores</li>\n<li style=\"\">Expert level experience with
+        Typescript, and one of Next.js, Nuxt, Svelte, Vue</li>\n<li style=\"\">Extensive
+        experience with headless CMS like Sanity, Contentful, Prismic or more</li>\n<li
+        style=\"\">Fluency in industry standard PaaS like Vercel, Netlify, Firebase,
+        etc</li>\n<li style=\"\">Fluency in eCommerce technologies like Shopify (headless
+        &amp; liquid), Stripe, Swell and others</li>\n<li style=\"\">Experience building
+        accessible, responsive interfaces with attention to performance optimization
+        and SEO best practices</li>\n<li style=\"\">Strong understanding of modern
+        CSS methodologies (Tailwind, CSS Modules, etc) and animation libraries</li>\n<li
+        style=\"\">Experience with state management solutions (Redux, Zustand, Pinia)
+        and API integration patterns</li>\n<li style=\"\">Proficiency with testing
+        frameworks (Jest, Playwright, Cypress) and commitment to writing maintainable,
+        well-documented code</li>\n<li style=\"\">Experience with design systems and
+        component libraries, working closely with designers to ensure pixel-perfect
+        implementations</li>\n<li style=\"\"><span style=\"box-sizing: inherit; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000;\">Real-time
+        &amp; performance optimization</span>: experience with WebSockets for live
+        data updates, caching strategies (Redis, CDN-level caching), CDN configuration
+        and optimization (Cloudflare, Fastly), and image optimization techniques including
+        proxies and delivery networks</li>\n</ul>\n<p style=\"box-sizing: inherit;
+        margin-bottom: 16px; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; padding: 0px; color: #050c26;\"><span style=\"box-sizing: inherit;
+        --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y:
+        0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y:
+        1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000;
+        --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; font-weight: 600;\">\u00a0</span></p>\n<p style=\"box-sizing: inherit;
+        margin-bottom: 16px; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; padding: 0px; color: #050c26;\"><span style=\"box-sizing: inherit;
+        --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y:
+        0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y:
+        1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000;
+        --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; font-weight: 600;\">Nice to Have Competencies:</span></p>\n<p style=\"box-sizing:
+        inherit; margin-bottom: 16px; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; padding:
+        0px; color: #050c26;\">We\u2019re always pitching for new and exciting technology
+        niches. Some of the areas below are relevant to us!</p>\n<ul style=\"\">\n<li
+        style=\"\"><span style=\"box-sizing: inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">WebGL &amp; Canvas expertise</span>: experience building interactive
+        graphics, animations, and visualizations using WebGL, Three.js, or native
+        Canvas API</li>\n<li style=\"\"><span style=\"box-sizing: inherit; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">Data visualization</span>: creating compelling, interactive data visualizations
+        with libraries like Mapbox, D3.js, Chart.js, or similar tools</li>\n<li style=\"\"><span
+        style=\"box-sizing: inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">Full-stack development experience</span>: comfortable working across
+        the entire stack, from frontend to backend and database layers</li>\n<li style=\"\"><span
+        style=\"box-sizing: inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">PostgreSQL expertise</span>: strong experience with database design,
+        query optimization, and managing complex relational data structures</li>\n<li
+        style=\"\"><span style=\"box-sizing: inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">GraphQL &amp; API design</span>: building and maintaining GraphQL or
+        REST APIs with a focus on performance and developer experience</li>\n<li style=\"\"><span
+        style=\"box-sizing: inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">Real-time technologies</span>: experience with WebSockets, Server-Sent
+        Events, or similar technologies for building live, interactive features</li>\n<li
+        style=\"\"><span style=\"box-sizing: inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">Authentication &amp; security</span>: implementing secure authentication
+        flows (OAuth, JWT) and following security best practices</li>\n<li style=\"\"><span
+        style=\"box-sizing: inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">Client-facing experience</span>: working directly with customers to
+        gather requirements and provide technical solutions</li>\n<li style=\"\"><span
+        style=\"box-sizing: inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgba(15,111,255,.5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; font-weight:
+        600;\">Product management experience</span>: defining product roadmaps and
+        collaborating closely with stakeholders</li>\n<li style=\"\"><span style=\"box-sizing:
+        inherit; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgba(15,111,255,.5); --tw-ring-offset-shadow:
+        0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored:
+        0 0 #0000; font-weight: 600;\">Engineering management experience</span>: leading
+        teams, setting technical direction, and mentoring developers</li>\n</ul>\n<p
+        class=\"h2\" style=\"color: #532a21;\">\u00a0</p>\n<p class=\"h2\" style=\"color:
+        #532a21;\">\ud83d\udcb8\u00a0<span style=\"font-weight: 600; color: #000000;
+        letter-spacing: 0.75px;\">Compensation</span></p>\n<p>Our pay scale ranges
+        from\u00a0<code>$35p/hr</code>\u00a0to\u00a0<code>$95p/hr\u00a0</code>pending
+        seniority (&amp; team leadership experience), and our projects are rarely
+        less than 8 full time weeks at 40 hours per week.</p>\n<p>We prefer long standing
+        relationships with highly accountable and communicative team members, so we
+        encourage candidates to expect longer term engagements.</p>\n<p>\u00a0</p>\n<p
+        class=\"h2\" style=\"color: #532a21;\">\ud83c\udfa4\u00a0<span style=\"font-weight:
+        600; color: #000000; letter-spacing: 0.75px;\">How we interview:</span></p>\n<p>Our
+        interview process starts with a call where you get to meet a few members of
+        our team. From there we\u2019ll ask appropriate candidates to take part in
+        a technical exercise which helps illustrate skill level and comfort.</p>\n<p>\u00a0</p>\n<p
+        class=\"h2\" style=\"color: #532a21;\">\ud83d\udc69\u200d\ud83c\udfed\u00a0<span
+        style=\"font-weight: 600; color: #000000; letter-spacing: 0.75px;\">How we
+        work:</span></p>\n<p>We believe that there\u2019s a better balance between
+        the poles of freelancing &amp; full time, and for that reason Sanctuary works
+        differently to most shops:</p>\n<ul style=\"\">\n<li style=\"\"><a href=\"https://sanctucompu.substack.com/p/our-open-source-2020-profit-and-loss\"
+        rel=\"nofollow\"><span style=\"font-weight: 600; color: #000000; letter-spacing:
+        0.75px;\">Transparency &amp; Ownership:</span></a>\u00a0We release out Profit
+        &amp; Loss statements to the community each year, open source our best ideas,
+        and talk business &amp; money with everyone in the company. We\u2019re proud
+        to run our business with integrity, and for that reason we share everything
+        with our team &amp; community.</li>\n<li style=\"\"><a href=\"https://negative.sanctuary.computer/\"
+        rel=\"nofollow\"><strong>150% Carbon Negative:</strong></a>\u00a0Our studio
+        offsets 150% of the carbon we use to do business each year, dated back to
+        our founding in 2015. We turn down work that is not in-line with our morals,
+        and we encourage our peers to do the same.\u00a0<a href=\"https://twitter.com/sanctucompu/status/1385282161197060100\"
+        rel=\"nofollow\">We have been certified climate neutral since 2021</a>.</li>\n<li
+        style=\"\"><a href=\"https://sanctucompu.substack.com/p/our-moral-compass\"
+        rel=\"nofollow\"><strong>Strong Morals:</strong></a>\u00a0Since our founding,
+        we''ve turned down somewhere between $1mm - $2mm of work that didn''t meet
+        our moral standards. (Most of that was DTC brands that can''t show a valid
+        sustainability initiative).</li>\n<li style=\"\"><span style=\"font-weight:
+        600; color: #000000; letter-spacing: 0.75px;\">Async &amp; Decentralized:</span>\u00a0We
+        use tools optimized for calm, thoughtful communication, and opt for async
+        whenever possible. We fight hard to maintain our focus time.</li>\n<li style=\"\"><span
+        style=\"font-weight: 600; color: #000000; letter-spacing: 0.75px;\">Remote
+        Friendly:</span>\u00a0Our company is fluent in remote work, making our workplace
+        more decentralized, and democratized in the process.</li>\n<li style=\"\"><span
+        style=\"font-weight: 600; color: #000000; letter-spacing: 0.75px;\">Ideas
+        &amp; Products:</span>\u00a0In our spare studio time, we work to build our
+        own open source or internal products to diversify &amp; bolster our income.
+        We create amazing technology products for our clients, so why not for the
+        studio?</li>\n</ul>\n<p><span style=\"font-weight: 600; color: #000000; letter-spacing:
+        0.75px;\">\u2192 Read more on our\u00a0<a href=\"https://sanctucompu.substack.com/\"
+        rel=\"nofollow\">Substack, over here</a>, or our\u00a0<a href=\"https://medium.com/sanctuary-computer-inc\"
+        rel=\"nofollow\">Medium, over there</a>.</span></p>\n<img src=\"https://remotive.com/job/track/2088707/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/2088707/logo"},
+        {"id": 2088706, "url": "https://remotive.com/remote-jobs/software-development/fullstack-developer-us-et-2088706",
+        "title": "Fullstack Developer (US - ET)", "company_name": "Chooose", "company_logo":
+        "https://remotive.com/job/2088706/logo", "category": "Software Development",
+        "tags": ["api", "azure", "fullstack", "python", "react", "saas", "AI/ML",
+        "project management", "documentation", "Typescript ", "computer science",
+        "diversity", "insurance"], "job_type": "full_time", "publication_date": "2026-04-08T12:36:43",
+        "candidate_required_location": "USA", "salary": "", "description": "<p>\u00a0</p>\n<p>Chooose
+        builds software to enable the lower carbon fuel value chain.</p>\n<p>Companies
+        like Delta Air Lines, Cathay Pacific, British Airways, and Microsoft use the
+        Chooose platform to build, operate, and scale their lower carbon fuel programs
+        (typically referred to as Sustainable Aviation Fuel, or SAF), and to advance
+        voluntary and compliance carbon management initiatives.</p>\n<p>With offices
+        in Miami and Oslo, and remote employees across the US and Europe, Chooose
+        is relentlessly focused on delivering enterprise software products to enable
+        our customers to drive lower carbon fuel adoption. The company has raised
+        $50M from leading venture capital and strategic investors.</p>\n<p><strong>The
+        role</strong></p>\n<p>We are looking for a person who is open to new technologies,
+        is not afraid to experiment, and is eager to learn. The ideal candidate will
+        be self-driven and able to take charge and make decisions. You will develop
+        internal applications to drive efficiency within the Chooose organization
+        leveraging your development skills and modern AI technologies, build-out back-end
+        services for our customers, and support our Commercial team through technical
+        implementation with customer facing opportunities.\u00a0</p>\n<p>\u00a0</p>\n<p><strong>This
+        is a remote role that must be based in Massachusetts, New York, Pennsylvania,
+        Maryland, or Florida</strong></p>\n<p>\u00a0</p>\n<p><strong>What you''ll
+        do</strong></p>\n<ul style=\"\">\n<li style=\"\">Maintain and scale complex
+        front-end (React, Typescript) and back-end architecture (C#/.net)</li>\n<li
+        style=\"\">Work directly with external clients</li>\n<li style=\"\">Develop
+        and maintain Python-based data processing pipelines and command-line interface
+        (CLI) tools.</li>\n<li style=\"\">Develop and integrate AI/ML solutions into
+        company processes and external facing products</li>\n<li style=\"\">Have a
+        hand in the technical implementation of our Platform and Solutions and support
+        our Commercial team</li>\n<li style=\"\">Creation of unit tests or integration
+        tests (Vitest)</li>\n<li style=\"\">Maintain and scale complex services</li>\n<li
+        style=\"\">Drive efficiency internally through scalable processes and applications</li>\n</ul>\n<p><strong>What
+        you''ll bring to the table</strong></p>\n<ul style=\"\">\n<li style=\"\">5+
+        years of hands-on experience</li>\n<li style=\"\">Strong organizational and
+        project management skills.</li>\n<li style=\"\">Excellent verbal communication
+        skills. A bonus if you have managed external facing clients previously.\u00a0</li>\n<li
+        style=\"\">Critical problem-solving skills.</li>\n<li style=\"\">Meticulous
+        attention to detail.</li>\n<li style=\"\">Degree in computer science, engineering
+        or equivalent.</li>\n<li style=\"\">Must be based in Massachusetts, New York,
+        Pennsylvania, Maryland, or Florida</li>\n</ul>\n<p><strong>You''ll stand out
+        if you have knowledge of</strong></p>\n<ul style=\"\">\n<li style=\"\">Azure
+        (Azure functions)</li>\n<li style=\"\">Integrations</li>\n<li style=\"\">Python
+        (Fast API)</li>\n<li style=\"\">You have some experience incorporating AI
+        features into SaaS products.</li>\n</ul>\n<p><strong>The interview process</strong></p>\n<p>\u00a0</p>\n<p>At
+        Chooose, we prioritize transparency throughout our interview process. If your
+        qualifications look like a fit, we\u2019ll begin with a 2-3 introductory conversations
+        where you''ll have the chance to discuss your experience and learn more about
+        our company. The second phase varies depending on the role and will most likely
+        involve a practical exercise or live session so you can show your work. The
+        third and final phase consists of a one-on-one in-person conversation with
+        a member of our executive team. The process should take approx. 4 weeks. While
+        we strive to keep to this timeline, the occasional adjustment may occur; we\u2019re
+        focused on ensuring for enough time to get to know one another.</p>\n<p>\u00a0</p>\n<p><strong>Pay,
+        perks, &amp; more</strong></p>\n<p>\u00a0</p>\n<p>We offer a competitive salary,
+        a comprehensive benefits package including medical, dental, and vision insurance,
+        voluntary 401k contributions, paid parental leave, a robust PTO package, the
+        option to participate in our employee equity program, flexible work hours,
+        and access to ''Spaces'' coworking space.</p>\n<p>\u00a0</p>\n<p>We value
+        diversity and believe forming teams in which everyone can be their authentic
+        self is key to our success. We encourage people from underrepresented backgrounds
+        and different industries to apply.</p>\n<p>\u00a0</p>\n<p><strong>Compensation
+        will be based on experience and skill, commensurate with market rates, and
+        will include both salary and equity in Chooose.</strong></p>\n<p>\u00a0</p>\n<p><strong>Chooose
+        is an equal opportunity employer and does not discriminate based on race,
+        color, religion (creed), gender, gender expression, age, national origin (ancestry),
+        disability, marital status, sexual orientation, or military status. We are
+        committed to providing an inclusive and welcoming environment to our employees
+        and welcome input from candidates and employees on how we can enhance our
+        inclusiveness.</strong></p>\n<p>\u00a0</p>\n<p><em>Prerequisite for Employment:
+        Chooose may request to conduct background checks on prospective applicants
+        to verify the information provided in the CV, transcripts, and other documentation.
+        This background check may be carried out by our partner and will not be conducted
+        without the applicant''s prior consent. Prospective applicants will receive
+        more information about this.</em></p>\n<img src=\"https://remotive.com/job/track/2088706/blank.gif?source=public_api\"
+        alt=\"\"/>"}, {"id": 2088704, "url": "https://remotive.com/remote-jobs/all-others/online-data-analyst-united-states-spanish-speakers-2088704",
+        "title": "Online Data Analyst (United States/Spanish speakers)", "company_name":
+        "TELUS Digital", "company_logo": "https://remotive.com/job/2088704/logo",
+        "category": "All others", "tags": ["go", "social media", "AI/ML", "research",
+        "diversity"], "job_type": "part_time", "publication_date": "2026-04-07T14:40:01",
+        "candidate_required_location": "USA", "salary": "", "description": "<p style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">Are you a detail-oriented individual with a passion for research and
+        a good understanding of national and local geography? This freelance opportunity
+        allows you to work at your own pace and from the comfort of your own home.</p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><strong>A Day in
+        the Life of an Online Data Analyst:</strong></p>\n<ul style=\"\">\n<li style=\"\">In
+        this role, you will be working on a project aimed at enhancing the content
+        and quality of digital maps that are used by millions of people worldwide</li>\n<li
+        style=\"\">Completing research and evaluation tasks in a web-based environment
+        such as verifying and comparing data, and determining the relevance and accuracy
+        of information.</li>\n</ul>\n<p style=\"border-color: #e5e7eb; --tw-shadow:
+        0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\">\u00a0</p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">Join us today and be part of a dynamic and innovative team that is making
+        a difference in the world!</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow:
+        0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\">\u00a0</p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\"><strong>TELUS Digital AI Community</strong></p>\n<p style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">Our global AI Community is a vibrant network of 1 million+ contributors
+        from diverse backgrounds who help our customers collect, enhance, train, translate,
+        and localize content to build better AI models. Become part of our growing
+        community and make an impact supporting the machine learning models of some
+        of the world\u2019s largest brands.</p>\n<p class=\"h4\" style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; line-height: 1.75rem; color: #414547;
+        letter-spacing: 0px; --tw-text-opacity: 1;\">Qualification path</p>\n<p style=\"border-color:
+        #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">No previous professional experience is required to apply to this role,
+        however, working on this project will require you to pass the basic requirements
+        and go through a standard assessment process. This is a part-time long-term
+        project and your work will be subject to our standard quality assurance checks
+        during the term of this agreement.\u00a0</p>\n<p style=\"border-color: #e5e7eb;
+        --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\"><strong>Basic Requirements</strong></p>\n<ul
+        style=\"\">\n<li style=\"\">Full Professional Proficiency in Spanish language</li>\n<li
+        style=\"\">Being a resident in United States for the last 2 consecutive years
+        and having familiarity with current and historical business, media, sport,
+        news, social media, and cultural affairs in United States</li>\n<li style=\"\">Ability
+        to follow guidelines and conduct online research using search engines, online
+        maps, and website information</li>\n<li style=\"\">Flexibility to work across
+        a diverse set of task types, including maps, news, audio tasks, and relevance</li>\n<li
+        style=\"\">Daily access to a broadband internet connection, computer, and
+        relevant software</li>\n</ul>\n<p style=\"border-color: #e5e7eb; --tw-shadow:
+        0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\">\u00a0</p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\"><strong>Assessment</strong></p>\n<p style=\"border-color: #e5e7eb; --tw-shadow:
+        0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\">In order to be
+        hired into the program, you\u2019ll take an open book qualification exam that
+        will determine your suitability for the position and complete ID verification.
+        Our team will provide you with guidelines and learning materials before your
+        qualification exam. You will be required to complete the exam in a specific
+        timeframe but at your convenience.</p>\n<p style=\"border-color: #e5e7eb;
+        --tw-shadow: 0 0 #0000; --tw-ring-offset-width: 0px; --tw-ring-offset-color:
+        #fff; --tw-ring-color: rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0
+        #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y:
+        0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x:
+        0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">\u00a0</p>\n<p style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000;
+        --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color:
+        rgb(59 130 246 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow:
+        0 0 #0000; --tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x:
+        0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x:
+        1; --tw-scale-y: 1; --tw-scroll-snap-strictness: proximity; --tw-shadow-colored:
+        0 0 #0000; cursor: text; padding: 0px; counter-reset: list-1 0 list-2 0 list-3
+        0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9 0;\">Equal Opportunity</p>\n<p
+        style=\"border-color: #e5e7eb; --tw-shadow: 0 0 #0000; --tw-ring-offset-width:
+        0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(59 130 246 / .5);
+        --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-border-spacing-x:
+        0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate:
+        0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-scroll-snap-strictness:
+        proximity; --tw-shadow-colored: 0 0 #0000; cursor: text; padding: 0px; counter-reset:
+        list-1 0 list-2 0 list-3 0 list-4 0 list-5 0 list-6 0 list-7 0 list-8 0 list-9
+        0;\">All qualified applicants will receive consideration for a contractual
+        relationship without regard to race, color, religion, sex, sexual orientation,
+        gender identity, national origin, disability, or protected veteran status.
+        At TELUS Digital AI, we are proud to offer equal opportunities and are committed
+        to creating a diverse and inclusive community. All aspects of selection are
+        based on applicants\u2019 qualifications, merits, competence, and performance
+        without regard to any characteristic related to diversity.</p>\n<img src=\"https://remotive.com/job/track/2088704/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/2088704/logo"},
+        {"id": 1185979, "url": "https://remotive.com/remote-jobs/writing/freelance-writer-1185979",
+        "title": "Freelance Writer", "company_name": "IAPWE", "company_logo": "https://remotive.com/job/1185979/logo",
+        "category": "Writing", "tags": ["REST"], "job_type": "freelance", "publication_date":
+        "2026-04-04T17:01:43", "candidate_required_location": "Worldwide", "salary":
+        "$50-$75 /hour", "description": "<p class=\"p1\" style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-stretch: normal; line-height:
+        normal; color: #000000;\">Our organization is seeking content writers to create
+        articles and blog posts on a variety of topics.</p>\n<p class=\"p1\" style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-stretch: normal; line-height:
+        normal; color: #000000;\">\u00a0</p>\n<p class=\"p1\" style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-stretch: normal; line-height:
+        normal; color: #000000;\">The rate of pay is $20 per 100 words (this comes
+        out to approximately $100 per article or $50 per hour).</p>\n<p>\u00a0</p>\n<p
+        class=\"p1\" style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; font-stretch: normal; line-height: normal; color: #000000;\">Some
+        topics you may be asked to write about include the following (you can always
+        turn down a topic if you do not feel comfortable writing about it, however
+        if you have experience or expertise in a specific area, please let us know):</p>\n<p>\u00a0</p>\n<ul
+        class=\"ul1\" style=\"\">\n<li class=\"li1\" style=\"\">Health &amp; beauty</li>\n<li
+        class=\"li1\" style=\"\">Fitness</li>\n<li class=\"li1\" style=\"\">Home Decor</li>\n<li
+        class=\"li1\" style=\"\">Fashion</li>\n<li class=\"li1\" style=\"\">Sports</li>\n<li
+        class=\"li1\" style=\"\">Do it yourself</li>\n<li class=\"li1\" style=\"\">Finance</li>\n<li
+        class=\"li1\" style=\"\">Legal</li>\n<li class=\"li1\" style=\"\">Medical</li>\n<li
+        class=\"li1\" style=\"\">Family/Parenting</li>\n<li class=\"li1\" style=\"\">Relationships</li>\n<li
+        class=\"li1\" style=\"\">Real Estate</li>\n<li class=\"li1\" style=\"\">Restaurants</li>\n<li
+        class=\"li1\" style=\"\">Contracting (plumbing, pool building, remodeling,
+        etc.)</li>\n</ul>\n<p>\u00a0</p>\n<p><span style=\"color: #000000;\">These
+        are just some of the more general industries and topics that we cover.</span></p>\n<p>\u00a0</p>\n<p><span
+        style=\"font-weight: 600; color: #000000; letter-spacing: 0.75px;\">Requirements</span><span
+        style=\"color: #000000;\">:</span></p>\n<ul style=\"\">\n<li style=\"\">We
+        ask that all work be completed using a word processor such as Microsoft Word
+        or Open Office</li>\n<li style=\"\">A reliable internet connection and the
+        ability to meet deadlines</li>\n<li style=\"\">Good communication skills and
+        respond in a timely manner to editorial staff when they ask for updates on
+        tasks, etc</li>\n<li style=\"\">Work well as a team member with the rest of
+        our content management and editorial staff</li>\n</ul>\n<p><br><br><em><strong>Note</strong>:
+        Applicants to this job signaled that accessing some writing tasks may require
+        payment.</em></p>\n<img src=\"https://remotive.com/job/track/1185979/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/1185979/logo"},
+        {"id": 1749306, "url": "https://remotive.com/remote-jobs/writing/copywriter-1749306",
+        "title": "Copywriter", "company_name": "Coalition Technologies ", "company_logo":
+        "https://remotive.com/job/1749306/logo", "category": "Writing", "tags": ["accounting",
+        "excel", "research", "data analysis", "bookkeeping", "google sheets", "quickbooks",
+        "data entry", "insurance", "G Suite"], "job_type": "freelance", "publication_date":
+        "2026-04-02T20:01:09", "candidate_required_location": "Worldwide", "salary":
+        "$20k -$35k", "description": "<p class=\"h3\">\u00a0</p>\n<div class=\"h3\">WHO
+        WE''RE LOOKING FOR</div>\n<div class=\"h3\">The ideal copywriter has excellent
+        English writing skills and is excited to write high-quality, SEO-driven content
+        that aligns with detailed, client-specific guidelines. Projects most commonly
+        include writing web pages for eCommerce and lead generation business sites
+        such as category pages, product descriptions, and blog posts. Our clientele
+        is constantly evolving. We produce content for these and many other industry
+        verticals:</div>\n<div class=\"h3\">\u00a0</div>\n<div class=\"h3\">Fashion
+        (both mass-market and luxury)</div>\n<div class=\"h3\">Skincare &amp; Beauty</div>\n<div
+        class=\"h3\">Tech &amp; Software**</div>\n<div class=\"h3\">Finance &amp;
+        Investing**</div>\n<div class=\"h3\">Law (family law, product liability, divorce,
+        etc.)**</div>\n<div class=\"h3\">Education</div>\n<div class=\"h3\">Home Improvement</div>\n<div
+        class=\"h3\">Automobiles &amp; Motorcycles (OEM and aftermarket accessories)</div>\n<div
+        class=\"h3\">Health and Wellness**</div>\n<div class=\"h3\">Medical / Clinical**</div>\n<div
+        class=\"h3\">Digital Marketing</div>\n<div class=\"h3\">SEO / PR / Advertising
+        / Marketing**</div>\n<div class=\"h3\">**Writers with a background in these
+        highly specialized fields are strongly encouraged to apply.</div>\n<div class=\"h3\">The
+        ideal candidate for this position is a multifaceted technical and creative
+        writer with at least two to four years of professional, non-academic experience.
+        Candidates should understand how to write content that effortlessly blends
+        SEO best practices and brand priorities for finished work that\u2019s engaging,
+        creative, and ROI-driven. Candidates should also be willing and able to complete
+        careful research in order to gain a strong understanding of various industries.
+        Candidates should be prepared to provide portfolios featuring published work.
+        Once an offer has been extended, writers will be asked to take a brief training
+        course.</div>\n<div class=\"h3\">\u00a0</div>\n<div class=\"h3\">Compensation</div>\n<div
+        class=\"h3\">Writers are paid on a per-word basis. The rate is assessed according
+        to our KPI rubric (key performance indicators) with an automatic raise after
+        400 and 800 pages have gone live on our client''s websites.</div>\n<div class=\"h3\">Initial
+        compensation is up to $0.06 per word with $0.034 per word being the most typical
+        compensation level. This is $30 or $17 per page of 500 words.</div>\n<div
+        class=\"h3\">After 400 pages live, the top marginal rate increases to $0.064
+        per word with the most typical rate of $0.038 per word, or $32 and $19 per
+        page. After 800 pages live, the top marginal rate increases to $0.07 per word
+        with $0.044 per word being the most typical, or $35 and $22 per page.</div>\n<img
+        src=\"https://remotive.com/job/track/1749306/blank.gif?source=public_api\"
+        alt=\"\"/>", "company_logo_url": "https://remotive.com/job/1749306/logo"},
+        {"id": 2088697, "url": "https://remotive.com/remote-jobs/customer-service/customer-success-team-lead-german-speaking-2088697",
+        "title": "Customer Success Team Lead (German Speaking)", "company_name": "Filestage",
+        "company_logo": "https://remotive.com/job/2088697/logo", "category": "Customer
+        Service", "tags": ["react", "hardware", "account management", "onboarding",
+        "startup", "risk management", "team lead", "travel", "REST"], "job_type":
+        "full_time", "publication_date": "2026-03-31T10:37:01", "candidate_required_location":
+        "Europe, EMEA", "salary": "", "description": "<div class=\"h1\"><strong><span
+        style=\"color: #00c261;\">About Filestage</span></strong></div>\n<p><span
+        style=\"color: #434343;\">Filestage frees people from chaotic approval processes,
+        making work more joyful and productive. From large enterprises to independent
+        agencies, our review and approval platform helps teams share, discuss, and
+        approve all their files, all in one place \u2013 including documents, designs,
+        images, videos, and audio files.</span></p>\n<p><span style=\"color: #434343;\">We''re
+        a fully remote team with people working in home offices, co-working spaces,
+        and coffee shops all over the world. Together, we''re on a mission to create
+        a seamless approval process that helps people deliver their best work.\u00a0</span></p>\n<p><span
+        style=\"color: #434343;\">We''ve raised our Series A and have over half a
+        million users across 500+ companies, including AB InBev, LG, Havas, GroupM,
+        and Emirates. So if you''re looking for a fast-growing startup in a booming
+        market, you''ve found it!</span></p>\n<p><span style=\"color: #434343;\">\u2b50
+        This role is fully remote and we are only able to consider candidates</span><strong><span
+        style=\"color: #434343;\"> who speak fluent German and are based in a European
+        time zone.</span></strong></p>\n<p>\u00a0</p>\n<div class=\"h1\"><strong><span
+        style=\"color: #00c261;\">Your mission: Architecting the future of CS</span></strong></div>\n<p><span
+        style=\"color: #434343;\">This is a pivotal moment for Filestage. We are currently
+        evolving our commercial structure by separating Customer Success (adoption
+        &amp; outcomes) from Account Management (renewals &amp; expansion).</span></p>\n<p><span
+        style=\"color: #434343;\">As our CS Team Lead, you will be the architect of
+        the Customer Success side of this transition. While Account Management handles
+        the commercials, you will define what a world-class \"Success\" journey looks
+        like. You\u2019ll act as a player-coach: leading by example with your own
+        high-touch DACH portfolio while building the operational standards the rest
+        of the team will follow.<br></span></p>\n<ul style=\"\">\n<li style=\"\">\n<p><strong><span
+        style=\"color: #434343;\">You define the CS operating system:</span></strong><span
+        style=\"color: #434343;\"> In partnership with RevOps, you\u2019ll refine
+        the foundation for onboarding, enablement, and health-score management. You\u2019ll
+        ensure the CS/AM \"handshake\" is seamless: no gaps, no double-touches, and
+        clear ownership at every stage.</span></p>\n</li>\n<li style=\"\">\n<p><strong><span
+        style=\"color: #434343;\">You standardize value delivery: </span></strong><span
+        style=\"color: #434343;\">You\u2019ll turn day-to-day execution into team-wide
+        standards. This means perfecting the \"Value Narrative\" in QBRs, shortening
+        Time-to-Value in onboarding, and enabling champions within our largest accounts.</span></p>\n</li>\n<li
+        style=\"\">\n<p><strong><span style=\"color: #434343;\">You proactively manage
+        retention &amp; risk: </span></strong><span style=\"color: #434343;\">You
+        won\u2019t just react to churn; you\u2019ll build the systems to predict it.
+        You\u2019ll monitor health signals and run structured recovery plans, ensuring
+        we protect Gross Revenue Retention (GRR) before it\u2019s ever at risk.</span></p>\n</li>\n<li
+        style=\"\">\n<p><strong><span style=\"color: #434343;\">You cultivate a high-performance
+        team: </span></strong><span style=\"color: #434343;\">You\u2019ll lead weekly
+        cadences such as portfolio reviews, risk assessments, and enablement sessions.
+        Your goal is to coach our CSMs toward a proactive, data-driven approach that
+        frees up human time for the conversations that move the needle.</span></p>\n</li>\n<li
+        style=\"\">\n<p><strong><span style=\"color: #434343;\">You are the voice
+        of the customer: </span></strong><span style=\"color: #434343;\">You\u2019ll
+        act as the strategic bridge to our Product team, translating customer bottlenecks
+        and feedback into actionable insights that shape our roadmap.</span></p>\n</li>\n</ul>\n<p>\u00a0</p>\n<div
+        class=\"h1\"><strong><span style=\"color: #00c261;\">Life at Filestage</span></strong></div>\n<p><span
+        style=\"color: #434343;\">We believe people are more productive when they
+        can choose their own schedule. So we\u2019re proud to offer fully-remote roles
+        that give you the perfect balance between work and life.</span></p>\n<p><span
+        style=\"color: #434343;\">Here are some of the benefits you can look forward
+        to at Filestage:</span></p>\n<ul style=\"\">\n<li style=\"\">\n<p><strong><span
+        style=\"color: #434343;\">\ud83c\udfe1 Work from where you''re happiest and
+        enjoy a flexible schedule. </span></strong><span style=\"color: #434343;\">We''ve
+        been fully remote from the start, giving you the opportunity to meet people
+        all over the world and broaden your horizons.</span></p>\n</li>\n<li style=\"\">\n<p><strong><span
+        style=\"color: #434343;\">\ud83c\udf0d Meet up in real life. </span></strong><span
+        style=\"color: #434343;\">We all travel together at least once a year at our
+        team retreat to have fun and get to know each other.</span></p>\n</li>\n<li
+        style=\"\">\n<p><strong><span style=\"color: #434343;\">\ud83d\udc65 Enjoy
+        a strong team culture. </span></strong><span style=\"color: #434343;\">We''re
+        a group of knowledge seekers, reflective thinkers, clear communicators, goal
+        owners, problem solvers, and team players. These are the values we strive
+        for to help us achieve our mission.</span></p>\n</li>\n<li style=\"\">\n<p><strong><span
+        style=\"color: #434343;\">\ud83d\ude0a Join a happy team. </span></strong><span
+        style=\"color: #434343;\">We''ve been rated five stars on Glassdoor by our
+        lovely team.</span></p>\n</li>\n<li style=\"\">\n<p><strong><span style=\"color:
+        #434343;\">\ud83d\udcbb Create a workspace that suits you. </span></strong><span
+        style=\"color: #434343;\">You''ll get a \u20ac1,500 budget for hardware, as
+        well as \u20ac500 for your home office \u2014 including a computer, webcam,
+        or standing desk.</span></p>\n</li>\n<li style=\"\">\n<p><strong><span style=\"color:
+        #434343;\">\ud83c\udf34 Get 38 days of holiday</span></strong><span style=\"color:
+        #434343;\">. Plenty of time for city breaks, summer escapes, and everything
+        in between. You''ll also get a half day on your birthday to celebrate!</span></p>\n</li>\n<li
+        style=\"\">\n<p><strong><span style=\"color: #434343;\">\ud83d\udc50 Volunteer/Charity
+        Day. </span></strong><span style=\"color: #434343;\">Enjoy a dedicated day
+        to support a cause close to your heart.</span></p>\n</li>\n<li style=\"\">\n<p><strong><span
+        style=\"color: #434343;\">\ud83d\udcda Continue to grow and develop your career</span></strong><span
+        style=\"color: #434343;\">. After six months, you''ll get a personal development
+        budget to invest in yourself.</span></p>\n</li>\n<li style=\"\">\n<p><strong><span
+        style=\"color: #434343;\">\ud83d\udde3\ufe0f Make your voice heard.</span></strong><span
+        style=\"color: #434343;\"> We trust our team members to make the best decisions
+        to achieve their goals \u2014 no micromanagers here.</span></p>\n</li>\n<li
+        style=\"\">\n<p><strong><span style=\"color: #434343;\">\ud83d\udcc5 Say goodbye
+        to pointless meetings. </span></strong><span style=\"color: #434343;\">Flat
+        hierarchies, fast iterations, and no bullshit meetings.</span></p>\n</li>\n</ul>\n<p>\u00a0</p>\n<p>\u00a0</p>\n<div
+        class=\"h1\"><strong><span style=\"color: #00c261;\">What you\u2019ll bring
+        to the role</span></strong></div>\n<ul style=\"\">\n<li style=\"\">\n<p><span
+        style=\"color: #434343;\">\ud83c\udfc6 </span><strong><span style=\"color:
+        #434343;\">You''ve been here before.</span></strong><span style=\"color: #434343;\">
+        You have 3\u20135 years of experience in Customer Success, with a proven track
+        record of owning GRR, running QBRs, and growing a high-value book of business.
+        You''ve outperformed retention targets, and you know what it takes.</span></p>\n</li>\n<li
+        style=\"\">\n<p><span style=\"color: #434343;\">\ud83d\udc65 </span><strong><span
+        style=\"color: #434343;\">You want to take the next step in leadership.</span></strong><span
+        style=\"color: #434343;\"> You understand the core principles of managing
+        a CS team because you have hands-on experience, remote experience, and ideally
+        experience during a period of growth or transition. You are ready to lift
+        people up, bring clarity to uncertainty, and set standards others want to
+        follow.</span></p>\n</li>\n<li style=\"\">\n<p><span style=\"color: #434343;\">\ud83d\udcca</span><strong><span
+        style=\"color: #434343;\"> You think like a business partner, not just a relationship
+        manager. </span></strong><span style=\"color: #434343;\">You understand revenue
+        strategy, GRR vs NRR, and how CS influences commercial outcomes. You can translate
+        product outcomes and user adoption into measurable business KPIs.\u00a0</span></p>\n</li>\n<li
+        style=\"\">\n<p><span style=\"color: #434343;\">\ud83d\udd0d </span><strong><span
+        style=\"color: #434343;\">You get ahead of problems. </span></strong><span
+        style=\"color: #434343;\">You''re analytical, process-oriented, and proactive.
+        You monitor health signals, build structured recovery plans, and prevent escalations
+        rather than reacting to them. Silent churn doesn''t stand a chance.</span></p>\n</li>\n<li
+        style=\"\">\n<p><span style=\"color: #434343;\">\ud83d\udee0\ufe0f</span><strong><span
+        style=\"color: #434343;\"> You build things that scale.</span></strong><span
+        style=\"color: #434343;\"> You''ve developed or improved CS playbooks \u2014
+        risk management, churn prevention, AM/CS handover, account monitoring \u2014
+        and you understand how to create a repeatable, scalable operating model.</span></p>\n</li>\n<li
+        style=\"\">\n<p><span style=\"color: #434343;\">\ud83e\udd1d </span><strong><span
+        style=\"color: #434343;\">You''re a team player with high EQ</span></strong><span
+        style=\"color: #434343;\">. You combine strong empathy with clear leadership.
+        You''re fair, honest, and collaborative \u2014 and you know that our success
+        as a business depends on the success of the people around you.</span></p>\n</li>\n<li
+        style=\"\">\n<p><span style=\"color: #434343;\">\ud83c\udf0d </span><strong><span
+        style=\"color: #434343;\">You''re fluent in German and English</span></strong><span
+        style=\"color: #434343;\">. Professional proficiency in both is essential
+        for this role. Spanish or French is a nice bonus.</span></p>\n</li>\n<li style=\"\">\n<p><span
+        style=\"color: #434343;\">\ud83c\udfe0 </span><strong><span style=\"color:
+        #434343;\">You''re built for remote</span></strong><span style=\"color: #434343;\">.
+        You''ve worked remotely for 2+ years and managed a team remotely for at least
+        a year. You''re self-motivated, async-friendly, and comfortable working independently
+        in an international environment.</span></p>\n</li>\n</ul>\n<p>\u00a0</p>\n<img
+        src=\"https://remotive.com/job/track/2088697/blank.gif?source=public_api\"
+        alt=\"\"/>"}, {"id": 2088696, "url": "https://remotive.com/remote-jobs/customer-service/technical-support-operator-2088696",
+        "title": "Technical Support Operator", "company_name": "KnownHost", "company_logo":
+        "https://remotive.com/job/2088696/logo", "category": "Customer Service", "tags":
+        ["apache", "drupal", "magento", "perl", "php", "python", "ruby/rails", "wordpress",
+        "bash", "dns", "web hosting", "helpdesk", "MySQL", "technical support", "chat",
+        "troubleshooting", "Linux/Unix", "shell", "REST", "insurance"], "job_type":
+        "full_time", "publication_date": "2026-03-27T09:51:22", "candidate_required_location":
+        "USA", "salary": "$30k - $40k", "description": "<p style=\"text-align: justify;\"><strong>THIS
+        IS WHO YOU ARE\u2026</strong></p>\n<p>You are our front line in the battle
+        for exceptional customer experience at the 24/7/365 help desk.</p>\n<p>Ideally,
+        you have experienced terrible web hosting customer service and have vowed
+        that will never happen on your watch!</p>\n<p>You are responsible for seeing
+        that our customers have excellent customer service by doing what you do every
+        day -&gt; exceeding customer expectations.</p>\n<p><strong>WHAT DO WE NEED
+        FROM YOU?</strong> Well, you should be customer focused, great under pressure,
+        and ready to engage a problem with your superior analytic skills. Can you
+        do several things at a time with amazing efficiency? Good! If you are a super
+        ninja with web hosting applications and platforms -&gt; we need to talk.</p>\n<p><strong>MORE
+        ABOUT THE POSITION</strong>. These will be your primary responsibilities in
+        your daily goal to fight bad web hosting:</p>\n<p>Hiring for day shift employees
+        CST.\u00a0<br>Provide customers support via our 24/7 helpdesk.<br>Troubleshooting
+        email delivery issues<br>Troubleshooting cPanel, Plesk, and DirectAdmin related
+        issues<br>Troubleshooting DNS, FTP, SSL, Apache, and other service-related
+        issues.</p>\n<p>Ensuring customer satisfaction</p>\n<p>You must know Linux
+        like your favorite cheeseburger and fries\u2019 combo! Here are your other
+        amazing attributes:</p>\n<p>Must be customer-focused, and willing to do whatever
+        it takes to resolve customer issues. Going above and beyond is the standard
+        at KnownHost. Our customer reviews reflect this.</p>\n<p>Excellent written
+        English. Technical Support Operators currently primarily provide support over
+        email, but may occasionally be asked to pitch in with live chat and phone
+        support.</p>\n<p>Must be familiar with Linux shell (bash), Apache, PHP, MySQL,
+        email (POP3/IMAP/SMTP), FTP, DNS, and other standard web hosting applications
+        and protocols.</p>\n<p>Must be able to work under pressure when bad stuff
+        happens and get the job done.</p>\n<p>Multi-tasking is a must. KnownHost has
+        a lot going on, and multiple brands.</p>\n<p>Must be able to ask customers
+        for complete error message or derive the context of their problem if they
+        provide insufficient information.</p>\n<p>Must have working knowledge of one
+        of the following control panels, cPanel/WHM, Plesk, and DirectAdmin is required.\u00a0</p>\n<p>Knowledge
+        of PHP, Python, Perl, and Ruby on Rail a bonus.\u00a0</p>\n<p>Working Knowledge
+        of Iptables firewalls (CSF, APF, etc.)</p>\n<p>Common customer website apps,
+        like Drupal, WordPress, MediaWiki, Magento, ZenCart, etc</p>\n<p>MySQL commands
+        for support or troubleshooting, like importing/dumping a database, simple
+        SELECT statements or \"SHOW PROCESSLIST\"</p>\n<p><strong>WHY IS KNOWNHOST
+        THE RIGHT FIT FOR YOU?</strong> We are seeking extraordinary people in a world
+        of mediocrity. You must live and breathe web hosting. To attract and retain
+        top-level talent, we are prepared to treat you like a VIP.</p>\n<p>With plush
+        benefits, paid vacation time,\u00a0and competitive pay, we believe that KnownHost
+        can be your next home away from home. Here is how we let you know that you
+        are valued on our red carpet:</p>\n<ul style=\"\">\n<li style=\"\">Competitive
+        pay between $14 to $20 per hour (depending on experience)</li>\n<li style=\"\">Comprehensive
+        health, dental, and vision insurance plans (US only)</li>\n<li style=\"\">Flexible
+        scheduling, &amp; paid vacation benefits.\u00a0</li>\n<li style=\"\">A variety
+        of other perks and benefits</li>\n</ul>\n<p>All our positions are full-time
+        employment, so we expect KnownHost to be your only hosting related job.</p>\n<p>All
+        you should do is know your field from every position, pass the background/
+        drug test, and let us do the rest!</p>\n<p>Apply today and let us get to know
+        you! \u00a0</p>\n<img src=\"https://remotive.com/job/track/2088696/blank.gif?source=public_api\"
+        alt=\"\"/>"}, {"id": 2088663, "url": "https://remotive.com/remote-jobs/project-management/junior-project-coordinator-2088663",
+        "title": "Junior Project Coordinator", "company_name": "C4Media Inc.", "company_logo":
+        "https://remotive.com/job/2088663/logo", "category": "Project Management",
+        "tags": ["html", "Figma", "research", "onboarding", "data entry", "infrastructure",
+        "travel"], "job_type": "full_time", "publication_date": "2026-03-24T09:43:07",
+        "candidate_required_location": "Brazil, Argentina", "salary": "", "description":
+        "<p dir=\"ltr\" style=\"line-height: 1.38; margin-top: 12pt; margin-bottom:
+        12pt;\"><span style=\"color: #000000; background-color: #ffffff; font-weight:
+        bold; font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">C4Media, Inc.</span><span style=\"color:
+        #000000; background-color: transparent; font-weight: 400; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\"> is seeking a motivated, fully remote </span><span style=\"color:
+        #000000; background-color: transparent; font-weight: bold; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">Junior Project Coordinator (contractor)</span><span style=\"color:
+        #000000; background-color: transparent; font-weight: 400; font-style: normal;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\"> to join our global team. In this role, you will provide essential
+        support for our expanding online learning and certification cohorts.</span></p>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 12pt; margin-bottom: 12pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">As a Junior Project Coordinator, you will assist
+        the team in planning and executing our virtual learning programs for software
+        professionals. This is a foundational, entry-level role designed for someone
+        who thrives on organization, clear communication, and the \"behind-the-scenes\"
+        work.</span></p>\n<p dir=\"ltr\" style=\"line-height: 1.38; margin-top: 12pt;
+        margin-bottom: 12pt;\"><span style=\"color: #000000; background-color: transparent;
+        font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">You will work under
+        the close guidance of our program leads, learning the operational \"ins and
+        outs\" of professional education in a highly collaborative environment.</span></p>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 14pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: bold;
+        font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">What You\u2019ll Do</span></p>\n<p dir=\"ltr\"
+        style=\"line-height: 1.38; margin-top: 12pt; margin-bottom: 12pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">Working as part of a team, you will assist with the
+        daily operations of our online learning cohorts:</span></p>\n<ul style=\"\">\n<ul
+        style=\"\">\n<li style=\"\"><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        font-weight: bold; vertical-align: baseline; white-space-collapse: preserve;\">Customer
+        Service:</span><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        vertical-align: baseline; white-space-collapse: preserve;\"> Act as a first
+        point of contact for learners. You\u2019ll help distribute onboarding materials,
+        answer inquiries, and follow up to ensure participants have a smooth experience.</span></li>\n<li
+        style=\"\"><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        font-weight: bold; vertical-align: baseline; white-space-collapse: preserve;\">Logistics
+        Assistance:</span><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        vertical-align: baseline; white-space-collapse: preserve;\"> Help maintain
+        our digital learning environments, including Zoom room administration, Google
+        Drive organization, and coordinating Slack communications.</span></li>\n<li
+        style=\"\"><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        font-weight: bold; vertical-align: baseline; white-space-collapse: preserve;\">Editorial
+        Pipeline Support:</span><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        vertical-align: baseline; white-space-collapse: preserve;\"> Support the coordination
+        of \"Capstone\" learning projects by collecting participant bios, tracking
+        deadlines, and sharing information with our internal editorial team.</span></li>\n<li
+        style=\"\"><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        font-weight: bold; vertical-align: baseline; white-space-collapse: preserve;\">Trainer
+        Coordination:</span><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        vertical-align: baseline; white-space-collapse: preserve;\"> Provide administrative
+        support to facilitators by ensuring session materials are organized and sessions
+        are ready to launch.</span></li>\n<li style=\"\"><span style=\"background-color:
+        transparent; font-variant-numeric: normal; font-variant-east-asian: normal;
+        font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #000000; font-weight: bold; vertical-align: baseline; white-space-collapse:
+        preserve;\">Data Entry &amp; Tracking:</span><span style=\"background-color:
+        transparent; font-variant-numeric: normal; font-variant-east-asian: normal;
+        font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #000000; vertical-align: baseline; white-space-collapse: preserve;\">
+        Assist in keeping our databases accurate. You\u2019ll help track attendance,
+        distribute feedback surveys, and compile results for program reports.</span></li>\n<li
+        style=\"\"><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        font-weight: bold; vertical-align: baseline; white-space-collapse: preserve;\">Ad-Hoc
+        Team Support:</span><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        vertical-align: baseline; white-space-collapse: preserve;\"> Help with research
+        tasks and small operational details, such as tracking costs or coordinating
+        with Finance and Marketing.</span></li>\n</ul>\n</ul>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: #ffffff; font-weight: bold; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">\u00a0</span></p>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: #ffffff; font-weight: bold; font-style:
+        normal; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">Job Requirements</span></p>\n<p><strong>\u00a0</strong></p>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: #ffffff; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\"><strong>Professional
+        Experience, Skills &amp; Education:</strong></span></p>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: #ffffff; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">\u00a0</span></p>\n<ul
+        style=\"\">\n<ul style=\"\">\n<li style=\"\">Excellent English proficiency
+        (written &amp; spoken) with the ability to communicate professionally with
+        a global audience.</li>\n<li style=\"\">A customer-first mindset\u2014you
+        are naturally helpful, patient, and supportive.</li>\n<li style=\"\">Sharp
+        attention to detail and exceptional organizational skills.</li>\n<li style=\"\">Comfort
+        with remote productivity tools such as Google Workspace and Slack.</li>\n<li
+        style=\"\">Technology curiosity: A desire to learn new software. Experience
+        with CRMs, Figma, or basic HTML is a plus, but not required.</li>\n<li style=\"\">A
+        recent degree or 1-2 years of experience in an administrative or customer-facing
+        role.</li>\n<li style=\"\">A proactive, solution-oriented mindset with a strong
+        willingness to help.</li>\n</ul>\n</ul>\n<p dir=\"ltr\" style=\"line-height:
+        1.38; margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000;
+        background-color: #ffffff; font-weight: 400; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\">\u00a0</span></p>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: #ffffff; font-style: normal; font-variant:
+        normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;\"><strong>Setup
+        Requirements:</strong></span></p>\n<p dir=\"ltr\" style=\"line-height: 1.38;
+        margin-top: 0pt; margin-bottom: 0pt;\"><span style=\"color: #000000; background-color:
+        #ffffff; font-weight: 400; font-style: normal; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\">\u00a0</span></p>\n<ul
+        style=\"\">\n<ul style=\"\">\n<li style=\"\">Able to work in a full-time remote
+        position</li>\n<li style=\"\">Must reside in Argentina or Brazil</li>\n<li
+        style=\"\">Able to work as an independent contractor</li>\n<li style=\"\">Able
+        to work in overlap with our core global office hours (9 AM - 1 PM EST)</li>\n<li
+        style=\"\">Quiet home office and ability to work comfortably from home</li>\n<li
+        style=\"\">Reliable infrastructure: Access to high-speed internet and a modern
+        computer</li>\n<li style=\"\">Able and willing to travel to locations in the
+        USA or Europe 1 - 3 times per year, with an average stay of 4-8 days each,
+        to attend our software conferences and annual company meetings</li>\n</ul>\n</ul>\n<p><strong>\u00a0</strong></p>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;\"><span
+        style=\"color: #25044e; background-color: #ffffff; font-weight: 400; font-style:
+        italic; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">Only candidates who submit their </span><span style=\"color:
+        #25044e; background-color: #ffffff; font-weight: bold; font-style: italic;
+        font-variant: normal; text-decoration: none; vertical-align: baseline; white-space:
+        pre-wrap;\">applications in English</span><span style=\"color: #25044e; background-color:
+        #ffffff; font-weight: 400; font-style: italic; font-variant: normal; text-decoration:
+        none; vertical-align: baseline; white-space: pre-wrap;\"> will be considered
+        for this role (including resume).</span></p>\n<p dir=\"ltr\" style=\"line-height:
+        1.2; background-color: #ffffff; margin-top: 30pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: bold;
+        font-style: normal; font-variant: normal; text-decoration: none; vertical-align:
+        baseline; white-space: pre-wrap;\">Why work at C4Media</span></p>\n<ul style=\"\">\n<ul
+        style=\"\">\n<li style=\"\"><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #212121; background-color: transparent; font-weight: bold;
+        vertical-align: baseline; white-space-collapse: preserve;\">Work from home
+        - always</span><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #212121; background-color: transparent; vertical-align: baseline;
+        white-space-collapse: preserve;\">: We are a remote-first and remote-always
+        team who has been successfully operating on a work-from-home basis since 2007.
+        And we have no intention of changing that.</span></li>\n<li style=\"\"><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates:
+        normal; font-variant-position: normal; font-variant-emoji: normal; color:
+        #212121; background-color: transparent; font-weight: bold; vertical-align:
+        baseline; white-space-collapse: preserve;\">Travel the world:</span><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates:
+        normal; font-variant-position: normal; font-variant-emoji: normal; color:
+        #212121; background-color: transparent; vertical-align: baseline; white-space-collapse:
+        preserve;\"> C4Media offers an opportunity to travel 3-4 times a year at our
+        expense to NYC, SF, London, and other fun, global locations for conferences
+        &amp; team building. We also got you covered to add a sightseeing day to the
+        end of the trip.</span></li>\n<li style=\"\"><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #212121;
+        background-color: transparent; font-weight: bold; vertical-align: baseline;
+        white-space-collapse: preserve;\">Take care of each other:</span><span style=\"font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #212121;
+        background-color: transparent; vertical-align: baseline; white-space-collapse:
+        preserve;\"> We look out for one another and prioritize respect, fairness,
+        support, and well-being. Check out our core values on our careers page.</span></li>\n<li
+        style=\"\"><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #212121; background-color: transparent; font-weight: bold;
+        vertical-align: baseline; white-space-collapse: preserve;\">Learn something
+        new:</span><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #212121; background-color: transparent; vertical-align: baseline;
+        white-space-collapse: preserve;\"> C4Media\u2019s culture is one of learning
+        &amp; mastering. Everyone has a training and education budget for professional
+        growth every year and is encouraged to use it.</span></li>\n<li style=\"\"><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates:
+        normal; font-variant-position: normal; font-variant-emoji: normal; color:
+        #212121; background-color: transparent; font-weight: bold; vertical-align:
+        baseline; white-space-collapse: preserve;\">Make friends across the world</span><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates:
+        normal; font-variant-position: normal; font-variant-emoji: normal; color:
+        #212121; background-color: transparent; vertical-align: baseline; white-space-collapse:
+        preserve;\">: Be a part of a leading, fast-growing international company and
+        build a network of international friends and colleagues for life.</span></li>\n<li
+        style=\"\"><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #212121; background-color: transparent; font-weight: bold;
+        vertical-align: baseline; white-space-collapse: preserve;\">Support wellbeing:</span><span
+        style=\"font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates:
+        normal; font-variant-position: normal; font-variant-emoji: normal; color:
+        #212121; background-color: transparent; vertical-align: baseline; white-space-collapse:
+        preserve;\"> In an effort to make physical activity more readily accessible,
+        we offer staff an annual subsidy towards fitness and wellness.</span></li>\n<li
+        style=\"\"><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #212121; background-color: transparent; font-weight: bold;
+        vertical-align: baseline; white-space-collapse: preserve;\">Generous paid
+        time off:</span><span style=\"font-variant-numeric: normal; font-variant-east-asian:
+        normal; font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #212121; background-color: transparent; vertical-align: baseline;
+        white-space-collapse: preserve;\"> In addition to 25 paid days off in the
+        1st year and 30 paid days off in every subsequent year, we provide 1 paid
+        day off for birthdays (or a similar special day) and 2 paid days for continuing
+        education.</span></li>\n<li style=\"\"><span style=\"background-color: transparent;
+        font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates:
+        normal; font-variant-position: normal; font-variant-emoji: normal; color:
+        #212121; font-weight: bold; vertical-align: baseline; white-space-collapse:
+        preserve;\">Mentorship</span><span style=\"background-color: transparent;
+        font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates:
+        normal; font-variant-position: normal; font-variant-emoji: normal; color:
+        #000000; vertical-align: baseline; white-space-collapse: preserve;\">: Receive
+        direct guidance and professional development from experienced project leads.</span></li>\n<li
+        style=\"\"><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #212121;
+        font-weight: bold; vertical-align: baseline; white-space-collapse: preserve;\">Global
+        Exposure</span><span style=\"background-color: transparent; font-variant-numeric:
+        normal; font-variant-east-asian: normal; font-variant-alternates: normal;
+        font-variant-position: normal; font-variant-emoji: normal; color: #000000;
+        vertical-align: baseline; white-space-collapse: preserve;\">: Interact with
+        tech professionals and world-class trainers daily.</span></li>\n<li style=\"\"><span
+        style=\"background-color: transparent; font-variant-numeric: normal; font-variant-east-asian:
+        normal; font-variant-alternates: normal; font-variant-position: normal; font-variant-emoji:
+        normal; color: #212121; font-weight: bold; vertical-align: baseline; white-space-collapse:
+        preserve;\">Event Experience</span><span style=\"background-color: transparent;
+        font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates:
+        normal; font-variant-position: normal; font-variant-emoji: normal; color:
+        #000000; vertical-align: baseline; white-space-collapse: preserve;\">: Gain
+        a front-row seat to how major international conferences are run, with potential
+        opportunities to support in-person events.</span></li>\n</ul>\n</ul>\n<p>\u00a0</p>\n<p
+        dir=\"ltr\" style=\"line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;\"><span
+        style=\"color: #000000; background-color: transparent; font-weight: 400; font-style:
+        italic; font-variant: normal; text-decoration: none; vertical-align: baseline;
+        white-space: pre-wrap;\">Qualified candidates are to submit their applications
+        on our C4Media website.</span></p>\n<img src=\"https://remotive.com/job/track/2088663/blank.gif?source=public_api\"
+        alt=\"\"/>"}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - '*'
+      Age:
+      - '35500'
+      CF-RAY:
+      - 9f10dc506b5a0c83-MIA
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2026 00:06:11 GMT
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=tXLRuN0DKick5XCK%2F2ehhRMDM6jB5nfG9J4VQkLcR6ohU9Sj43AEmEJ4fUAJEwwR57GbDTgSz7NY%2FsK4aa5xzkx7C%2F7ytmkTuk4RZ7pTBGoYTLW5ijhc4dgRKeCSSA%3D%3D"}]}'
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      cf-cache-status:
+      - HIT
+      last-modified:
+      - Thu, 23 Apr 2026 14:14:56 GMT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/sources/remotive/test_remotive.py
+++ b/tests/sources/remotive/test_remotive.py
@@ -1,0 +1,319 @@
+"""Unit tests for the Remotive plugin — pure, no I/O.
+
+Tests cover:
+- ClassVar metadata declared correctly
+- settings_schema() returns an empty dict (no credentials)
+- normalise() maps every Remotive API field to JobRecord correctly
+- normalise() handles missing / None values gracefully
+- pages() yields nothing when fetch returns empty
+- ScrapeError is raised (re-raised from requests) on network failure
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from job_aggregator.plugins.remotive import Plugin
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_raw(**overrides: Any) -> dict[str, Any]:
+    """Return a minimal valid Remotive job dict, with optional overrides."""
+    base: dict[str, Any] = {
+        "id": 12345,
+        "url": "https://remotive.com/remote-jobs/software-dev/senior-python-12345",
+        "title": "Senior Python Engineer",
+        "company_name": "Acme Corp",
+        "company_logo": "https://remotive.com/logo/acme.png",
+        "category": "Software Development",
+        "tags": ["python", "django"],
+        "job_type": "full_time",
+        "publication_date": "2026-04-20T12:00:00",
+        "candidate_required_location": "Worldwide",
+        "salary": "$120k-$150k",
+        "description": "<p>We are looking for a <strong>Python</strong> engineer.</p>",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# ClassVar metadata
+# ---------------------------------------------------------------------------
+
+
+class TestPluginMetadata:
+    """Verify every required ClassVar is set with the correct type/value."""
+
+    def test_source_key(self) -> None:
+        assert Plugin.SOURCE == "remotive"
+
+    def test_display_name(self) -> None:
+        assert Plugin.DISPLAY_NAME == "Remotive"
+
+    def test_description_matches_source_json(self) -> None:
+        # Verbatim from source.json
+        assert "remote" in Plugin.DESCRIPTION.lower()
+
+    def test_home_url(self) -> None:
+        assert Plugin.HOME_URL == "https://remotive.com"
+
+    def test_geo_scope_is_remote_only(self) -> None:
+        assert Plugin.GEO_SCOPE == "remote-only"
+
+    def test_accepts_query(self) -> None:
+        # Remotive supports a 'search' query param
+        assert Plugin.ACCEPTS_QUERY == "always"
+
+    def test_accepts_location_false(self) -> None:
+        # Remotive does not accept a location filter; results are remote-only
+        assert Plugin.ACCEPTS_LOCATION is False
+
+    def test_accepts_country_false(self) -> None:
+        # No country filter in the Remotive API
+        assert Plugin.ACCEPTS_COUNTRY is False
+
+    def test_rate_limit_notes_nonempty(self) -> None:
+        assert isinstance(Plugin.RATE_LIMIT_NOTES, str)
+        assert len(Plugin.RATE_LIMIT_NOTES) > 0
+
+    def test_required_search_fields_empty(self) -> None:
+        # No fields are mandatory; works without a query
+        assert Plugin.REQUIRED_SEARCH_FIELDS == ()
+
+
+# ---------------------------------------------------------------------------
+# settings_schema
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsSchema:
+    """Remotive requires no credentials."""
+
+    def test_returns_empty_dict(self) -> None:
+        plugin = Plugin()
+        assert plugin.settings_schema() == {}
+
+
+# ---------------------------------------------------------------------------
+# normalise() — field-by-field audit
+# ---------------------------------------------------------------------------
+
+
+class TestNormalise:
+    """Verify normalise() maps every upstream field correctly per §9.3."""
+
+    def setup_method(self) -> None:
+        self.plugin = Plugin()
+
+    def test_source_field(self) -> None:
+        result = self.plugin.normalise(_make_raw())
+        assert result["source"] == "remotive"
+
+    def test_source_id_is_str(self) -> None:
+        result = self.plugin.normalise(_make_raw(id=99))
+        assert result["source_id"] == "99"
+
+    def test_title(self) -> None:
+        result = self.plugin.normalise(_make_raw(title="ML Engineer"))
+        assert result["title"] == "ML Engineer"
+
+    def test_url(self) -> None:
+        url = "https://remotive.com/remote-jobs/foo/bar-1"
+        result = self.plugin.normalise(_make_raw(url=url))
+        assert result["url"] == url
+
+    def test_posted_at_mapped_from_publication_date(self) -> None:
+        result = self.plugin.normalise(_make_raw(publication_date="2026-04-20T12:00:00"))
+        assert result["posted_at"] == "2026-04-20T12:00:00"
+
+    def test_company(self) -> None:
+        result = self.plugin.normalise(_make_raw(company_name="Globex"))
+        assert result["company"] == "Globex"
+
+    def test_location_from_candidate_required_location(self) -> None:
+        result = self.plugin.normalise(_make_raw(candidate_required_location="USA only"))
+        assert result["location"] == "USA only"
+
+    def test_contract_time_from_job_type(self) -> None:
+        result = self.plugin.normalise(_make_raw(job_type="contract"))
+        assert result["contract_time"] == "contract"
+
+    def test_description_has_html_stripped(self) -> None:
+        result = self.plugin.normalise(_make_raw(description="<p>We need a <b>Python</b> dev.</p>"))
+        assert "<p>" not in result["description"]
+        assert "<b>" not in result["description"]
+        assert "Python" in result["description"]
+
+    def test_description_source_is_snippet(self) -> None:
+        result = self.plugin.normalise(_make_raw())
+        assert result["description_source"] == "snippet"
+
+    def test_remote_eligible_true(self) -> None:
+        # Remotive is a remote-only board; all listings are remote-eligible
+        result = self.plugin.normalise(_make_raw())
+        assert result["remote_eligible"] is True
+
+    def test_salary_currency_none_when_freetext(self) -> None:
+        # Salary is free-text; currency cannot be reliably parsed
+        result = self.plugin.normalise(_make_raw(salary="$120k-$150k"))
+        assert result["salary_currency"] is None
+
+    def test_salary_period_none(self) -> None:
+        result = self.plugin.normalise(_make_raw())
+        assert result["salary_period"] is None
+
+    def test_contract_type_none(self) -> None:
+        # contract_type has no direct upstream equivalent
+        result = self.plugin.normalise(_make_raw())
+        assert result["contract_type"] is None
+
+    def test_extra_contains_category(self) -> None:
+        # category and tags are source-specific; stored in extra
+        result = self.plugin.normalise(_make_raw(category="Design", tags=["ui", "ux"]))
+        assert result.get("extra") is not None
+        extra = result["extra"]
+        assert isinstance(extra, dict)
+        assert extra.get("category") == "Design"
+
+    def test_extra_contains_tags(self) -> None:
+        result = self.plugin.normalise(_make_raw(tags=["go", "kubernetes"]))
+        extra = result["extra"]
+        assert isinstance(extra, dict)
+        assert extra.get("tags") == ["go", "kubernetes"]
+
+    def test_extra_contains_company_logo(self) -> None:
+        logo = "https://remotive.com/logo/acme.png"
+        result = self.plugin.normalise(_make_raw(company_logo=logo))
+        extra = result["extra"]
+        assert isinstance(extra, dict)
+        assert extra.get("company_logo") == logo
+
+
+# ---------------------------------------------------------------------------
+# normalise() — graceful degradation with missing / None fields
+# ---------------------------------------------------------------------------
+
+
+class TestNormaliseMissingFields:
+    """Verify normalise() does not crash when upstream fields are absent."""
+
+    def setup_method(self) -> None:
+        self.plugin = Plugin()
+
+    def test_missing_id_gives_empty_source_id(self) -> None:
+        raw = _make_raw()
+        del raw["id"]
+        result = self.plugin.normalise(raw)
+        assert result["source_id"] == ""
+
+    def test_none_title_gives_empty_string(self) -> None:
+        result = self.plugin.normalise(_make_raw(title=None))
+        assert result["title"] == ""
+
+    def test_none_company_gives_none(self) -> None:
+        result = self.plugin.normalise(_make_raw(company_name=None))
+        assert result["company"] is None
+
+    def test_missing_salary_gives_no_salary_min_max(self) -> None:
+        raw = _make_raw()
+        del raw["salary"]
+        result = self.plugin.normalise(raw)
+        assert result["salary_min"] is None
+        assert result["salary_max"] is None
+
+    def test_none_location_gives_none(self) -> None:
+        result = self.plugin.normalise(_make_raw(candidate_required_location=None))
+        assert result["location"] is None
+
+    def test_missing_publication_date_gives_none_posted_at(self) -> None:
+        raw = _make_raw()
+        del raw["publication_date"]
+        result = self.plugin.normalise(raw)
+        assert result["posted_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# pages() — behaviour without real HTTP
+# ---------------------------------------------------------------------------
+
+
+class TestPages:
+    """pages() integration with mocked HTTP layer."""
+
+    def setup_method(self) -> None:
+        self.plugin = Plugin()
+
+    def test_pages_yields_list_of_records(self) -> None:
+        raw_jobs = [_make_raw(id=1), _make_raw(id=2)]
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"jobs": raw_jobs}
+
+        with patch("job_aggregator.plugins.remotive.plugin.requests.get", return_value=mock_resp):
+            pages = list(self.plugin.pages())
+
+        assert len(pages) == 1
+        assert len(pages[0]) == 2
+        assert pages[0][0]["source"] == "remotive"
+        assert pages[0][0]["source_id"] == "1"
+
+    def test_pages_yields_nothing_when_jobs_empty(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"jobs": []}
+
+        with patch("job_aggregator.plugins.remotive.plugin.requests.get", return_value=mock_resp):
+            pages = list(self.plugin.pages())
+
+        assert pages == []
+
+    def test_pages_yields_nothing_on_http_error(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 503
+
+        with patch("job_aggregator.plugins.remotive.plugin.requests.get", return_value=mock_resp):
+            pages = list(self.plugin.pages())
+
+        assert pages == []
+
+    def test_pages_raises_scrape_error_on_network_failure(self) -> None:
+        import requests as req
+
+        from job_aggregator.errors import ScrapeError
+
+        with (
+            patch(
+                "job_aggregator.plugins.remotive.plugin.requests.get",
+                side_effect=req.RequestException("connection refused"),
+            ),
+            pytest.raises(ScrapeError),
+        ):
+            list(self.plugin.pages())
+
+
+# ---------------------------------------------------------------------------
+# Constructor — search params forwarded to API
+# ---------------------------------------------------------------------------
+
+
+class TestConstructor:
+    """Plugin accepts SearchParams-style kwargs and forwards them."""
+
+    def test_default_construction_succeeds(self) -> None:
+        plugin = Plugin()
+        assert plugin is not None
+
+    def test_query_param_accepted(self) -> None:
+        plugin = Plugin(query="data engineer")
+        assert plugin is not None
+
+    def test_category_param_accepted(self) -> None:
+        plugin = Plugin(category="software-dev")
+        assert plugin is not None

--- a/tests/sources/remotive/test_remotive_integration.py
+++ b/tests/sources/remotive/test_remotive_integration.py
@@ -1,0 +1,59 @@
+"""VCR integration tests for the Remotive plugin.
+
+Uses pytest-recording (vcrpy) cassettes to replay a real API response
+without making live network calls.  Record once with::
+
+    uv run pytest tests/sources/remotive/test_remotive_integration.py \\
+        --record-mode=once
+
+No scrubbing is required — Remotive is a public API with no credentials.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from job_aggregator.plugins.remotive import Plugin
+
+
+@pytest.mark.vcr()
+def test_pages_returns_listings_from_cassette() -> None:
+    """pages() returns at least one normalised listing via cassette.
+
+    Verifies the full request→parse→normalise round-trip against a
+    recorded real response.
+    """
+    plugin = Plugin(query="python", limit=5)
+    pages = list(plugin.pages())
+
+    assert len(pages) >= 1, "Expected at least one page of results"
+    records = pages[0]
+    assert len(records) >= 1, "Expected at least one listing"
+
+    first = records[0]
+    # Identity fields
+    assert first["source"] == "remotive"
+    assert isinstance(first["source_id"], str)
+    assert first["source_id"] != ""
+    assert first["description_source"] == "snippet"
+
+    # Always-present fields
+    assert isinstance(first["title"], str)
+    assert isinstance(first["url"], str)
+    assert isinstance(first["description"], str)
+    # HTML must be stripped
+    assert "<" not in first["description"]
+
+    # remote_eligible must be True for all Remotive listings
+    assert first["remote_eligible"] is True
+
+
+@pytest.mark.vcr()
+def test_pages_with_category_filter() -> None:
+    """pages() works when a category filter is supplied."""
+    plugin = Plugin(category="software-dev", limit=3)
+    pages = list(plugin.pages())
+
+    assert len(pages) >= 1
+    for record in pages[0]:
+        assert record["source"] == "remotive"


### PR DESCRIPTION
## Summary

- Migrates the `remotive` plugin from the legacy `job-matcher-pr` repo into `src/job_aggregator/plugins/remotive/`
- Implements the `JobSource` ABC contract: `pages()`, `normalise()`, `settings_schema()`
- Registers the entry-point in `pyproject.toml`; updates `CHANGELOG.md` and the §11.5 catalog table

## Audit values table

| Attribute | Value | Justification |
|---|---|---|
| `SOURCE` | `"remotive"` | Canonical key from legacy `source.json` |
| `DISPLAY_NAME` | `"Remotive"` | Verbatim from `source.json` |
| `DESCRIPTION` | `"Curated remote tech jobs across software, design, and marketing. Free API with no authentication. Smaller volume but strong signal-to-noise."` | Verbatim from `source.json` |
| `HOME_URL` | `"https://remotive.com"` | Verbatim from `source.json` |
| `GEO_SCOPE` | `"remote-only"` | Remotive is a curated remote-jobs board; all listings are inherently remote |
| `ACCEPTS_QUERY` | `"always"` | API supports a `search` query parameter forwarded on every call |
| `ACCEPTS_LOCATION` | `False` | No location filter in the API; the board is remote-only by design |
| `ACCEPTS_COUNTRY` | `False` | No country filter in the API |
| `RATE_LIMIT_NOTES` | `"No published rate limit; public API, use conservatively."` | Remotive's API docs recommend max 4 calls/day; no hard limit published |
| `REQUIRED_SEARCH_FIELDS` | `()` | No mandatory parameters; plugin works without a query |

## Drift notes

The legacy plugin used `parse_salary` (a utility in the legacy repo) and `strip_html` (from `job_sources.utils`). Neither utility exists in this package:

- **HTML stripping**: replaced with a stdlib `html.parser.HTMLParser` subclass (`_HTMLStripper`). No external dependency required.
- **Salary parsing**: dropped. Remotive salary is free-text (e.g. `"$120k-$150k"`); reliable numeric extraction requires a heuristic beyond plugin scope. `salary_min`/`salary_max` are set to `None`; the raw string is preserved in `extra.salary_raw` for consumers who want it.
- **`redirect_url` → `url`**: renamed per §9.3 spec (`url` is the canonical field name; `redirect_url` was the legacy schema key).
- **`created_at` → `posted_at`**: renamed per §9.3 spec.
- **`remote_eligible`**: added as `True` unconditionally — Remotive is remote-only so this is always correct.
- **`description_source`**: set to `"snippet"` because Remotive returns HTML descriptions that are source-provided rather than full scraped text.
- **source-specific fields**: `company_logo`, `category`, `tags` moved to `extra` dict per §9.5 policy.

## Test plan

- [x] 41 unit tests covering all ClassVar metadata, `settings_schema()`, every `normalise()` field mapping, missing/None field graceful degradation, `pages()` happy path + error paths
- [x] 2 VCR integration tests recorded against live API (22 listings returned in preflight); cassettes committed
- [x] No credentials in cassettes (public API — no scrubbing needed)
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src tests scripts` — no issues in 21 source files
- [x] `deptry src/` — clean (pre-existing DEP003/DEP004 on `deptry .` are from skeleton tests, not this plugin)
- [x] Full pytest suite: 150/150 passed

Closes #12

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*