### PR TITLE
chore: fix mypy errors in tests/ and expand CI mypy scope (closes #40, #41)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: uv sync --group dev
 
       - name: Type check
-        run: uv run mypy src/
+        run: uv run mypy src/ tests/ scripts/
 
   # --------------------------------------------------------------------------
   # Job 3: deptry — import / dependency hygiene

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,10 @@ uv run ruff format src tests scripts
 uv run mypy src tests scripts
 ```
 
+CI runs `mypy --strict` against `src/`, `tests/`, and `scripts/`. If you add another
+top-level directory with Python code, extend the `Type check` step in
+`.github/workflows/ci.yml` to cover it.
+
 ---
 
 ## Dependency audit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ select = ["E", "F", "W", "I", "N", "UP", "B", "SIM", "RUF"]
 [tool.mypy]
 strict = true
 python_version = "3.11"
-mypy_path = "src"
+mypy_path = ["src", "scripts"]
 namespace_packages = true
 explicit_package_bases = true
 

--- a/tests/test_preflight_smoke.py
+++ b/tests/test_preflight_smoke.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -103,7 +103,7 @@ class TestArgumentParsing:
 
     def _parse(self, argv: list[str]) -> argparse.Namespace:
         """Parse argv without sys.argv side-effects."""
-        return cast(argparse.Namespace, ps.build_arg_parser().parse_args(argv))
+        return ps.build_arg_parser().parse_args(argv)
 
     def test_default_mode_is_dry_run(self) -> None:
         """Running with no flags must default to dry-run mode."""

--- a/tests/test_preflight_smoke.py
+++ b/tests/test_preflight_smoke.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -103,7 +103,7 @@ class TestArgumentParsing:
 
     def _parse(self, argv: list[str]) -> argparse.Namespace:
         """Parse argv without sys.argv side-effects."""
-        return ps.build_arg_parser().parse_args(argv)
+        return cast(argparse.Namespace, ps.build_arg_parser().parse_args(argv))
 
     def test_default_mode_is_dry_run(self) -> None:
         """Running with no flags must default to dry-run mode."""


### PR DESCRIPTION
## Summary

- **Fix `import-not-found` (#40):** Added `scripts` to `mypy_path` in `pyproject.toml` so mypy can resolve `import preflight_smoke` in `tests/test_preflight_smoke.py` without requiring a package install or path hacks.
- **Fix `no-any-return` (#40):** Added `cast(argparse.Namespace, ...)` in the `_parse` test helper to narrow the `Any`-typed return from `_PreflightParser.parse_args` (which carries `# type: ignore[override]`) to the declared return type.
- **Expand CI mypy scope (#41):** Changed the `Type check` step in `.github/workflows/ci.yml` from `uv run mypy src/` to `uv run mypy src/ tests/ scripts/` so future regressions in tests/ or scripts/ are caught in CI. Updated `CONTRIBUTING.md` to document this coverage.

## Verification (all 5 gates pass)

- `uv run pytest` — 646 passed, 2 skipped (expected credential skips)
- `uv run ruff check .` — All checks passed
- `uv run ruff format --check .` — 70 files already formatted
- `uv run mypy --strict src/ tests/ scripts/` — **Success: no issues found in 70 source files**
- `uv run deptry src/` — No dependency issues found

## Files changed

| File | Change |
|---|---|
| `pyproject.toml` | `mypy_path` expanded from `"src"` to `["src", "scripts"]` |
| `tests/test_preflight_smoke.py` | Added `cast` import; wrapped `parse_args` return in `cast(argparse.Namespace, ...)` |
| `.github/workflows/ci.yml` | Mypy step: `src/` → `src/ tests/ scripts/` |
| `CONTRIBUTING.md` | Added note on extended mypy scope and how to extend it further |

Closes #40
Closes #41

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*