### PR TITLE
feat: hydrate CLI + public scrape_description (#17)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev = [
     "pip-audit",
     "pre-commit",
     "python-dotenv>=1.0",
+    "responses>=0.25",
     "types-requests>=2.31",
 ]
 

--- a/src/job_aggregator/__init__.py
+++ b/src/job_aggregator/__init__.py
@@ -16,8 +16,8 @@ from job_aggregator.errors import (
     SchemaVersionError,
     ScrapeError,
 )
+from job_aggregator.hydrator import HydrateConfig, hydrate
 from job_aggregator.normalizer import (
-    SCRAPE_MIN_LENGTH,
     classify_description_source,
     normalize,
 )
@@ -33,6 +33,7 @@ from job_aggregator.schema import (
     PluginInfo,
     SearchParams,
 )
+from job_aggregator.scraping import SCRAPE_MIN_LENGTH, scrape_description
 
 # ---------------------------------------------------------------------------
 # Version
@@ -66,6 +67,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 __all__: list[str] = [
     "SCRAPE_MIN_LENGTH",
     "CredentialsError",
+    "HydrateConfig",
     "JobAggregatorError",
     "JobRecord",
     "JobSource",
@@ -80,8 +82,10 @@ __all__: list[str] = [
     "build_jsonl_lines",
     "classify_description_source",
     "get_plugin",
+    "hydrate",
     "list_plugins",
     "make_enabled_sources",
     "normalize",
     "run_jobs",
+    "scrape_description",
 ]

--- a/src/job_aggregator/cli/__main__.py
+++ b/src/job_aggregator/cli/__main__.py
@@ -8,9 +8,7 @@ parallel-PR integration a 2-line diff per new command.
 Current sub-commands:
     ``jobs``    — fetch, normalise, dedup, and emit job listings (Issue #16 / Phase D).
     ``sources`` — list registered plugins as JSON (Issue F / #18).
-
-Stub sub-commands:
-    ``hydrate`` — scrape full descriptions (Issue #18 / Phase E, not yet implemented).
+    ``hydrate`` — scrape full descriptions (Issue #17 / Phase E).
 
 Public API (consumed by tests):
     :func:`main` — console-script entry point.
@@ -25,6 +23,7 @@ import argparse
 import sys
 
 from job_aggregator import __version__
+from job_aggregator.cli import hydrate as _hydrate_cmd
 from job_aggregator.cli import jobs as _jobs_cmd
 from job_aggregator.cli import sources as _sources_cmd
 
@@ -72,53 +71,9 @@ def _build_parser() -> argparse.ArgumentParser:
     # Register each sub-command module here — one line per module.
     _jobs_cmd.register(subparsers)
     _sources_cmd.register(subparsers)
-
-    # ------------------------------------------------------------------
-    # hydrate stub — Phase E (Issue #18, not yet implemented).
-    # Registering here keeps --help accurate; the real module will
-    # replace this with its own register() call when it lands.
-    # ------------------------------------------------------------------
-    _add_hydrate_stub(subparsers)
+    _hydrate_cmd.register(subparsers)
 
     return parser
-
-
-def _add_hydrate_stub(
-    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
-) -> None:
-    """Register the ``hydrate`` stub subparser.
-
-    Full implementation is delivered by Issue #18 (Phase E).  This stub
-    registers the subcommand so ``--help`` documents it and the parallel
-    PR can introduce the real module without touching other registrations.
-
-    Args:
-        subparsers: The subparsers action from the top-level parser.
-    """
-    p = subparsers.add_parser(
-        "hydrate",
-        help=(
-            "Scrape full job descriptions for records produced by `jobs`. "
-            "(Not yet implemented — Phase E)"
-        ),
-    )
-    p.set_defaults(func=_cmd_hydrate_stub)
-
-
-def _cmd_hydrate_stub(args: argparse.Namespace) -> None:
-    """Stub handler for the ``hydrate`` subcommand.
-
-    Exits non-zero with a not-yet-implemented message until Issue #18
-    (Phase E) delivers the real implementation.
-
-    Args:
-        args: Parsed namespace (unused by stub).
-    """
-    print(
-        "hydrate: not yet implemented (Issue #18 / Phase E).",
-        file=sys.stderr,
-    )
-    sys.exit(1)
 
 
 # ---------------------------------------------------------------------------

--- a/src/job_aggregator/cli/hydrate.py
+++ b/src/job_aggregator/cli/hydrate.py
@@ -1,0 +1,254 @@
+"""CLI subcommand: job-aggregator hydrate.
+
+Reads job records from stdin or a file, scrapes full descriptions for each
+record, and emits enriched records (spec §8.2 / Phase E, Issue #17).
+
+Input handling follows the §8.2.1 table exactly:
+- Records with ``description_source = "full"`` are passed through unchanged.
+- Records with absent, null, empty, or non-HTTP/HTTPS ``url`` are passed
+  through unchanged with a stderr warning.
+- Records with an unrecognised ``description_source`` value are passed through
+  unchanged with a stderr warning (future-compat / defensive).
+- A ``schema_version`` major mismatch in the input envelope causes exit code 4.
+
+Format inference (when ``--format`` is not set explicitly): peek the first
+non-whitespace byte of input.  If it is ``{`` **and** the first complete JSON
+value parses as a single object containing a ``"jobs"`` key, treat as
+``--format json``.  Otherwise treat as ``--format jsonl``.
+
+Integration pattern
+-------------------
+This module follows the same conflict-friendly dispatcher pattern as
+``cli/sources.py`` and ``cli/jobs.py``:
+
+- :func:`register` — adds the ``hydrate`` subparser to an existing
+  :class:`argparse.ArgumentParser` subparsers group.
+- :func:`run` — executes the command given a parsed
+  :class:`argparse.Namespace`.
+
+The dispatcher wires this in with two lines::
+
+    from job_aggregator.cli import hydrate as _hydrate_cmd
+    _hydrate_cmd.register(subparsers)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from job_aggregator.errors import SchemaVersionError
+from job_aggregator.hydrator import HydrateConfig, hydrate
+
+# ---------------------------------------------------------------------------
+# Public subcommand API
+# ---------------------------------------------------------------------------
+
+
+def register(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Add the ``hydrate`` subcommand to an argparse subparsers group.
+
+    Registers all §8.2 flags and sets ``func=run`` as the dispatch target.
+
+    Args:
+        subparsers: The ``_SubParsersAction`` returned by
+            ``parser.add_subparsers()``.
+    """
+    p = subparsers.add_parser(
+        "hydrate",
+        help="Scrape full job descriptions for records produced by `jobs`.",
+        description=(
+            "Read job records from stdin or --input, fetch the full job "
+            "description for each record, and emit enriched records.\n\n"
+            "Input handling (§8.2.1):\n"
+            "  description_source='full'   — passed through unchanged\n"
+            "  url absent/null/empty       — passed through, warning emitted\n"
+            "  url not http/https          — passed through, warning emitted\n"
+            "  unknown description_source  — passed through, warning emitted\n"
+            "  schema_version major mismatch — exit code 4\n\n"
+            "Format inference (when --format not set): "
+            "if the first non-whitespace byte is '{' and the input parses as "
+            "a JSON object containing 'jobs', treat as --format json; "
+            "otherwise treat as --format jsonl."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    # --- Input / output ---
+    p.add_argument(
+        "--input",
+        metavar="PATH",
+        default=None,
+        help=("JSONL or JSON file produced by `jobs`.  Use '-' or omit to read from stdin."),
+    )
+    p.add_argument(
+        "--output",
+        metavar="PATH",
+        default=None,
+        help="Output file path.  Defaults to stdout.",
+    )
+
+    # --- Timeout ---
+    p.add_argument(
+        "--timeout-per-request",
+        type=int,
+        default=15,
+        metavar="N",
+        help="Per-URL HTTP timeout in seconds (default: 15).",
+    )
+    p.add_argument(
+        "--timeout-total",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Hard wall-clock budget for the whole run in seconds.  "
+            "When exceeded, remaining records are passed through unchanged "
+            "and a warning is logged.  Default: no limit."
+        ),
+    )
+
+    # --- Error handling ---
+    p.add_argument(
+        "--continue-on-error",
+        action="store_true",
+        default=True,
+        help=(
+            "When a scrape fails, pass the record through unchanged and "
+            "log to stderr.  This is the default behaviour."
+        ),
+    )
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        default=False,
+        help="Exit non-zero on the first scrape failure.",
+    )
+
+    # --- Format ---
+    p.add_argument(
+        "--format",
+        dest="fmt",
+        choices=["json", "jsonl"],
+        default=None,
+        metavar="FORMAT",
+        help=(
+            "Output format: 'json' (single envelope object) or 'jsonl' "
+            "(envelope first line, one record per subsequent line).  "
+            "Inferred from input when not set."
+        ),
+    )
+
+    # --- Verbosity ---
+    verbosity = p.add_mutually_exclusive_group()
+    verbosity.add_argument(
+        "-v",
+        dest="verbosity",
+        action="store_const",
+        const=1,
+        default=0,
+        help="Verbose output.",
+    )
+    verbosity.add_argument(
+        "-vv",
+        dest="verbosity",
+        action="store_const",
+        const=2,
+        help="Very verbose output.",
+    )
+    verbosity.add_argument(
+        "--quiet",
+        dest="verbosity",
+        action="store_const",
+        const=-1,
+        help="Suppress all non-error output.",
+    )
+
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> None:
+    """Execute the hydrate subcommand.
+
+    Opens the input stream, constructs a :class:`~job_aggregator.hydrator.HydrateConfig`
+    from *args*, delegates to :func:`~job_aggregator.hydrator.hydrate`, and
+    writes the output.
+
+    Exit codes:
+        0 — success (or failure tolerated by ``--continue-on-error``).
+        1 — unrecoverable I/O or parse error.
+        2 — scrape failure when ``--strict`` is set.
+        4 — cross-major ``schema_version`` mismatch in the input envelope.
+
+    Args:
+        args: The parsed :class:`argparse.Namespace`.  Recognised attributes:
+
+            - ``input`` (:class:`str` | ``None``) — path to input file;
+              ``None`` or ``"-"`` reads from stdin.
+            - ``output`` (:class:`str` | ``None``) — path to output file;
+              ``None`` writes to stdout.
+            - ``timeout_per_request`` (:class:`int`) — per-URL HTTP timeout.
+            - ``timeout_total`` (:class:`int` | ``None``) — total budget.
+            - ``strict`` (:class:`bool`) — exit non-zero on any failure.
+            - ``continue_on_error`` (:class:`bool`) — tolerate failures.
+            - ``fmt`` (:class:`str` | ``None``) — format override.
+            - ``verbosity`` (:class:`int`) — 0/1/2/-1.
+    """
+    # --- Open input stream ---
+    input_path: str | None = getattr(args, "input", None)
+    if input_path is None or input_path == "-":
+        raw = sys.stdin.read()
+    else:
+        try:
+            raw = Path(input_path).read_text(encoding="utf-8")
+        except OSError as exc:
+            print(
+                f"job-aggregator hydrate: cannot read input file {input_path!r}: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    # --- Build config ---
+    config = HydrateConfig(
+        timeout_per_request=int(args.timeout_per_request),
+        timeout_total=(int(args.timeout_total) if args.timeout_total is not None else None),
+        continue_on_error=bool(getattr(args, "continue_on_error", True)),
+        strict=bool(args.strict),
+        fmt=getattr(args, "fmt", None),
+        verbosity=int(getattr(args, "verbosity", 0)),
+    )
+
+    # --- Run hydrator ---
+    from io import StringIO
+
+    try:
+        output = hydrate(StringIO(raw), config)
+    except SchemaVersionError as exc:
+        print(
+            f"job-aggregator hydrate: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(4)
+    except Exception as exc:
+        print(
+            f"job-aggregator hydrate: unexpected error: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    # --- Write output ---
+    output_path: str | None = getattr(args, "output", None)
+    if output_path is None:
+        print(output)
+    else:
+        try:
+            Path(output_path).write_text(output + "\n", encoding="utf-8")
+        except OSError as exc:
+            print(
+                f"job-aggregator hydrate: cannot write output file {output_path!r}: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(1)

--- a/src/job_aggregator/hydrator.py
+++ b/src/job_aggregator/hydrator.py
@@ -1,0 +1,384 @@
+"""Hydrate orchestrator: read records, scrape descriptions, emit enriched output.
+
+Implements the ``hydrate`` command's core loop (spec §8.2, §9.2, §9.6):
+
+1. Infer or accept the input format (JSON envelope or JSONL).
+2. Parse the input stream, detecting an optional §9.2 envelope.
+3. For each record, apply the §8.2.1 input handling rules:
+   - Skip if ``description_source = "full"``.
+   - Skip (warn) if ``url`` is absent, null, empty, or non-HTTP/HTTPS.
+   - Skip (warn) if ``description_source`` is an unknown value.
+   - Pass through unchanged if the total wall-clock budget is exhausted.
+4. For records that need scraping, call :func:`~job_aggregator.scraping.scrape_description`.
+5. Emit enriched records in the same format as the input (or as overridden
+   by ``HydrateConfig.fmt``).
+6. Propagate the input envelope, updating ``command`` → ``"hydrate"`` and
+   ``generated_at`` → now (spec §9.2).
+
+Public API:
+    :class:`HydrateConfig` — typed configuration bag.
+    :func:`hydrate` — main entry point consumed by the CLI and tests.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from io import StringIO
+from typing import Any
+
+from job_aggregator.envelope import SCHEMA_VERSION, build_envelope, build_jsonl_lines
+from job_aggregator.errors import SchemaVersionError, ScrapeError
+from job_aggregator.scraping import scrape_description
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Valid description_source values understood by this version of the package.
+# ---------------------------------------------------------------------------
+
+_KNOWN_DESCRIPTION_SOURCES = frozenset({"full", "snippet", "none"})
+
+# ---------------------------------------------------------------------------
+# HydrateConfig — typed configuration bag
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HydrateConfig:
+    """Typed configuration for :func:`hydrate`.
+
+    Attributes:
+        timeout_per_request: Per-URL HTTP timeout in seconds (§8.2).
+        timeout_total: Hard wall-clock budget for the whole run in seconds,
+            or ``None`` for no limit (§8.2).
+        continue_on_error: When ``True`` (default), scrape failures are
+            logged and the record is passed through unchanged.
+        strict: When ``True``, raise :class:`~job_aggregator.errors.ScrapeError`
+            on the first scrape failure (§8.2).
+        fmt: Output format override — ``"json"``, ``"jsonl"``, or ``None``
+            to infer from the input.
+        verbosity: 0 = default, 1 = ``-v``, 2 = ``-vv``, -1 = ``--quiet``.
+    """
+
+    timeout_per_request: int
+    timeout_total: int | None
+    continue_on_error: bool
+    strict: bool
+    fmt: str | None
+    verbosity: int
+
+
+# ---------------------------------------------------------------------------
+# Format inference
+# ---------------------------------------------------------------------------
+
+
+def _infer_format(raw: str) -> str:
+    """Infer the input format from the first non-whitespace byte.
+
+    Per spec §8.2.1: if the first non-whitespace character is ``{`` AND
+    the first complete JSON value parses as a single object containing a
+    ``"jobs"`` key, treat as ``"json"``.  Otherwise treat as ``"jsonl"``.
+
+    Args:
+        raw: The full input string (may be empty).
+
+    Returns:
+        ``"json"`` or ``"jsonl"``.
+    """
+    stripped = raw.lstrip()
+    if not stripped.startswith("{"):
+        return "jsonl"
+
+    # Try to parse the entire string as a JSON object
+    try:
+        obj = json.loads(stripped)
+        if isinstance(obj, dict) and "jobs" in obj:
+            return "json"
+    except json.JSONDecodeError:
+        pass
+
+    return "jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Envelope / record parsing
+# ---------------------------------------------------------------------------
+
+
+def _check_schema_version(schema_version: str) -> None:
+    """Raise SchemaVersionError if the major version is incompatible.
+
+    Args:
+        schema_version: The ``schema_version`` string from the input envelope.
+
+    Raises:
+        SchemaVersionError: If the major component of *schema_version* differs
+            from the package's current major version.
+    """
+    try:
+        input_major = int(schema_version.split(".")[0])
+        package_major = int(SCHEMA_VERSION.split(".")[0])
+    except (ValueError, IndexError):
+        # Malformed version — treat as incompatible
+        raise SchemaVersionError(got=schema_version, expected=SCHEMA_VERSION) from None
+
+    if input_major != package_major:
+        raise SchemaVersionError(got=schema_version, expected=SCHEMA_VERSION)
+
+    if schema_version != SCHEMA_VERSION:
+        logger.warning(
+            "Input schema_version %r differs from package version %r; proceeding best-effort.",
+            schema_version,
+            SCHEMA_VERSION,
+        )
+
+
+def _parse_json_input(raw: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Parse a JSON-format input string.
+
+    Args:
+        raw: A JSON string representing a §9.2 envelope.
+
+    Returns:
+        A ``(envelope, records)`` tuple where *envelope* is the full
+        envelope dict and *records* is the list of job dicts from the
+        ``"jobs"`` field.
+    """
+    envelope: dict[str, Any] = json.loads(raw)
+    records: list[dict[str, Any]] = list(envelope.get("jobs", []))
+    return envelope, records
+
+
+def _parse_jsonl_input(
+    raw: str,
+) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+    """Parse a JSONL-format input string.
+
+    The first line is examined to see if it is an envelope (contains
+    ``"schema_version"`` and an empty or absent ``"jobs"`` list).  All
+    remaining non-empty lines are treated as job records.
+
+    Args:
+        raw: A JSONL string.
+
+    Returns:
+        A ``(envelope_or_none, records)`` tuple.
+    """
+    lines = [line for line in raw.splitlines() if line.strip()]
+    if not lines:
+        return None, []
+
+    envelope: dict[str, Any] | None = None
+    start = 0
+
+    first = json.loads(lines[0])
+    if isinstance(first, dict) and "schema_version" in first:
+        envelope = first
+        start = 1
+
+    records = [json.loads(line) for line in lines[start:]]
+    return envelope, records
+
+
+# ---------------------------------------------------------------------------
+# Record processing
+# ---------------------------------------------------------------------------
+
+
+def _should_skip_record(
+    record: dict[str, Any],
+) -> tuple[bool, str]:
+    """Determine whether a record should be skipped without scraping.
+
+    Implements §8.2.1 input handling rules.
+
+    Args:
+        record: A job record dict.
+
+    Returns:
+        A ``(skip, reason)`` tuple.  *skip* is ``True`` if the record
+        should be passed through unchanged; *reason* is a short string
+        describing why (empty when *skip* is ``False``).
+    """
+    ds = record.get("description_source", "")
+
+    # Row 1: already full — no re-scrape.
+    if ds == "full":
+        return True, "already_full"
+
+    # Defensive: unknown description_source — pass through.
+    if ds not in _KNOWN_DESCRIPTION_SOURCES:
+        return True, f"unknown_description_source:{ds}"
+
+    # Rows 2-4: check URL validity.
+    url = record.get("url")
+    if url is None or url == "":
+        return True, "missing_url"
+
+    if not str(url).startswith(("http://", "https://")):
+        return True, "malformed_url"
+
+    return False, ""
+
+
+def _warn_skip(
+    record: dict[str, Any],
+    reason: str,
+) -> None:
+    """Emit a stderr warning for a skipped record.
+
+    Only emits when the skip reason is informative (not ``"already_full"``).
+
+    Args:
+        record: The job record being skipped.
+        reason: The reason returned by :func:`_should_skip_record`.
+    """
+    if reason == "already_full":
+        return
+    source = record.get("source", "?")
+    source_id = record.get("source_id", "?")
+    print(
+        f"WARNING: hydrate skipping ({source}, {source_id}): {reason}",
+        file=sys.stderr,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def hydrate(
+    stream: StringIO,
+    config: HydrateConfig,
+) -> str:
+    """Read job records from *stream*, scrape descriptions, return enriched output.
+
+    Implements the full §8.2 / §9.6 hydrate pipeline:
+
+    1. Read the full input from *stream*.
+    2. Infer or apply the configured format.
+    3. Validate the envelope schema version (if present).
+    4. Process each record per §8.2.1 and the §9.6 hydrate truth table.
+    5. Emit the enriched records, propagating the envelope per §9.2.
+
+    Args:
+        stream: Readable text stream containing job records (JSONL or JSON).
+        config: A :class:`HydrateConfig` controlling timeouts, error handling,
+            output format, and verbosity.
+
+    Returns:
+        A string containing the enriched output (JSONL or JSON).
+
+    Raises:
+        SchemaVersionError: When the input envelope's major ``schema_version``
+            differs from the package's current major version.
+        ScrapeError: When ``config.strict`` is ``True`` and a scrape fails.
+    """
+    raw = stream.read()
+
+    # Determine format.
+    fmt = config.fmt if config.fmt is not None else _infer_format(raw)
+
+    # Parse input.
+    envelope: dict[str, Any] | None
+    if fmt == "json":
+        envelope, records = _parse_json_input(raw)
+    else:
+        envelope, records = _parse_jsonl_input(raw)
+
+    # Validate schema version if present.
+    if envelope is not None:
+        sv = envelope.get("schema_version", SCHEMA_VERSION)
+        _check_schema_version(str(sv))
+
+    # Build a mutable copy of the envelope for propagation.
+    input_envelope: dict[str, Any] | None = envelope
+
+    # Track wall-clock budget.
+    run_start = time.monotonic()
+    budget_exhausted = False
+
+    enriched: list[dict[str, Any]] = []
+
+    for record in records:
+        skip, reason = _should_skip_record(record)
+        if skip:
+            _warn_skip(record, reason)
+            enriched.append(record)
+            continue
+
+        # Check total timeout budget.
+        if config.timeout_total is not None:
+            elapsed = time.monotonic() - run_start
+            if elapsed >= config.timeout_total:
+                if not budget_exhausted:
+                    logger.warning(
+                        "hydrate: total timeout (%ds) exceeded; "
+                        "remaining records passed through unchanged.",
+                        config.timeout_total,
+                    )
+                    budget_exhausted = True
+                enriched.append(record)
+                continue
+
+        url = str(record["url"])
+        fallback_desc = str(record.get("description", ""))
+
+        scraped_text, ok = scrape_description(
+            url,
+            fallback=fallback_desc,
+            timeout=config.timeout_per_request,
+        )
+
+        if ok:
+            new_record = dict(record)
+            new_record["description"] = scraped_text
+            new_record["description_source"] = "full"
+            enriched.append(new_record)
+        else:
+            # Scrape failed.
+            if config.strict:
+                raise ScrapeError(url=url, reason="scrape returned ok=False")
+            enriched.append(record)
+
+    # Assemble the output envelope.
+    now = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    if input_envelope is not None:
+        sources_used: list[str] = list(input_envelope.get("sources_used", []))
+        sources_failed: list[str] = list(input_envelope.get("sources_failed", []))
+        request_summary: dict[str, Any] = dict(input_envelope.get("request_summary", {}))
+    else:
+        sources_used = []
+        sources_failed = []
+        request_summary = {}
+
+    if fmt == "json":
+        out_envelope = build_envelope(
+            command="hydrate",
+            sources_used=sources_used,
+            sources_failed=sources_failed,
+            request_summary=request_summary,
+            jobs=enriched,  # type: ignore[arg-type]
+            generated_at=now,
+        )
+        return json.dumps(out_envelope, separators=(",", ":"))
+    else:
+        lines = list(
+            build_jsonl_lines(
+                command="hydrate",
+                sources_used=sources_used,
+                sources_failed=sources_failed,
+                request_summary=request_summary,
+                jobs=enriched,  # type: ignore[arg-type]
+                generated_at=now,
+            )
+        )
+        return "\n".join(lines)

--- a/src/job_aggregator/normalizer.py
+++ b/src/job_aggregator/normalizer.py
@@ -30,11 +30,9 @@ from job_aggregator.schema import JobRecord
 # ---------------------------------------------------------------------------
 # Public constants
 # ---------------------------------------------------------------------------
-
-#: Minimum character length for a description to be classified as "full".
-#: Imported by the ``hydrate`` orchestrator and by ``ingest.py`` in
-#: ``job-matcher-pr`` (never redefined locally there — spec §9.6).
-SCRAPE_MIN_LENGTH: int = 500
+# Canonical definition lives in scraping.py (spec §9.6).  Re-exported here
+# so that existing callers of normalizer.SCRAPE_MIN_LENGTH keep working.
+from job_aggregator.scraping import SCRAPE_MIN_LENGTH as SCRAPE_MIN_LENGTH
 
 # ---------------------------------------------------------------------------
 # description_source classifier — §9.6 truth table (jobs orchestrator rows)

--- a/src/job_aggregator/scraping.py
+++ b/src/job_aggregator/scraping.py
@@ -1,0 +1,112 @@
+"""HTTP scraping helpers for job description pages.
+
+Provides :func:`scrape_description`, which fetches a job listing URL,
+strips navigation/chrome noise, and returns the visible text.  Also
+exports :data:`SCRAPE_MIN_LENGTH`, the minimum character length for a
+description to qualify as a "full" description (spec §9.6).
+
+This is the **canonical** definition of ``SCRAPE_MIN_LENGTH``.
+``normalizer.py`` and the package root both import from here.
+
+NOTE: No inter-request delay or robots.txt check is performed.  This is
+acceptable for personal use at low volume (~50-250 listings per run), but
+would require rate limiting and robots.txt compliance for any
+higher-volume or production deployment.
+
+Public API:
+    :data:`SCRAPE_MIN_LENGTH` — minimum character count for "full" status.
+    :func:`scrape_description` — fetch and extract visible text from a URL.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import requests
+from bs4 import BeautifulSoup
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+#: Minimum character length for a scraped description to be classified as
+#: "full" (spec §9.6).  Imported by :mod:`job_aggregator.normalizer` and
+#: by ``ingest.py`` in the job-matcher-pr repo — never redefined locally.
+SCRAPE_MIN_LENGTH: int = 500
+
+# ---------------------------------------------------------------------------
+# Module-private constants
+# ---------------------------------------------------------------------------
+
+_USER_AGENT: str = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/124.0.0.0 Safari/537.36"
+)
+
+#: HTML tags whose content is purely structural / non-content noise.
+_NOISE_TAGS: list[str] = ["script", "style", "nav", "header", "footer"]
+
+# ---------------------------------------------------------------------------
+# Public functions
+# ---------------------------------------------------------------------------
+
+
+def scrape_description(
+    url: str,
+    fallback: str = "",
+    timeout: int = 15,
+) -> tuple[str, bool]:
+    """GET a job listing page and extract its visible text.
+
+    Removes noise tags (script, style, nav, header, footer) and collapses
+    whitespace before returning.  Falls back to *fallback* if the request
+    fails, the status code is not 200, or the extracted text is under
+    :data:`SCRAPE_MIN_LENGTH` characters.
+
+    Args:
+        url: The job listing URL to scrape.
+        fallback: Text to return when scraping fails (typically the API
+            snippet already stored in the record).
+        timeout: Per-request HTTP timeout in seconds.  Defaults to 15.
+
+    Returns:
+        A ``(description_text, scraped_ok)`` tuple where ``scraped_ok`` is
+        ``True`` on success and ``False`` when the fallback was used.
+    """
+    try:
+        response = requests.get(
+            url,
+            headers={"User-Agent": _USER_AGENT},
+            timeout=timeout,
+        )
+    except requests.RequestException as exc:
+        logger.warning("Scrape request failed for %s: %s", url, exc)
+        return fallback, False
+
+    if response.status_code != 200:
+        logger.warning("Scrape returned HTTP %d for %s", response.status_code, url)
+        return fallback, False
+
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    for tag in _NOISE_TAGS:
+        for element in soup.find_all(tag):
+            element.decompose()
+
+    raw_text = soup.get_text(separator=" ", strip=True)
+    # Collapse runs of whitespace (spaces, tabs, newlines) to single spaces.
+    cleaned = re.sub(r"\s+", " ", raw_text).strip()
+
+    if len(cleaned) < SCRAPE_MIN_LENGTH:
+        logger.warning(
+            "Scraped text too short (%d chars) for %s; using fallback",
+            len(cleaned),
+            url,
+        )
+        return fallback, False
+
+    return cleaned, True

--- a/tests/cli/test_hydrate_cli.py
+++ b/tests/cli/test_hydrate_cli.py
@@ -1,0 +1,397 @@
+"""CLI integration tests for ``job-aggregator hydrate``.
+
+Covers:
+- ``--help`` prints all §8.2 flags.
+- Format inference (json vs jsonl) wired through CLI.
+- ``--strict`` exits non-zero on scrape failure.
+- ``--continue-on-error`` (default) exits 0 on scrape failure.
+- ``--timeout-per-request`` forwarded to hydrator.
+- ``--timeout-total`` forwarded to hydrator.
+- ``--input`` reads from a file instead of stdin.
+- ``--output`` writes to a file instead of stdout.
+- Exit code 4 on cross-major schema_version mismatch.
+- ``-v``/``-vv``/``--quiet`` flags are accepted (no crash).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from job_aggregator.cli import hydrate as hydrate_cmd
+from job_aggregator.cli.__main__ import _build_parser
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_LONG_TEXT = "word " * 120
+
+
+def _make_record(
+    *,
+    source_id: str = "001",
+    description_source: str = "snippet",
+    url: str = "https://example.com/job/1",
+) -> dict[str, Any]:
+    return {
+        "source": "test",
+        "source_id": source_id,
+        "url": url,
+        "title": "Test Job",
+        "description": "short snippet",
+        "description_source": description_source,
+        "posted_at": "2026-04-01T00:00:00Z",
+        "company": None,
+        "location": None,
+        "salary_min": None,
+        "salary_max": None,
+        "salary_currency": None,
+        "salary_period": None,
+        "contract_type": None,
+        "contract_time": None,
+        "remote_eligible": None,
+    }
+
+
+def _json_input(records: list[dict[str, Any]]) -> str:
+    """Return a JSON envelope string."""
+    env: dict[str, Any] = {
+        "schema_version": "1.0",
+        "generated_at": "2026-04-01T00:00:00Z",
+        "command": "jobs",
+        "sources_used": ["test"],
+        "sources_failed": [],
+        "request_summary": {
+            "hours": 24,
+            "query": None,
+            "location": None,
+            "country": None,
+            "sources": ["test"],
+        },
+        "jobs": records,
+    }
+    return json.dumps(env)
+
+
+def _jsonl_input(records: list[dict[str, Any]]) -> str:
+    """Return JSONL (no envelope) string."""
+    return "\n".join(json.dumps(r) for r in records)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse argv using the real top-level parser."""
+    parser = _build_parser()
+    return parser.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# --help
+# ---------------------------------------------------------------------------
+
+
+def test_hydrate_help_lists_all_flags() -> None:
+    """``hydrate --help`` must document every §8.2 flag."""
+    parser = _build_parser()
+    subparsers_action = None
+    for action in parser._actions:
+        if hasattr(action, "_parser_class"):
+            subparsers_action = action
+            break
+
+    # Get the hydrate subparser via choices dict (cast required for mypy
+    # since stub types choices as Iterable[Any] even though at runtime
+    # argparse uses a dict here).
+    assert subparsers_action is not None
+    choices: dict[str, argparse.ArgumentParser] = subparsers_action.choices  # type: ignore[assignment]
+    hydrate_parser = choices["hydrate"]
+    help_text = hydrate_parser.format_help()
+
+    expected_flags = [
+        "--input",
+        "--output",
+        "--timeout-per-request",
+        "--timeout-total",
+        "--continue-on-error",
+        "--strict",
+        "--format",
+        "-v",
+        "--quiet",
+    ]
+    for flag in expected_flags:
+        assert flag in help_text, f"Flag {flag!r} missing from hydrate --help output"
+
+
+# ---------------------------------------------------------------------------
+# register() and run() shape
+# ---------------------------------------------------------------------------
+
+
+def test_hydrate_register_adds_subcommand() -> None:
+    """register() must add 'hydrate' to the subparsers group."""
+    parser = _build_parser()
+    subparsers_action = None
+    for action in parser._actions:
+        if hasattr(action, "_parser_class"):
+            subparsers_action = action
+            break
+    assert subparsers_action is not None
+    assert subparsers_action.choices is not None
+    assert "hydrate" in subparsers_action.choices
+
+
+# ---------------------------------------------------------------------------
+# run() wired through CLI — exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_run_exits_0_on_success(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """run() must complete without exception when scrape succeeds."""
+    input_file = tmp_path / "input.jsonl"
+    input_file.write_text(_jsonl_input([_make_record()]))
+
+    args = _parse_args(["hydrate", "--input", str(input_file)])
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=(_LONG_TEXT, True),
+    ):
+        # Should NOT raise — successful run returns normally (exit 0)
+        hydrate_cmd.run(args)
+
+    captured = capsys.readouterr()
+    assert captured.out.strip() != ""
+
+
+def test_run_continue_on_error_exits_0_on_scrape_failure(
+    tmp_path: Path,
+) -> None:
+    """--continue-on-error (default) exits 0 even when scrape fails."""
+    input_file = tmp_path / "input.jsonl"
+    input_file.write_text(_jsonl_input([_make_record()]))
+
+    args = _parse_args(["hydrate", "--input", str(input_file)])
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=("short", False),
+    ):
+        # Should NOT raise SystemExit with non-zero code
+        try:
+            hydrate_cmd.run(args)
+        except SystemExit as e:
+            assert e.code == 0 or e.code is None
+
+
+def test_run_strict_exits_nonzero_on_scrape_failure(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--strict exits non-zero when a scrape fails."""
+    input_file = tmp_path / "input.jsonl"
+    input_file.write_text(_jsonl_input([_make_record()]))
+
+    args = _parse_args(["hydrate", "--strict", "--input", str(input_file)])
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=("short", False),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            hydrate_cmd.run(args)
+        assert exc_info.value.code != 0
+
+
+def test_run_exits_4_on_cross_major_schema_mismatch(
+    tmp_path: Path,
+) -> None:
+    """Cross-major schema_version in input envelope exits with code 4."""
+    input_file = tmp_path / "input.json"
+    rec = _make_record()
+    bad_env = json.loads(_json_input([rec]))
+    bad_env["schema_version"] = "2.0"
+    input_file.write_text(json.dumps(bad_env))
+
+    args = _parse_args(["hydrate", "--input", str(input_file), "--format", "json"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        hydrate_cmd.run(args)
+    assert exc_info.value.code == 4
+
+
+# ---------------------------------------------------------------------------
+# --input / --output file handling
+# ---------------------------------------------------------------------------
+
+
+def test_run_reads_from_input_file(tmp_path: Path) -> None:
+    """--input PATH reads records from the given file."""
+    rec = _make_record()
+    input_file = tmp_path / "in.jsonl"
+    input_file.write_text(_jsonl_input([rec]))
+    output_file = tmp_path / "out.jsonl"
+
+    args = _parse_args(["hydrate", "--input", str(input_file), "--output", str(output_file)])
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=(_LONG_TEXT, True),
+    ):
+        hydrate_cmd.run(args)
+
+    content = output_file.read_text()
+    lines = [ln for ln in content.splitlines() if ln.strip()]
+    assert len(lines) >= 1
+
+
+def test_run_writes_to_output_file(tmp_path: Path) -> None:
+    """--output PATH writes enriched records to the file."""
+    rec = _make_record()
+    input_file = tmp_path / "in.jsonl"
+    input_file.write_text(_jsonl_input([rec]))
+    output_file = tmp_path / "out.jsonl"
+
+    args = _parse_args(["hydrate", "--input", str(input_file), "--output", str(output_file)])
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=(_LONG_TEXT, True),
+    ):
+        hydrate_cmd.run(args)
+
+    assert output_file.exists()
+    assert output_file.stat().st_size > 0
+
+
+# ---------------------------------------------------------------------------
+# --format flag
+# ---------------------------------------------------------------------------
+
+
+def test_run_explicit_json_format_produces_envelope(tmp_path: Path) -> None:
+    """--format json produces a single JSON object with 'jobs' key."""
+    rec = _make_record()
+    input_file = tmp_path / "in.json"
+    input_file.write_text(_json_input([rec]))
+    output_file = tmp_path / "out.json"
+
+    args = _parse_args(
+        [
+            "hydrate",
+            "--input",
+            str(input_file),
+            "--output",
+            str(output_file),
+            "--format",
+            "json",
+        ]
+    )
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=(_LONG_TEXT, True),
+    ):
+        hydrate_cmd.run(args)
+
+    parsed = json.loads(output_file.read_text())
+    assert "jobs" in parsed
+    assert parsed["command"] == "hydrate"
+
+
+def test_run_explicit_jsonl_format_produces_lines(tmp_path: Path) -> None:
+    """--format jsonl produces multiple JSONL lines."""
+    rec = _make_record()
+    input_file = tmp_path / "in.jsonl"
+    input_file.write_text(_jsonl_input([rec]))
+    output_file = tmp_path / "out.jsonl"
+
+    args = _parse_args(
+        [
+            "hydrate",
+            "--input",
+            str(input_file),
+            "--output",
+            str(output_file),
+            "--format",
+            "jsonl",
+        ]
+    )
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=(_LONG_TEXT, True),
+    ):
+        hydrate_cmd.run(args)
+
+    lines = [ln for ln in output_file.read_text().splitlines() if ln.strip()]
+    assert len(lines) >= 2  # envelope + at least one record
+
+
+# ---------------------------------------------------------------------------
+# Verbosity flags accepted without crash
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("flag", ["-v", "-vv", "--quiet"])
+def test_verbosity_flags_accepted(flag: str, tmp_path: Path) -> None:
+    """Verbosity flags must be accepted without error."""
+    rec = _make_record()
+    input_file = tmp_path / "in.jsonl"
+    input_file.write_text(_jsonl_input([rec]))
+
+    args = _parse_args(["hydrate", "--input", str(input_file), flag])
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=(_LONG_TEXT, True),
+    ):
+        # Should not raise
+        try:
+            hydrate_cmd.run(args)
+        except SystemExit as e:
+            assert e.code == 0 or e.code is None
+
+
+# ---------------------------------------------------------------------------
+# --timeout-per-request / --timeout-total forwarded
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_per_request_forwarded(tmp_path: Path) -> None:
+    """--timeout-per-request N must be forwarded to the hydrator."""
+
+    rec = _make_record()
+    input_file = tmp_path / "in.jsonl"
+    input_file.write_text(_jsonl_input([rec]))
+
+    args = _parse_args(["hydrate", "--timeout-per-request", "7", "--input", str(input_file)])
+
+    with patch("job_aggregator.cli.hydrate.hydrate") as mock_hydrate:
+        mock_hydrate.return_value = _jsonl_input([rec])
+        hydrate_cmd.run(args)
+
+    call_args = mock_hydrate.call_args
+    config = call_args.args[1] if call_args.args else call_args.kwargs["config"]
+    assert config.timeout_per_request == 7
+
+
+def test_timeout_total_forwarded(tmp_path: Path) -> None:
+    """--timeout-total N must be forwarded to the hydrator."""
+    rec = _make_record()
+    input_file = tmp_path / "in.jsonl"
+    input_file.write_text(_jsonl_input([rec]))
+
+    args = _parse_args(["hydrate", "--timeout-total", "60", "--input", str(input_file)])
+
+    with patch("job_aggregator.cli.hydrate.hydrate") as mock_hydrate:
+        mock_hydrate.return_value = _jsonl_input([rec])
+        hydrate_cmd.run(args)
+
+    call_args = mock_hydrate.call_args
+    config = call_args.args[1] if call_args.args else call_args.kwargs["config"]
+    assert config.timeout_total == 60

--- a/tests/test_hydrator.py
+++ b/tests/test_hydrator.py
@@ -1,0 +1,550 @@
+"""Tests for job_aggregator.hydrator — orchestrator-level hydrate logic.
+
+Covers:
+- §9.6 hydrate truth table rows (all four hydrate-orchestrator rows).
+- §8.2.1 input handling cases (every table row).
+- --timeout-per-request is passed to scrape_description.
+- --timeout-total: remaining records pass through unchanged when exceeded.
+- --strict raises / returns non-zero on scrape failure.
+- --continue-on-error (default) keeps going on failure.
+- Envelope propagation: command → "hydrate", generated_at updated,
+  request_summary preserved.
+- Format inference: { + jobs key → json; otherwise → jsonl.
+- Cross-major schema_version mismatch raises SchemaVersionError.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import time
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from job_aggregator.errors import SchemaVersionError
+from job_aggregator.hydrator import HydrateConfig, hydrate
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+_LONG_TEXT = "word " * 120  # safely above SCRAPE_MIN_LENGTH
+
+
+def _make_record(
+    *,
+    source: str = "test",
+    source_id: str = "001",
+    url: str = "https://example.com/job/1",
+    description: str = "short snippet",
+    description_source: str = "snippet",
+    **extra: Any,
+) -> dict[str, Any]:
+    """Return a minimal job record dict."""
+    rec: dict[str, Any] = {
+        "source": source,
+        "source_id": source_id,
+        "url": url,
+        "title": "Test Job",
+        "description": description,
+        "description_source": description_source,
+        "posted_at": "2026-04-01T00:00:00Z",
+        "company": None,
+        "location": None,
+        "salary_min": None,
+        "salary_max": None,
+        "salary_currency": None,
+        "salary_period": None,
+        "contract_type": None,
+        "contract_time": None,
+        "remote_eligible": None,
+    }
+    rec.update(extra)
+    return rec
+
+
+def _make_jsonl_input(
+    records: list[dict[str, Any]],
+    envelope: dict[str, Any] | None = None,
+) -> str:
+    """Return a JSONL string with optional envelope on first line."""
+    lines: list[str] = []
+    if envelope is not None:
+        lines.append(json.dumps(envelope))
+    for rec in records:
+        lines.append(json.dumps(rec))
+    return "\n".join(lines)
+
+
+def _make_json_input(
+    records: list[dict[str, Any]],
+    envelope_extra: dict[str, Any] | None = None,
+) -> str:
+    """Return a JSON envelope string with records in 'jobs'."""
+    env: dict[str, Any] = {
+        "schema_version": "1.0",
+        "generated_at": "2026-04-01T00:00:00Z",
+        "command": "jobs",
+        "sources_used": ["test"],
+        "sources_failed": [],
+        "request_summary": {
+            "hours": 24,
+            "query": None,
+            "location": None,
+            "country": None,
+            "sources": ["test"],
+        },
+        "jobs": records,
+    }
+    if envelope_extra:
+        env.update(envelope_extra)
+    return json.dumps(env)
+
+
+def _default_config(**kwargs: Any) -> HydrateConfig:
+    """Return a HydrateConfig with sensible defaults for testing."""
+    defaults: dict[str, Any] = {
+        "timeout_per_request": 15,
+        "timeout_total": None,
+        "continue_on_error": True,
+        "strict": False,
+        "fmt": None,
+        "verbosity": 0,
+    }
+    defaults.update(kwargs)
+    return HydrateConfig(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# §9.6 hydrate truth table rows
+# ---------------------------------------------------------------------------
+
+
+def test_hydrate_row1_already_full_passes_through() -> None:
+    """Row 1: description_source='full' → pass through unchanged, no scrape."""
+    rec = _make_record(
+        description="already full text",
+        description_source="full",
+    )
+    input_text = _make_jsonl_input([rec])
+
+    with patch("job_aggregator.hydrator.scrape_description") as mock_scrape:
+        result = hydrate(io.StringIO(input_text), _default_config())
+
+    mock_scrape.assert_not_called()
+    records = _parse_records(result)
+    assert records[0]["description_source"] == "full"
+    assert records[0]["description"] == "already full text"
+
+
+def test_hydrate_row2_snippet_scrape_success_sets_full() -> None:
+    """Row 2: snippet + scrape success → description_source='full', new text."""
+    rec = _make_record(description_source="snippet")
+    input_text = _make_jsonl_input([rec])
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=(_LONG_TEXT, True),
+    ):
+        result = hydrate(io.StringIO(input_text), _default_config())
+
+    records = _parse_records(result)
+    assert records[0]["description_source"] == "full"
+    assert records[0]["description"] == _LONG_TEXT
+
+
+def test_hydrate_row2_none_scrape_success_sets_full() -> None:
+    """Row 2 (none variant): description_source='none' + success → 'full'."""
+    rec = _make_record(description="", description_source="none")
+    input_text = _make_jsonl_input([rec])
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=(_LONG_TEXT, True),
+    ):
+        result = hydrate(io.StringIO(input_text), _default_config())
+
+    records = _parse_records(result)
+    assert records[0]["description_source"] == "full"
+    assert records[0]["description"] == _LONG_TEXT
+
+
+def test_hydrate_row3_scrape_failure_preserves_input() -> None:
+    """Row 3: snippet + scrape failure → description_source unchanged."""
+    rec = _make_record(
+        description="original snippet",
+        description_source="snippet",
+    )
+    input_text = _make_jsonl_input([rec])
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=("original snippet", False),
+    ):
+        result = hydrate(io.StringIO(input_text), _default_config())
+
+    records = _parse_records(result)
+    assert records[0]["description_source"] == "snippet"
+    assert records[0]["description"] == "original snippet"
+
+
+def test_hydrate_row4_missing_url_passes_through() -> None:
+    """Row 4: url missing → pass through unchanged, no scrape."""
+    rec = _make_record()
+    del rec["url"]
+    input_text = _make_jsonl_input([rec])
+
+    with patch("job_aggregator.hydrator.scrape_description") as mock_scrape:
+        result = hydrate(io.StringIO(input_text), _default_config())
+
+    mock_scrape.assert_not_called()
+    records = _parse_records(result)
+    assert records[0]["description_source"] == "snippet"
+
+
+# ---------------------------------------------------------------------------
+# §8.2.1 input handling cases
+# ---------------------------------------------------------------------------
+
+
+def test_input_handling_url_absent_passes_through(capsys: pytest.CaptureFixture[str]) -> None:
+    """url key absent: pass through unchanged, emit warning."""
+    rec = _make_record()
+    del rec["url"]
+    input_text = _make_jsonl_input([rec])
+
+    with patch("job_aggregator.hydrator.scrape_description") as mock_scrape:
+        hydrate(io.StringIO(input_text), _default_config())
+
+    mock_scrape.assert_not_called()
+    captured = capsys.readouterr()
+    assert "warning" in captured.err.lower() or "warn" in captured.err.lower()
+
+
+def test_input_handling_url_null_passes_through(capsys: pytest.CaptureFixture[str]) -> None:
+    """url=null: pass through unchanged, emit warning."""
+    rec = _make_record(url=None)  # type: ignore[arg-type]
+    input_text = _make_jsonl_input([rec])
+
+    with patch("job_aggregator.hydrator.scrape_description") as mock_scrape:
+        hydrate(io.StringIO(input_text), _default_config())
+
+    mock_scrape.assert_not_called()
+
+
+def test_input_handling_url_empty_passes_through(capsys: pytest.CaptureFixture[str]) -> None:
+    """url='': pass through unchanged, emit warning."""
+    rec = _make_record(url="")
+    input_text = _make_jsonl_input([rec])
+
+    with patch("job_aggregator.hydrator.scrape_description") as mock_scrape:
+        hydrate(io.StringIO(input_text), _default_config())
+
+    mock_scrape.assert_not_called()
+
+
+def test_input_handling_malformed_url_passes_through(capsys: pytest.CaptureFixture[str]) -> None:
+    """url malformed (not http/https): pass through unchanged, emit warning."""
+    rec = _make_record(url="ftp://not-http.example.com/")
+    input_text = _make_jsonl_input([rec])
+
+    with patch("job_aggregator.hydrator.scrape_description") as mock_scrape:
+        hydrate(io.StringIO(input_text), _default_config())
+
+    mock_scrape.assert_not_called()
+
+
+def test_input_handling_unknown_description_source_passes_through() -> None:
+    """description_source not in {full,snippet,none}: pass through, warn."""
+    rec = _make_record(description_source="unknown_future_value")
+    input_text = _make_jsonl_input([rec])
+
+    with patch("job_aggregator.hydrator.scrape_description") as mock_scrape:
+        result = hydrate(io.StringIO(input_text), _default_config())
+
+    mock_scrape.assert_not_called()
+    records = _parse_records(result)
+    assert records[0]["description_source"] == "unknown_future_value"
+
+
+def test_input_handling_cross_major_schema_raises() -> None:
+    """Envelope with incompatible major schema_version raises SchemaVersionError."""
+    rec = _make_record()
+    input_text = _make_json_input([rec], {"schema_version": "2.0"})
+
+    with pytest.raises(SchemaVersionError):
+        hydrate(io.StringIO(input_text), _default_config())
+
+
+def test_input_handling_same_major_minor_diff_warns(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Envelope with same major but different minor version proceeds with warning."""
+    rec = _make_record()
+    input_text = _make_json_input([rec], {"schema_version": "1.99"})
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=(_LONG_TEXT, True),
+    ):
+        result = hydrate(io.StringIO(input_text), _default_config(fmt="json"))
+
+    # Should succeed (not raise)
+    assert result != ""
+
+
+# ---------------------------------------------------------------------------
+# --strict vs --continue-on-error
+# ---------------------------------------------------------------------------
+
+
+def test_strict_raises_on_scrape_failure() -> None:
+    """--strict: ScrapeError (or SystemExit) raised on scrape failure."""
+    from job_aggregator.errors import ScrapeError
+
+    rec = _make_record(description_source="snippet")
+    input_text = _make_jsonl_input([rec])
+
+    with (
+        patch(
+            "job_aggregator.hydrator.scrape_description",
+            return_value=("short", False),
+        ),
+        pytest.raises((ScrapeError, SystemExit)),
+    ):
+        hydrate(
+            io.StringIO(input_text),
+            _default_config(strict=True, continue_on_error=False),
+        )
+
+
+def test_continue_on_error_does_not_raise() -> None:
+    """--continue-on-error (default): scrape failure passes through silently."""
+    rec = _make_record(description_source="snippet")
+    input_text = _make_jsonl_input([rec])
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=("short snippet", False),
+    ):
+        # Should NOT raise
+        result = hydrate(io.StringIO(input_text), _default_config())
+
+    records = _parse_records(result)
+    assert records[0]["description_source"] == "snippet"
+
+
+# ---------------------------------------------------------------------------
+# Timeout enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_per_request_passed_to_scrape() -> None:
+    """timeout_per_request must be forwarded to scrape_description."""
+    rec = _make_record(description_source="snippet")
+    input_text = _make_jsonl_input([rec])
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=(_LONG_TEXT, True),
+    ) as mock_scrape:
+        hydrate(
+            io.StringIO(input_text),
+            _default_config(timeout_per_request=5),
+        )
+
+    mock_scrape.assert_called_once()
+    call_kwargs = mock_scrape.call_args
+    # timeout_per_request should appear in kwargs or positional args
+    assert 5 in call_kwargs.args or call_kwargs.kwargs.get("timeout") == 5
+
+
+def test_timeout_total_exceeded_passes_remaining_through() -> None:
+    """When timeout_total is exceeded, remaining records pass through unchanged."""
+
+    rec1 = _make_record(source_id="001", description_source="snippet")
+    rec2 = _make_record(source_id="002", description_source="snippet")
+    input_text = _make_jsonl_input([rec1, rec2])
+
+    call_count = 0
+
+    def slow_scrape(url: str, fallback: str = "", timeout: int = 15) -> tuple[str, bool]:
+        nonlocal call_count
+        call_count += 1
+        time.sleep(0.2)  # simulate slow HTTP
+        return (_LONG_TEXT, True)
+
+    with patch("job_aggregator.hydrator.scrape_description", side_effect=slow_scrape):
+        result = hydrate(
+            io.StringIO(input_text),
+            _default_config(timeout_total=0),  # 0s budget → expires immediately
+        )
+
+    # At least one record should be passed through unchanged
+    records = _parse_records(result)
+    assert len(records) == 2
+    unchanged_count = sum(1 for r in records if r["description_source"] == "snippet")
+    assert unchanged_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# Envelope propagation
+# ---------------------------------------------------------------------------
+
+
+def test_hydrate_updates_command_in_envelope() -> None:
+    """Output envelope must have command='hydrate'."""
+    rec = _make_record()
+    input_text = _make_json_input([rec])
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=(_LONG_TEXT, True),
+    ):
+        result = hydrate(io.StringIO(input_text), _default_config(fmt="json"))
+
+    envelope = json.loads(result)
+    assert envelope["command"] == "hydrate"
+
+
+def test_hydrate_updates_generated_at_in_envelope() -> None:
+    """Output envelope generated_at must differ from the input's generated_at."""
+    rec = _make_record()
+    input_text = _make_json_input([rec], {"generated_at": "2020-01-01T00:00:00Z"})
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=(_LONG_TEXT, True),
+    ):
+        result = hydrate(io.StringIO(input_text), _default_config(fmt="json"))
+
+    envelope = json.loads(result)
+    assert envelope["generated_at"] != "2020-01-01T00:00:00Z"
+
+
+def test_hydrate_preserves_request_summary() -> None:
+    """Output envelope request_summary must be copied verbatim from input."""
+    rec = _make_record()
+    summary = {
+        "hours": 48,
+        "query": "python",
+        "location": "Atlanta",
+        "country": None,
+        "sources": ["test"],
+    }
+    input_text = _make_json_input([rec], {"request_summary": summary})
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=(_LONG_TEXT, True),
+    ):
+        result = hydrate(io.StringIO(input_text), _default_config(fmt="json"))
+
+    envelope = json.loads(result)
+    assert envelope["request_summary"] == summary
+
+
+# ---------------------------------------------------------------------------
+# Format inference
+# ---------------------------------------------------------------------------
+
+
+def test_format_inference_json_when_jobs_key_present() -> None:
+    """Input starting with { containing 'jobs' key infers --format json."""
+    rec = _make_record()
+    input_text = _make_json_input([rec])
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=(_LONG_TEXT, True),
+    ):
+        # fmt=None → inferred
+        result = hydrate(io.StringIO(input_text), _default_config(fmt=None))
+
+    # Output should be parseable as single JSON object with 'jobs' key
+    parsed = json.loads(result)
+    assert "jobs" in parsed
+    assert isinstance(parsed["jobs"], list)
+
+
+def test_format_inference_jsonl_for_plain_records() -> None:
+    """Input without envelope { object infers --format jsonl."""
+    rec = _make_record()
+    input_text = _make_jsonl_input([rec])  # no envelope
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=(_LONG_TEXT, True),
+    ):
+        result = hydrate(io.StringIO(input_text), _default_config(fmt=None))
+
+    # JSONL: first line is envelope, second is record
+    lines = [ln for ln in result.split("\n") if ln.strip()]
+    assert len(lines) >= 1
+    first = json.loads(lines[0])
+    # First line should be envelope (has schema_version) or record
+    # Accept either layout — the key requirement is that it parses as JSONL
+    assert isinstance(first, dict)
+
+
+def test_format_inference_jsonl_when_no_jobs_key() -> None:
+    """Input starting with { but no 'jobs' key uses jsonl format."""
+    # A record that starts with { but lacks the envelope jobs key
+    rec = _make_record()
+    # Produce JSONL with an envelope that has no 'jobs' key
+    bare_envelope = {"schema_version": "1.0", "command": "jobs"}
+    lines = [json.dumps(bare_envelope), json.dumps(rec)]
+    input_text = "\n".join(lines)
+
+    with patch(
+        "job_aggregator.hydrator.scrape_description",
+        return_value=(_LONG_TEXT, True),
+    ):
+        # Should not raise
+        result = hydrate(io.StringIO(input_text), _default_config(fmt=None))
+
+    assert result != ""
+
+
+# ---------------------------------------------------------------------------
+# Public API re-export
+# ---------------------------------------------------------------------------
+
+
+def test_hydrate_re_exported_from_package() -> None:
+    """hydrate must be importable from the package root."""
+    from job_aggregator import hydrate as pkg_hydrate
+
+    assert callable(pkg_hydrate)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_records(output: str) -> list[dict[str, Any]]:
+    """Parse hydrate output (JSONL or JSON) and return the record list."""
+    output = output.strip()
+    if not output:
+        return []
+
+    # Try JSON envelope first
+    try:
+        parsed = json.loads(output)
+        if isinstance(parsed, dict) and "jobs" in parsed:
+            result: list[dict[str, Any]] = parsed["jobs"]
+            return result
+    except json.JSONDecodeError:
+        pass
+
+    # JSONL: first line is envelope (with jobs=[]), rest are records
+    lines = [ln for ln in output.split("\n") if ln.strip()]
+    records: list[dict[str, Any]] = []
+    for line in lines:
+        obj = json.loads(line)
+        if "jobs" not in obj:  # it's a record, not the envelope
+            records.append(obj)
+    return records

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -1,0 +1,223 @@
+"""Tests for job_aggregator.scraping — scrape_description and SCRAPE_MIN_LENGTH.
+
+Covers:
+- SCRAPE_MIN_LENGTH is a public int constant.
+- scrape_description returns (text, True) on a successful scrape.
+- scrape_description returns (fallback, False) on HTTP non-200.
+- scrape_description returns (fallback, False) on a network error.
+- scrape_description returns (fallback, False) when scraped text is below
+  SCRAPE_MIN_LENGTH.
+- Noise tags (script, style, nav, header, footer) are stripped from the output.
+- Whitespace is collapsed to single spaces.
+- SCRAPE_MIN_LENGTH is importable from the package root (re-export check).
+"""
+
+from __future__ import annotations
+
+import responses as resp
+
+from job_aggregator.scraping import SCRAPE_MIN_LENGTH, scrape_description
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_LONG_TEXT = "word " * 120  # 600 chars — safely above MIN
+
+
+def _html_page(body_inner: str) -> str:
+    """Wrap *body_inner* in minimal HTML."""
+    return f"<html><body>{body_inner}</body></html>"
+
+
+# ---------------------------------------------------------------------------
+# SCRAPE_MIN_LENGTH
+# ---------------------------------------------------------------------------
+
+
+def test_scrape_min_length_is_public_int() -> None:
+    """SCRAPE_MIN_LENGTH must be a public integer constant."""
+    assert isinstance(SCRAPE_MIN_LENGTH, int)
+    assert SCRAPE_MIN_LENGTH > 0
+
+
+def test_scrape_min_length_re_exported_from_package() -> None:
+    """SCRAPE_MIN_LENGTH must still be importable from the package root."""
+    from job_aggregator import SCRAPE_MIN_LENGTH as PKG_MIN
+
+    assert PKG_MIN is SCRAPE_MIN_LENGTH
+
+
+# ---------------------------------------------------------------------------
+# scrape_description — success
+# ---------------------------------------------------------------------------
+
+
+@resp.activate
+def test_scrape_description_success_returns_text_and_true() -> None:
+    """A 200 response with enough text returns (text, True)."""
+    url = "https://example.com/job/1"
+    html = _html_page(f"<p>{_LONG_TEXT}</p>")
+    resp.add(resp.GET, url, body=html, status=200)
+
+    text, ok = scrape_description(url)
+
+    assert ok is True
+    assert len(text) >= SCRAPE_MIN_LENGTH
+    # Collapsed whitespace — no double spaces
+    assert "  " not in text
+
+
+@resp.activate
+def test_scrape_description_uses_fallback_by_default() -> None:
+    """Default fallback is empty string when no fallback is supplied."""
+    url = "https://example.com/job/2"
+    resp.add(resp.GET, url, status=404)
+
+    text, ok = scrape_description(url)
+
+    assert ok is False
+    assert text == ""
+
+
+@resp.activate
+def test_scrape_description_uses_supplied_fallback_on_failure() -> None:
+    """When scrape fails, the caller-supplied fallback is returned."""
+    url = "https://example.com/job/3"
+    resp.add(resp.GET, url, status=500)
+
+    text, ok = scrape_description(url, fallback="original snippet")
+
+    assert ok is False
+    assert text == "original snippet"
+
+
+# ---------------------------------------------------------------------------
+# scrape_description — HTTP failures
+# ---------------------------------------------------------------------------
+
+
+@resp.activate
+def test_scrape_description_non_200_returns_fallback_false() -> None:
+    """Any non-200 HTTP status triggers the fallback path."""
+    url = "https://example.com/job/4"
+    resp.add(resp.GET, url, status=403)
+
+    _, ok = scrape_description(url, fallback="fb")
+
+    assert ok is False
+
+
+@resp.activate
+def test_scrape_description_5xx_returns_fallback_false() -> None:
+    """5xx responses also trigger the fallback path."""
+    url = "https://example.com/job/5"
+    resp.add(resp.GET, url, status=503)
+
+    _, ok = scrape_description(url, fallback="fb")
+
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# scrape_description — network error
+# ---------------------------------------------------------------------------
+
+
+@resp.activate
+def test_scrape_description_network_error_returns_fallback_false() -> None:
+    """A network-level exception (ConnectionError) triggers the fallback."""
+    import requests as _req
+
+    url = "https://example.com/job/6"
+    resp.add(resp.GET, url, body=_req.exceptions.ConnectionError("timeout"))
+
+    text, ok = scrape_description(url, fallback="kept")
+
+    assert ok is False
+    assert text == "kept"
+
+
+# ---------------------------------------------------------------------------
+# scrape_description — text too short
+# ---------------------------------------------------------------------------
+
+
+@resp.activate
+def test_scrape_description_short_body_returns_fallback_false() -> None:
+    """Scraped text shorter than SCRAPE_MIN_LENGTH is treated as failure."""
+    url = "https://example.com/job/7"
+    short_text = "x" * (SCRAPE_MIN_LENGTH - 1)
+    html = _html_page(f"<p>{short_text}</p>")
+    resp.add(resp.GET, url, body=html, status=200)
+
+    text, ok = scrape_description(url, fallback="kept snippet")
+
+    assert ok is False
+    assert text == "kept snippet"
+
+
+@resp.activate
+def test_scrape_description_exactly_min_length_succeeds() -> None:
+    """Text of exactly SCRAPE_MIN_LENGTH characters is classified as success."""
+    url = "https://example.com/job/8"
+    exact_text = "a" * SCRAPE_MIN_LENGTH
+    html = _html_page(f"<p>{exact_text}</p>")
+    resp.add(resp.GET, url, body=html, status=200)
+
+    text, ok = scrape_description(url)
+
+    assert ok is True
+    assert len(text) >= SCRAPE_MIN_LENGTH
+
+
+# ---------------------------------------------------------------------------
+# scrape_description — noise-tag removal
+# ---------------------------------------------------------------------------
+
+
+@resp.activate
+def test_scrape_description_strips_noise_tags() -> None:
+    """script, style, nav, header, footer content must not appear in output."""
+    url = "https://example.com/job/9"
+    html = (
+        "<html><body>"
+        "<script>var x=1;</script>"
+        "<style>.foo{color:red}</style>"
+        "<nav>Home About Contact</nav>"
+        "<header>Site Header Text</header>"
+        "<footer>Site Footer Text</footer>"
+        f"<main><p>{_LONG_TEXT}</p></main>"
+        "</body></html>"
+    )
+    resp.add(resp.GET, url, body=html, status=200)
+
+    text, ok = scrape_description(url)
+
+    assert ok is True
+    assert "var x=1" not in text
+    assert ".foo" not in text
+    assert "Site Header Text" not in text
+    assert "Site Footer Text" not in text
+
+
+# ---------------------------------------------------------------------------
+# scrape_description — whitespace collapsing
+# ---------------------------------------------------------------------------
+
+
+@resp.activate
+def test_scrape_description_collapses_whitespace() -> None:
+    """Multiple whitespace characters in the body are collapsed to one space."""
+    url = "https://example.com/job/10"
+    # Use enough repetitions that after whitespace collapse the text is
+    # still >= SCRAPE_MIN_LENGTH.  "word " (5 chars) * 120 = 600 chars
+    # before collapse; after collapse still well above 500.
+    padded = ("word   \n\n   " * 120).strip()
+    html = _html_page(f"<p>{padded}</p>")
+    resp.add(resp.GET, url, body=html, status=200)
+
+    text, ok = scrape_description(url)
+
+    assert ok is True
+    assert "  " not in text

--- a/uv.lock
+++ b/uv.lock
@@ -292,6 +292,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-recording" },
     { name = "python-dotenv" },
+    { name = "responses" },
     { name = "ruff" },
     { name = "types-requests" },
 ]
@@ -311,6 +312,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-recording" },
     { name = "python-dotenv", specifier = ">=1.0" },
+    { name = "responses", specifier = ">=0.25" },
     { name = "ruff" },
     { name = "types-requests", specifier = ">=2.31" },
 ]
@@ -819,6 +821,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/96/fb6dbfebb524d5601d359a47c78fe7ba1eef90fc4096404aa60c9a906fbb/requirements_parser-0.13.0.tar.gz", hash = "sha256:0843119ca2cb2331de4eb31b10d70462e39ace698fd660a915c247d2301a4418", size = 22630, upload-time = "2025-05-21T13:42:05.464Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/60/50fbb6ffb35f733654466f1a90d162bcbea358adc3b0871339254fbc37b2/requirements_parser-0.13.0-py3-none-any.whl", hash = "sha256:2b3173faecf19ec5501971b7222d38f04cb45bb9d87d0ad629ca71e2e62ded14", size = 14782, upload-time = "2025-05-21T13:42:04.007Z" },
+]
+
+[[package]]
+name = "responses"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/b4/b7e040379838cc71bf5aabdb26998dfbe5ee73904c92c1c161faf5de8866/responses-0.26.0.tar.gz", hash = "sha256:c7f6923e6343ef3682816ba421c006626777893cb0d5e1434f674b649bac9eb4", size = 81303, upload-time = "2026-02-19T14:38:05.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/04/7f73d05b556da048923e31a0cc878f03be7c5425ed1f268082255c75d872/responses-0.26.0-py3-none-any.whl", hash = "sha256:03ec4409088cd5c66b71ecbbbd27fe2c58ddfad801c66203457b3e6a04868c37", size = 35099, upload-time = "2026-02-19T14:38:03.847Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `src/job_aggregator/scraping.py` with public `SCRAPE_MIN_LENGTH` constant and `scrape_description()` function (ported from `job-matcher-pr/ingest.py`, preserving identical HTTP behaviour, noise-tag removal, and whitespace collapsing).
- Moves the canonical `SCRAPE_MIN_LENGTH` definition to `scraping.py`; `normalizer.py` imports from there (spec §9.6).
- Adds `src/job_aggregator/hydrator.py` implementing the full §8.2 / §9.6 hydrate pipeline: format inference, schema version validation, all §8.2.1 input-handling cases, `timeout_total` wall-clock budget, `--strict` vs `--continue-on-error`, and §9.2 envelope propagation.
- Adds `src/job_aggregator/cli/hydrate.py` with `register()` + `run()` following the `sources`/`jobs` subcommand pattern; all §8.2 flags documented in `--help`.
- Wires `cli/hydrate.py` into `cli/__main__.py`, replacing the Phase-E stub.
- Re-exports `HydrateConfig`, `hydrate`, and `scrape_description` from the package root.
- Adds `responses>=0.25` dev dep; adds 50 new tests across `test_scraping.py`, `test_hydrator.py`, `tests/cli/test_hydrate_cli.py`.

## Test plan

- [x] `uv run pytest` — 783 passed, 2 skipped (expected API-key integration skips)
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run mypy src/ tests/ scripts/` — clean (91 files)
- [x] `uv run deptry .` — clean
- [x] All §9.6 hydrate truth table rows tested
- [x] All §8.2.1 input-handling cases tested
- [x] Exit code 4 on cross-major schema_version mismatch tested
- [x] `--timeout-per-request`, `--timeout-total`, `--strict`, format inference all tested

Closes #17

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*