### PR TITLE
docs: fix README quickstart to exclude credentialed sources (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,5 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `jobs` subcommand no longer requires `--credentials` when all selected sources are no-auth. When some selected sources do require credentials, the error names them explicitly instead of the generic argparse message. (#50)
+- README quickstart example now explicitly excludes credentialed sources (`adzuna,jooble,jsearch,usajobs`) so the bare copy-paste invocation runs out of the box without a credentials file. The previous example was inconsistent with the new `--credentials` guard introduced in #51. (#52)
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -19,8 +19,12 @@ pip install job-aggregator
 # List available plugins and whether credentials are configured
 job-aggregator sources
 
-# Fetch listings from no-auth sources and enrich with full descriptions
+# Fetch listings from no-auth sources and enrich with full descriptions.
+# Run `job-aggregator sources` to see which plugins need credentials —
+# the example below excludes the four credentialed plugins so it runs
+# out of the box without a credentials file.
 job-aggregator jobs --query "python developer" --hours 24 \
+  --exclude-sources adzuna,jooble,jsearch,usajobs \
   | job-aggregator hydrate > full.jsonl
 ```
 


### PR DESCRIPTION
## Summary

Fixes the README quickstart so the bare copy-paste example actually works against the published wheel. After #51's `--credentials` guard, the previous example (`jobs --query ... --hours 24` with no source filter) errored out because the default source set includes 4 credentialed plugins.

Closes #52

## Changes

- **`README.md`**: no-auth quickstart example now passes `--exclude-sources adzuna,jooble,jsearch,usajobs`. Added a comment pointing users to `job-aggregator sources` so they can discover the current credentialed-vs-no-auth split themselves rather than relying on the hardcoded list staying current forever.
- **`CHANGELOG.md`**: entry under `[Unreleased] / Fixed` referencing #52.

Docs-only — no code changes.

## Test plan

- [x] Built `0.1.0` wheel from current main (`uv build --wheel`)
- [x] Force-reinstalled into scratch venv at `I:/tmp/ja-smoke/.ja-test/`
- [x] Ran the **new** README quickstart command end-to-end against live no-auth APIs
- [x] Result: exit 0, 221 stdout lines (envelope + 220 hydrated records), 6 no-auth sources used, 0 failed

## Why not change CLI behavior instead?

Considered (silently skip credentialed sources when `--credentials` is omitted) and rejected — would contradict #51's explicit-error UX intent. If reconsidered, it should be its own issue.

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*