### PR TITLE
chore: add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ ENV/
 # Claude Code local settings
 .claude/settings.local.json
 
+# Environment / credentials (never commit)
+.env
+
 # Git worktrees (local-only by convention)
 .worktrees/
 


### PR DESCRIPTION
## Summary

- Adds `.env` to `.gitignore` with an explanatory comment
- Protects credential files for the 4 paid-source plugins (adzuna, jooble, jsearch, usajobs) from accidental commit

## Why

The extraction work tracked in #35 uses a `.env` file to load API credentials for recording VCR cassettes. Cassettes are scrubbed of secrets before commit, but `.env` itself has no ignore rule today — any `git add -A` would commit it.

Closes #36

## Test plan

- [x] `.gitignore` diff is exactly three lines added (comment + `.env` + trailing blank)
- [x] CI green
- [ ] `git check-ignore .env` exits 0 after merge

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*