### PR TITLE
fix: make --credentials optional for no-auth runs (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,4 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `jobs` subcommand no longer requires `--credentials` when all selected sources are no-auth. When some selected sources do require credentials, the error names them explicitly instead of the generic argparse message. (#50)
+
 ### Security

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install job-aggregator
 # List available plugins and whether credentials are configured
 job-aggregator sources
 
-# Fetch listings and enrich with full descriptions in a pipeline
+# Fetch listings from no-auth sources and enrich with full descriptions
 job-aggregator jobs --query "python developer" --hours 24 \
   | job-aggregator hydrate > full.jsonl
 ```
@@ -28,11 +28,9 @@ Each line of `full.jsonl` after the first is a normalized job record. The
 first line is the output envelope (see [docs/output_schema.md](docs/output_schema.md)
 for the full field reference).
 
-To use sources that require API credentials, pass a credentials file:
-
 ```bash
-job-aggregator jobs --query "python developer" \
-  --credentials ~/.job-aggregator/creds.json \
+# With credentials for paid/keyed sources
+job-aggregator jobs --credentials providers.json --sources adzuna,jooble --hours 24 \
   | job-aggregator hydrate > full.jsonl
 ```
 

--- a/src/job_aggregator/cli/jobs.py
+++ b/src/job_aggregator/cli/jobs.py
@@ -17,6 +17,14 @@ The dispatcher wires this in with two lines::
 
     from job_aggregator.cli import jobs as _jobs_cmd
     _jobs_cmd.register(subparsers)
+
+Credentials are optional (#50)
+-------------------------------
+``--credentials`` is no longer required.  When omitted, the command
+inspects the selected sources and proceeds with an empty credentials
+dict if none of them require credentials.  If any selected source
+*does* require credentials and ``--credentials`` was not supplied, the
+command exits non-zero with a message naming the offending sources.
 """
 
 from __future__ import annotations
@@ -25,6 +33,9 @@ import argparse
 import json
 import sys
 from typing import Any
+
+from job_aggregator.registry import list_plugins
+from job_aggregator.schema import PluginInfo
 
 # ---------------------------------------------------------------------------
 # Public subcommand API
@@ -121,9 +132,13 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
     p.add_argument(
         "--credentials",
         type=str,
-        required=True,
+        default=None,
         metavar="PATH",
-        help="Path to a JSON credentials file (see package docs §10). Required.",
+        help=(
+            "Path to a JSON credentials file (see docs/credentials_format.md). "
+            "Optional when all selected sources are no-auth; required when any "
+            "selected source needs credentials."
+        ),
     )
     p.add_argument(
         "--format",
@@ -175,31 +190,58 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
     p.set_defaults(func=run)
 
 
+def _resolve_selected_sources(
+    sources: list[str] | None,
+    exclude_sources: list[str] | None,
+) -> list[PluginInfo]:
+    """Return the effective list of selected :class:`PluginInfo` objects.
+
+    Uses the registry to enumerate all registered plugins and applies the
+    same ``--sources`` / ``--exclude-sources`` filter logic as the
+    orchestrator, so the CLI can inspect ``requires_credentials`` before
+    deciding whether a credentials file is mandatory.
+
+    Args:
+        sources: Allowlist of plugin keys from ``--sources``, or ``None``
+            to select all registered plugins.
+        exclude_sources: Blocklist of plugin keys from
+            ``--exclude-sources``, or ``None`` for no exclusions.
+
+    Returns:
+        A list of :class:`PluginInfo` for the selected plugins (may be
+        empty when no plugins are registered or none match the filters).
+    """
+    all_plugins = list_plugins()
+
+    # Apply --sources allowlist
+    selected = [p for p in all_plugins if p.key in sources] if sources else list(all_plugins)
+
+    # Apply --exclude-sources blocklist
+    if exclude_sources:
+        selected = [p for p in selected if p.key not in exclude_sources]
+
+    return selected
+
+
 def run(ns: argparse.Namespace) -> None:
     """Execute the ``jobs`` subcommand.
 
-    Loads the credentials file, resolves plugin filters, delegates to
-    :func:`~job_aggregator.orchestrator.run_jobs`, and writes the result
+    Resolves credentials (loading from file when ``--credentials`` is
+    supplied, or using an empty dict when all selected sources are
+    no-auth), then delegates to
+    :func:`~job_aggregator.orchestrator.run_jobs` and writes the result
     to stdout (or the file named by ``--output``).
+
+    When ``--credentials`` is omitted but one or more selected sources
+    require credentials, the command exits with code 2 and a message
+    naming the offending sources.
 
     Args:
         ns: Parsed :class:`argparse.Namespace` from the ``jobs`` subparser.
     """
     from job_aggregator.orchestrator import run_jobs
 
-    # Load credentials file
-    credentials: dict[str, Any] = {}
-    try:
-        with open(ns.credentials, encoding="utf-8") as fh:
-            creds_doc = json.load(fh)
-        # Credentials file format: {"schema_version": "1.0", "plugins": {...}}
-        if isinstance(creds_doc, dict):
-            credentials = creds_doc.get("plugins", {})
-    except (OSError, json.JSONDecodeError) as exc:
-        print(f"ERROR: Cannot load credentials from {ns.credentials!r}: {exc}", file=sys.stderr)
-        sys.exit(1)
-
-    # Parse comma-separated source lists
+    # Parse comma-separated source lists (needed for creds check too)
     sources: list[str] | None = None
     if getattr(ns, "sources", None):
         sources = [s.strip() for s in ns.sources.split(",") if s.strip()]
@@ -207,6 +249,43 @@ def run(ns: argparse.Namespace) -> None:
     exclude_sources: list[str] | None = None
     if getattr(ns, "exclude_sources", None):
         exclude_sources = [s.strip() for s in ns.exclude_sources.split(",") if s.strip()]
+
+    # ------------------------------------------------------------------
+    # Credentials: load from file, or validate that none are needed
+    # ------------------------------------------------------------------
+    credentials: dict[str, Any] = {}
+
+    if ns.credentials is not None:
+        # --credentials supplied — load and validate as before
+        try:
+            with open(ns.credentials, encoding="utf-8") as fh:
+                creds_doc = json.load(fh)
+            # Credentials file format:
+            #   {"schema_version": "1.0", "plugins": {...}}
+            if isinstance(creds_doc, dict):
+                credentials = creds_doc.get("plugins", {})
+        except (OSError, json.JSONDecodeError) as exc:
+            print(
+                f"ERROR: Cannot load credentials from {ns.credentials!r}: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
+        # --credentials omitted — check whether any selected source needs
+        # credentials; if so, exit with a helpful error message.
+        selected = _resolve_selected_sources(sources, exclude_sources)
+        needs_creds = [p.key for p in selected if p.requires_credentials]
+        if needs_creds:
+            keys_str = ", ".join(sorted(needs_creds))
+            print(
+                f"error: --credentials is required because the following "
+                f"selected sources need credentials: {keys_str}. "
+                f"Omit these sources (via --exclude-sources) or supply a "
+                f"credentials file.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        # No selected source needs credentials — proceed with empty dict
 
     result = run_jobs(
         credentials=credentials,
@@ -229,7 +308,10 @@ def run(ns: argparse.Namespace) -> None:
             with open(ns.output, "w", encoding="utf-8") as fh:
                 fh.write(result)
         except OSError as exc:
-            print(f"ERROR: Cannot write output to {ns.output!r}: {exc}", file=sys.stderr)
+            print(
+                f"ERROR: Cannot write output to {ns.output!r}: {exc}",
+                file=sys.stderr,
+            )
             sys.exit(1)
     else:
         print(result, end="")

--- a/tests/cli/test_jobs_cli.py
+++ b/tests/cli/test_jobs_cli.py
@@ -1,0 +1,369 @@
+"""CLI integration tests for ``job-aggregator jobs``.
+
+Covers the credentials-optional behaviour introduced in Issue #50:
+
+- Test 1: ``jobs --sources <no-auth>`` with no ``--credentials`` —
+  parser accepts and orchestrator runs (no HTTP).
+- Test 2: ``jobs --sources adzuna`` with no ``--credentials`` — exits 2,
+  error message names ``adzuna``.
+- Test 3: ``jobs --sources himalayas,adzuna`` with no ``--credentials`` —
+  exits 2, error message names ``adzuna`` (not ``himalayas``).
+- Test 4: ``jobs --sources <no-auth> --credentials <empty-file>`` —
+  back-compat: supplying a credentials file for a no-auth-only run
+  must succeed.
+- Existing credentialed-path tests: ``--credentials`` supplied for a run
+  that includes credentialed sources must succeed.
+"""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from job_aggregator.cli.__main__ import _build_parser
+from job_aggregator.schema import PluginField, PluginInfo
+from tests.fixtures.plugins.stub_plugins import AlwaysQueryPlugin
+
+# ---------------------------------------------------------------------------
+# PluginInfo helpers
+# ---------------------------------------------------------------------------
+
+_FIELD_APP_ID = PluginField(
+    name="app_id",
+    label="App ID",
+    type="text",
+    required=True,
+)
+
+_FIELD_API_KEY = PluginField(
+    name="api_key",
+    label="API Key",
+    type="password",
+    required=True,
+)
+
+
+def _make_noauth_info(key: str = "himalayas") -> PluginInfo:
+    """Return a PluginInfo with no required credential fields.
+
+    Args:
+        key: Plugin key to use (default: ``"himalayas"``).
+
+    Returns:
+        A :class:`~job_aggregator.schema.PluginInfo` with empty
+        ``fields``, so ``requires_credentials`` is ``False``.
+    """
+    return PluginInfo(
+        key=key,
+        display_name=key.title(),
+        description=f"Stub {key} plugin.",
+        home_url=f"https://example.com/{key}",
+        geo_scope="global",
+        accepts_query="always",
+        accepts_location=False,
+        accepts_country=False,
+        rate_limit_notes="No limit.",
+        required_search_fields=(),
+        fields=(),
+    )
+
+
+def _make_credentialed_info(key: str = "adzuna") -> PluginInfo:
+    """Return a PluginInfo with required credential fields.
+
+    Args:
+        key: Plugin key to use (default: ``"adzuna"``).
+
+    Returns:
+        A :class:`~job_aggregator.schema.PluginInfo` with two required
+        fields, so ``requires_credentials`` is ``True``.
+    """
+    return PluginInfo(
+        key=key,
+        display_name=key.title(),
+        description=f"Stub {key} plugin.",
+        home_url=f"https://example.com/{key}",
+        geo_scope="global",
+        accepts_query="always",
+        accepts_location=True,
+        accepts_country=True,
+        rate_limit_notes="Keyed API.",
+        required_search_fields=(),
+        fields=(_FIELD_APP_ID, _FIELD_API_KEY),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_jobs_cli(
+    argv: list[str],
+    *,
+    list_plugins_return: list[PluginInfo],
+    plugin_classes: dict[str, Any] | None = None,
+) -> tuple[str, str, int]:
+    """Invoke the ``jobs`` subcommand via the real argparse parser.
+
+    Patches ``job_aggregator.cli.jobs.list_plugins`` (used by
+    ``_resolve_selected_sources``) and
+    ``job_aggregator.orchestrator.discover_plugins`` (used by
+    ``run_jobs``).
+
+    Args:
+        argv: Arguments passed *after* ``"jobs"`` on the command line.
+        list_plugins_return: The list of :class:`PluginInfo` objects that
+            ``list_plugins()`` should return in ``_resolve_selected_sources``.
+        plugin_classes: Optional mapping of plugin key → class for the
+            orchestrator.  When ``None``, an empty dict is used so no
+            real HTTP calls are made.
+
+    Returns:
+        Tuple of ``(stdout_text, stderr_text, exit_code)``.
+    """
+    if plugin_classes is None:
+        plugin_classes = {}
+
+    parser = _build_parser()
+    full_argv = ["jobs", *argv]
+
+    stdout_buf = StringIO()
+    stderr_buf = StringIO()
+    exit_code = 0
+
+    try:
+        ns = parser.parse_args(full_argv)
+    except SystemExit as exc:
+        return "", "", int(exc.code or 0)
+
+    with (
+        patch("sys.stdout", stdout_buf),
+        patch("sys.stderr", stderr_buf),
+        patch(
+            "job_aggregator.cli.jobs.list_plugins",
+            return_value=list_plugins_return,
+        ),
+        patch(
+            "job_aggregator.orchestrator.discover_plugins",
+            return_value=plugin_classes,
+        ),
+    ):
+        try:
+            ns.func(ns)
+        except SystemExit as exc:
+            exit_code = int(exc.code or 0)
+
+    return stdout_buf.getvalue(), stderr_buf.getvalue(), exit_code
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — no-auth source, no --credentials → succeeds
+# ---------------------------------------------------------------------------
+
+
+class TestNoCredsNoAuthSource:
+    """``jobs --sources <no-auth>`` with no --credentials must succeed."""
+
+    def test_no_credentials_no_auth_source_exits_zero(self) -> None:
+        """Parser accepts and run completes when source needs no creds.
+
+        Uses a stub AlwaysQueryPlugin (SOURCE="stub_always") so no real
+        HTTP calls are made.
+        """
+        _stdout, _stderr, code = _run_jobs_cli(
+            ["--sources", "stub_always", "--dry-run", "--format", "json"],
+            list_plugins_return=[_make_noauth_info("stub_always")],
+            plugin_classes={AlwaysQueryPlugin.SOURCE: AlwaysQueryPlugin},
+        )
+        assert code == 0
+
+    def test_no_credentials_no_auth_source_emits_envelope(self) -> None:
+        """run() emits a valid JSON envelope to stdout when no creds needed."""
+        stdout, _stderr, code = _run_jobs_cli(
+            ["--sources", "stub_always", "--dry-run", "--format", "json"],
+            list_plugins_return=[_make_noauth_info("stub_always")],
+            plugin_classes={AlwaysQueryPlugin.SOURCE: AlwaysQueryPlugin},
+        )
+        assert code == 0
+        data = json.loads(stdout)
+        assert "schema_version" in data
+        assert "jobs" in data
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — credentialed source, no --credentials → exits 2 naming adzuna
+# ---------------------------------------------------------------------------
+
+
+class TestNoCredsCredentialedSource:
+    """``jobs --sources adzuna`` with no --credentials exits 2."""
+
+    def test_exits_nonzero_when_creds_required(self) -> None:
+        """Exit code must be 2 (argparse convention) when creds missing."""
+        _stdout, _stderr, code = _run_jobs_cli(
+            ["--sources", "adzuna"],
+            list_plugins_return=[_make_credentialed_info("adzuna")],
+        )
+        assert code == 2
+
+    def test_error_message_names_adzuna(self) -> None:
+        """Error message must name the source that needs credentials."""
+        _stdout, stderr, _code = _run_jobs_cli(
+            ["--sources", "adzuna"],
+            list_plugins_return=[_make_credentialed_info("adzuna")],
+        )
+        assert "adzuna" in stderr
+
+    def test_error_message_mentions_credentials_flag(self) -> None:
+        """Error message must mention ``--credentials`` so user knows the fix."""
+        _stdout, stderr, _code = _run_jobs_cli(
+            ["--sources", "adzuna"],
+            list_plugins_return=[_make_credentialed_info("adzuna")],
+        )
+        assert "--credentials" in stderr
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — mixed sources, no --credentials → names only adzuna (not himalayas)
+# ---------------------------------------------------------------------------
+
+
+class TestMixedSourcesNoCredsError:
+    """Mixed no-auth + credentialed sources without --credentials."""
+
+    def test_exits_nonzero(self) -> None:
+        """Exit code must be 2 when a credentialed source is selected."""
+        _stdout, _stderr, code = _run_jobs_cli(
+            ["--sources", "himalayas,adzuna"],
+            list_plugins_return=[
+                _make_noauth_info("himalayas"),
+                _make_credentialed_info("adzuna"),
+            ],
+        )
+        assert code == 2
+
+    def test_error_names_adzuna_only(self) -> None:
+        """Error message must name adzuna but not himalayas."""
+        _stdout, stderr, _code = _run_jobs_cli(
+            ["--sources", "himalayas,adzuna"],
+            list_plugins_return=[
+                _make_noauth_info("himalayas"),
+                _make_credentialed_info("adzuna"),
+            ],
+        )
+        assert "adzuna" in stderr
+        assert "himalayas" not in stderr
+
+    def test_error_suggests_exclude_sources(self) -> None:
+        """Error message must mention --exclude-sources as a remedy."""
+        _stdout, stderr, _code = _run_jobs_cli(
+            ["--sources", "himalayas,adzuna"],
+            list_plugins_return=[
+                _make_noauth_info("himalayas"),
+                _make_credentialed_info("adzuna"),
+            ],
+        )
+        assert "--exclude-sources" in stderr
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — no-auth source + --credentials supplied → back-compat
+# ---------------------------------------------------------------------------
+
+
+class TestCredsSuppliedNoAuthSource:
+    """Supplying --credentials for a no-auth-only run must not break."""
+
+    def test_creds_file_for_noauth_source_exits_zero(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """Back-compat: supplying an empty credentials file must succeed."""
+        empty_creds = tmp_path / "empty_creds.json"  # type: ignore[operator]
+        empty_creds.write_text(json.dumps({"schema_version": "1.0", "plugins": {}}))
+
+        _stdout, _stderr, code = _run_jobs_cli(
+            [
+                "--sources",
+                "stub_always",
+                "--credentials",
+                str(empty_creds),
+                "--dry-run",
+                "--format",
+                "json",
+            ],
+            list_plugins_return=[_make_noauth_info("stub_always")],
+            plugin_classes={AlwaysQueryPlugin.SOURCE: AlwaysQueryPlugin},
+        )
+        assert code == 0
+
+    def test_creds_file_for_noauth_source_emits_envelope(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """Envelope is emitted normally when credentials file is supplied."""
+        empty_creds = tmp_path / "empty_creds.json"  # type: ignore[operator]
+        empty_creds.write_text(json.dumps({"schema_version": "1.0", "plugins": {}}))
+
+        stdout, _stderr, code = _run_jobs_cli(
+            [
+                "--sources",
+                "stub_always",
+                "--credentials",
+                str(empty_creds),
+                "--dry-run",
+                "--format",
+                "json",
+            ],
+            list_plugins_return=[_make_noauth_info("stub_always")],
+            plugin_classes={AlwaysQueryPlugin.SOURCE: AlwaysQueryPlugin},
+        )
+        assert code == 0
+        data = json.loads(stdout)
+        assert "schema_version" in data
+
+
+# ---------------------------------------------------------------------------
+# Existing path — credentialed run with --credentials supplied
+# ---------------------------------------------------------------------------
+
+
+class TestCredsSuppliedCredentialedSource:
+    """``--credentials`` supplied for a credentialed source must succeed."""
+
+    def test_credentialed_run_with_creds_file_exits_zero(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """When --credentials is supplied with real keys, run succeeds."""
+        creds_file = tmp_path / "creds.json"  # type: ignore[operator]
+        creds_file.write_text(
+            json.dumps(
+                {
+                    "schema_version": "1.0",
+                    "plugins": {
+                        "stub_always": {
+                            "app_id": "dummy-id",
+                            "api_key": "dummy-key",
+                        }
+                    },
+                }
+            )
+        )
+
+        _stdout, _stderr, code = _run_jobs_cli(
+            [
+                "--sources",
+                "stub_always",
+                "--credentials",
+                str(creds_file),
+                "--dry-run",
+                "--format",
+                "json",
+            ],
+            list_plugins_return=[_make_noauth_info("stub_always")],
+            plugin_classes={AlwaysQueryPlugin.SOURCE: AlwaysQueryPlugin},
+        )
+        assert code == 0


### PR DESCRIPTION
## Summary

- Drop `required=True` from the `--credentials` argparse argument so `job-aggregator jobs` can be run without a credentials file when all selected sources are no-auth
- Add `_resolve_selected_sources()` helper that uses `list_plugins()` + `PluginInfo.requires_credentials` to determine whether any selected source needs credentials
- When `--credentials` is omitted and a credentialed source is selected, exit 2 with an explicit message naming the offending sources and suggesting `--exclude-sources` or a credentials file
- Add 11 new tests in `tests/cli/test_jobs_cli.py` covering all four scenarios (no-auth only, credentialed-only error, mixed error, back-compat with creds file supplied)
- Update README Quickstart and CHANGELOG

## Test plan

- [x] `uv run pytest` — 840 passed, 6 skipped (up from 829 baseline)
- [x] `uv run ruff check .` — no issues
- [x] `uv run ruff format --check .` — all formatted
- [x] `uv run mypy src/ tests/` — no issues in 92 source files
- [x] `uv run deptry .` — no dependency issues

Closes #50

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*