### PR TITLE
fix: implement --hours post-fetch filter in orchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `--hours` / `SearchParams.hours` filter is now implemented: records with parseable `posted_at` older than the lookback cutoff are excluded from output. Records with `null` or unparseable `posted_at` are retained (soft-filter policy). `request_summary.records_filtered_by_hours` reports the drop count. (#54)
 - `jobs` subcommand no longer requires `--credentials` when all selected sources are no-auth. When some selected sources do require credentials, the error names them explicitly instead of the generic argparse message. (#50)
 - README quickstart example now explicitly excludes credentialed sources (`adzuna,jooble,jsearch,usajobs`) so the bare copy-paste invocation runs out of the box without a credentials file. The previous example was inconsistent with the new `--credentials` guard introduced in #51. (#52)
 

--- a/docs/output_schema.md
+++ b/docs/output_schema.md
@@ -58,12 +58,49 @@ envelope with `"jobs": []`; every subsequent line is a single record.
 | `command` | string | `"jobs"` or `"hydrate"`, depending on which command produced the output. |
 | `sources_used` | array of strings | Plugin keys that returned at least one result. |
 | `sources_failed` | array of strings | Plugin keys that raised an error; their listings are absent. |
-| `request_summary` | object | The search parameters used for this run. |
+| `request_summary` | object | The search parameters used for this run. See [request_summary fields](#request_summary-fields) below. |
 | `jobs` | array | Present in JSON format only; empty array in JSONL envelope line. |
 
 `hydrate` propagates the envelope from its input, updating `command` to
 `"hydrate"` and `generated_at` to the current time. The original
 `request_summary` is preserved unchanged.
+
+### `request_summary` fields
+
+| Field | Type | Description |
+|---|---|---|
+| `hours` | integer | Lookback window in hours as specified by `--hours` (default 168). |
+| `query` | string \| null | Free-text search query, or `null` if none was given. |
+| `location` | string \| null | Location hint, or `null` if none was given. |
+| `country` | string \| null | ISO 3166-1 alpha-2 country code, or `null`. |
+| `sources` | array of strings | Plugin keys that were enabled for this run (before any per-source errors). |
+| `records_filtered_by_hours` | integer | Count of records dropped because their `posted_at` was older than the `hours` cutoff. See [Hours Filter Semantics](#hours-filter-semantics) below. |
+
+### Hours Filter Semantics
+
+The `--hours` flag (default 168, i.e. one week) controls a post-fetch
+filter applied by the orchestrator after all plugin records have been
+normalised and before deduplication.
+
+**Cutoff computation:** `cutoff = now_utc - timedelta(hours=hours)`.
+
+**Filter policy per record:**
+
+| `posted_at` value | Action |
+|---|---|
+| Parseable RFC 3339 UTC timestamp, `>= cutoff` | **Kept** |
+| Parseable RFC 3339 UTC timestamp, `< cutoff` | **Dropped** |
+| `null` (absent or `None`) | **Kept** — soft-filter policy |
+| Non-empty but unparseable string | **Kept** — soft-filter policy |
+
+**Soft-filter policy (null / unparseable):** Records whose `posted_at`
+cannot be parsed are retained rather than dropped. This preserves recall
+for sources that frequently omit `posted_at` (e.g. Remotive). The
+trade-off is documented here so consumers can decide whether to apply
+their own strict filter downstream.
+
+`records_filtered_by_hours` counts only **dropped** records.  Kept
+null/unparseable records do **not** increment this counter.
 
 ---
 

--- a/src/job_aggregator/orchestrator.py
+++ b/src/job_aggregator/orchestrator.py
@@ -22,7 +22,9 @@ Public API:
 from __future__ import annotations
 
 import json
+import logging
 import sys
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from urllib.parse import urlparse, urlunparse
 
@@ -117,6 +119,88 @@ def _build_query_applied(
         Dict mapping plugin key → ``bool``.
     """
     return {key: cls.ACCEPTS_QUERY == "always" for key, cls in plugin_classes.items()}
+
+
+# ---------------------------------------------------------------------------
+# Hours-filter helpers
+# ---------------------------------------------------------------------------
+
+_UTC = UTC
+
+_log = logging.getLogger(__name__)
+
+
+def _parse_posted_at(posted_at: str | None) -> datetime | None:
+    """Parse an RFC 3339 UTC timestamp string into a timezone-aware datetime.
+
+    Accepts the common ``Z``-suffixed form as well as explicit ``+00:00``.
+    Returns ``None`` for ``None`` input, empty strings, or any string that
+    cannot be parsed — callers treat ``None`` as "unknown".
+
+    Args:
+        posted_at: An RFC 3339 UTC timestamp string (e.g.
+            ``"2026-04-01T00:00:00Z"``), or ``None`` / empty string.
+
+    Returns:
+        A timezone-aware :class:`~datetime.datetime` in UTC, or ``None``
+        if the value is absent or not parseable.
+    """
+    if not posted_at:
+        return None
+    # Normalise the trailing 'Z' to '+00:00' so fromisoformat accepts it
+    # on Python 3.10 and earlier (fromisoformat supports 'Z' from 3.11+).
+    normalised = posted_at.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(normalised)
+        # Ensure the result is timezone-aware; treat naive as UTC.
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=_UTC)
+        return dt
+    except (ValueError, OverflowError):
+        return None
+
+
+def _apply_hours_filter(
+    records: list[Any],
+    hours: int,
+    source_key: str,
+) -> tuple[list[Any], int]:
+    """Filter *records* to those within the *hours* lookback window.
+
+    Soft-filter policy: records with ``None`` or unparseable ``posted_at``
+    are **kept**; only records with a parseable timestamp strictly older
+    than ``cutoff`` are dropped.
+
+    Args:
+        records: Normalised :class:`~job_aggregator.schema.JobRecord` list
+            from a single source.
+        hours: Lookback window in hours.  ``cutoff = now_utc - hours``.
+        source_key: Plugin key used only for the summary log line.
+
+    Returns:
+        A 2-tuple of ``(kept_records, drop_count)`` where *drop_count* is
+        the number of records that were dropped.
+    """
+    cutoff = datetime.now(_UTC) - timedelta(hours=hours)
+    kept: list[Any] = []
+    dropped = 0
+    for record in records:
+        dt = _parse_posted_at(record.get("posted_at"))
+        if dt is None:
+            # Null / unparseable → keep (soft-filter policy)
+            kept.append(record)
+        elif dt >= cutoff:
+            kept.append(record)
+        else:
+            dropped += 1
+    if dropped:
+        _log.info(
+            "source %r: dropped %d record(s) older than %d-hour cutoff",
+            source_key,
+            dropped,
+            hours,
+        )
+    return kept, dropped
 
 
 # ---------------------------------------------------------------------------
@@ -288,28 +372,39 @@ def run_jobs(
     records: list[JobRecord] = []
     sources_used: list[str] = []
     sources_failed: list[str] = []
+    total_filtered_by_hours: int = 0
 
     for key, cls in enabled.items():
         source_creds: dict[str, Any] = creds.get(key, {})
         try:
             plugin = _instantiate_plugin(cls, source_creds, search_params)
-            source_had_records = False
+            # Collect all normalised records for this source before dedup
+            # so the hours filter sees the full set (not limit-capped).
+            source_records: list[JobRecord] = []
             for page in plugin.pages():
                 for raw in page:
                     normalised_raw = plugin.normalise(raw)
                     record = normalize(normalised_raw)
-                    # Dedup
-                    dedup_key = (record["source"], record["source_id"])
-                    if dedup_key in seen:
-                        continue
-                    seen.add(dedup_key)
-                    records.append(record)
-                    source_had_records = True
-                    # Respect limit
-                    if limit > 0 and len(records) >= limit:
-                        break
+                    source_records.append(record)
+
+            # ----------------------------------------------------------
+            # Apply hours filter (post-fetch, per-source)
+            # ----------------------------------------------------------
+            source_records, dropped = _apply_hours_filter(source_records, hours, key)
+            total_filtered_by_hours += dropped
+
+            # Dedup + limit
+            source_had_records = False
+            for record in source_records:
+                dedup_key = (record["source"], record["source_id"])
+                if dedup_key in seen:
+                    continue
+                seen.add(dedup_key)
+                records.append(record)
+                source_had_records = True
                 if limit > 0 and len(records) >= limit:
                     break
+
             if not sources_used or key not in sources_used:
                 sources_used.append(key)
             _ = source_had_records  # suppress unused warning
@@ -327,7 +422,12 @@ def run_jobs(
             break
 
     # ------------------------------------------------------------------
-    # 8. Serialise and return
+    # 8. Augment request_summary with hours-filter observability count
+    # ------------------------------------------------------------------
+    request_summary["records_filtered_by_hours"] = total_filtered_by_hours
+
+    # ------------------------------------------------------------------
+    # 9. Serialise and return
     # ------------------------------------------------------------------
     return _serialise(
         jobs=records,

--- a/tests/fixtures/plugins/stub_plugins.py
+++ b/tests/fixtures/plugins/stub_plugins.py
@@ -12,10 +12,14 @@ ignored; ``search`` is captured on ``last_search`` for test assertions.
 from __future__ import annotations
 
 from collections.abc import Iterator
+from datetime import UTC, datetime
 from typing import Any, ClassVar, Literal
 
 from job_aggregator.base import JobSource
 from job_aggregator.schema import SearchParams
+
+#: Sentinel that tells ``_make_record`` to generate a recent timestamp.
+_RECENT: str = "__recent__"
 
 
 def _make_record(
@@ -24,9 +28,13 @@ def _make_record(
     *,
     title: str | None = None,
     url: str = "",
-    posted_at: str | None = "2026-04-01T00:00:00Z",
+    posted_at: str | None = _RECENT,
 ) -> dict[str, Any]:
     """Return a minimal normalise()-compatible dict for stub plugins.
+
+    The default ``posted_at`` is the current UTC time (always within any
+    reasonable lookback window).  Pass an explicit ISO 8601 string, an
+    empty string, or ``None`` to override.
 
     Args:
         source: The SOURCE key of the stub plugin.
@@ -34,11 +42,15 @@ def _make_record(
         title: Optional title override; defaults to
             ``"Stub Job <source>-<idx>"``.
         url: Optional URL override.
-        posted_at: Optional posted_at override.
+        posted_at: Optional posted_at override.  Use ``None`` for a
+            null timestamp, an ISO 8601 string for a specific time, or
+            leave unset to receive the current UTC time.
 
     Returns:
         A dict conforming to the ``normalise()`` output contract.
     """
+    if posted_at is _RECENT:
+        posted_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     return {
         "source": source,
         "source_id": f"{source}-{idx}",

--- a/tests/test_hours_filter.py
+++ b/tests/test_hours_filter.py
@@ -1,0 +1,481 @@
+"""Tests for the --hours post-fetch filter in the orchestrator.
+
+Covers acceptance criteria from issue #54:
+- Past-cutoff records are excluded.
+- Within-cutoff records are kept.
+- Null posted_at records are kept (soft-filter policy).
+- Unparseable posted_at records are kept (soft-filter policy).
+- request_summary.records_filtered_by_hours is populated.
+- Integration test: mocked plugin output spanning the cutoff boundary.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any, ClassVar, Literal
+
+import pytest
+
+from job_aggregator.base import JobSource
+from job_aggregator.schema import SearchParams
+from tests.fixtures.plugins.stub_plugins import _make_record
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_UTC = UTC
+
+
+def _utc_now() -> datetime:
+    """Return the current UTC time as a timezone-aware datetime.
+
+    Returns:
+        Current UTC datetime with tzinfo set.
+    """
+    return datetime.now(_UTC)
+
+
+def _iso(dt: datetime) -> str:
+    """Format *dt* as an RFC 3339 UTC string.
+
+    Args:
+        dt: A timezone-aware UTC datetime.
+
+    Returns:
+        ISO 8601 string with 'Z' suffix.
+    """
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _make_hours_record(
+    source: str,
+    idx: int,
+    *,
+    posted_at: str | None,
+) -> dict[str, Any]:
+    """Return a normalise()-compatible record with the given posted_at.
+
+    Args:
+        source: Plugin SOURCE key.
+        idx: Unique record index.
+        posted_at: ISO 8601 timestamp string, or None.
+
+    Returns:
+        A minimal dict conforming to the normalise() output contract.
+    """
+    return _make_record(source, idx, posted_at=posted_at)
+
+
+def _import_run_jobs() -> Any:
+    """Import run_jobs from the orchestrator.
+
+    Returns:
+        The ``run_jobs`` callable.
+    """
+    from job_aggregator.orchestrator import run_jobs
+
+    return run_jobs
+
+
+# ---------------------------------------------------------------------------
+# Stub plugin factory for hours-filter tests
+# ---------------------------------------------------------------------------
+
+
+def _make_hours_plugin(
+    records: list[dict[str, Any]],
+) -> type[JobSource]:
+    """Create a stub plugin class that yields *records* in a single page.
+
+    Args:
+        records: The list of pre-normalised dicts to yield.
+
+    Returns:
+        A new ``JobSource`` subclass that emits exactly *records*.
+    """
+
+    class _HoursStubPlugin(JobSource):
+        """Stub plugin for hours-filter tests."""
+
+        SOURCE: ClassVar[str] = "stub_hours"
+        DISPLAY_NAME: ClassVar[str] = "Stub Hours"
+        DESCRIPTION: ClassVar[str] = "Hours-filter stub."
+        HOME_URL: ClassVar[str] = "https://example.com/hours"
+        GEO_SCOPE: ClassVar[
+            Literal[
+                "global",
+                "global-by-country",
+                "remote-only",
+                "federal-us",
+                "regional",
+                "unknown",
+            ]
+        ] = "global"
+        ACCEPTS_QUERY: ClassVar[Literal["always", "partial", "never"]] = "always"
+        ACCEPTS_LOCATION: ClassVar[bool] = False
+        ACCEPTS_COUNTRY: ClassVar[bool] = False
+        RATE_LIMIT_NOTES: ClassVar[str] = "No limit."
+        REQUIRED_SEARCH_FIELDS: ClassVar[tuple[str, ...]] = ()
+
+        _records: list[dict[str, Any]] = records
+
+        def __init__(
+            self,
+            *,
+            credentials: dict[str, Any] | None = None,
+            search: SearchParams | None = None,
+        ) -> None:
+            """Initialise; ignore credentials and search.
+
+            Args:
+                credentials: Ignored.
+                search: Ignored.
+            """
+            super().__init__(credentials=credentials, search=search)
+
+        @classmethod
+        def settings_schema(cls) -> dict[str, Any]:
+            """Return empty schema.
+
+            Returns:
+                Empty dict.
+            """
+            return {}
+
+        def pages(self) -> Iterator[list[dict[str, Any]]]:
+            """Yield one page containing all pre-set records.
+
+            Yields:
+                A single list of normalise()-compatible dicts.
+            """
+            yield list(self._records)
+
+        def normalise(self, raw: dict[str, Any]) -> dict[str, Any]:
+            """Return raw unchanged.
+
+            Args:
+                raw: The dict yielded by ``pages()``.
+
+            Returns:
+                The same dict, unchanged.
+            """
+            return raw
+
+    return _HoursStubPlugin
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — hours filter behaviour per record
+# ---------------------------------------------------------------------------
+
+
+class TestHoursFilterDropsPastCutoff:
+    """Records with parseable posted_at older than cutoff must be dropped."""
+
+    def test_record_older_than_cutoff_is_excluded(self) -> None:
+        """A record posted 25 hours ago must not appear with --hours 24."""
+        run_jobs = _import_run_jobs()
+        now = _utc_now()
+        old_posted_at = _iso(now - timedelta(hours=25))
+        plugin_cls = _make_hours_plugin(
+            [_make_hours_record("stub_hours", 1, posted_at=old_posted_at)]
+        )
+        result = run_jobs(
+            plugin_classes={plugin_cls.SOURCE: plugin_cls},
+            credentials={},
+            format="json",
+            hours=24,
+            generated_at="2026-01-01T00:00:00Z",
+        )
+        data = json.loads(result)
+        assert len(data["jobs"]) == 0
+
+    def test_record_exactly_at_cutoff_boundary_is_kept(self) -> None:
+        """A record posted exactly at the cutoff must be kept (>= semantics).
+
+        The filter drops strictly-before-cutoff records; at-cutoff is kept.
+        """
+        run_jobs = _import_run_jobs()
+        now = _utc_now()
+        # Slightly before now so the cutoff is definitely in the past relative
+        # to when the filter runs — use 24h - 1s so it lands right on boundary.
+        at_cutoff = _iso(now - timedelta(hours=24) + timedelta(seconds=1))
+        plugin_cls = _make_hours_plugin([_make_hours_record("stub_hours", 1, posted_at=at_cutoff)])
+        result = run_jobs(
+            plugin_classes={plugin_cls.SOURCE: plugin_cls},
+            credentials={},
+            format="json",
+            hours=24,
+            generated_at="2026-01-01T00:00:00Z",
+        )
+        data = json.loads(result)
+        assert len(data["jobs"]) == 1
+
+
+class TestHoursFilterKeepsWithinCutoff:
+    """Records with parseable posted_at within the window must be kept."""
+
+    def test_recent_record_is_kept(self) -> None:
+        """A record posted 1 hour ago must appear with --hours 24."""
+        run_jobs = _import_run_jobs()
+        now = _utc_now()
+        recent = _iso(now - timedelta(hours=1))
+        plugin_cls = _make_hours_plugin([_make_hours_record("stub_hours", 1, posted_at=recent)])
+        result = run_jobs(
+            plugin_classes={plugin_cls.SOURCE: plugin_cls},
+            credentials={},
+            format="json",
+            hours=24,
+            generated_at="2026-01-01T00:00:00Z",
+        )
+        data = json.loads(result)
+        assert len(data["jobs"]) == 1
+
+
+class TestHoursFilterSoftPolicyNullPostedAt:
+    """Records with null posted_at must be retained (soft-filter policy)."""
+
+    def test_null_posted_at_is_kept(self) -> None:
+        """A record with posted_at=None must not be dropped by the filter."""
+        run_jobs = _import_run_jobs()
+        plugin_cls = _make_hours_plugin([_make_hours_record("stub_hours", 1, posted_at=None)])
+        result = run_jobs(
+            plugin_classes={plugin_cls.SOURCE: plugin_cls},
+            credentials={},
+            format="json",
+            hours=24,
+            generated_at="2026-01-01T00:00:00Z",
+        )
+        data = json.loads(result)
+        assert len(data["jobs"]) == 1
+
+
+class TestHoursFilterSoftPolicyUnparseablePostedAt:
+    """Records with unparseable posted_at must be retained (soft policy)."""
+
+    def test_unparseable_posted_at_is_kept(self) -> None:
+        """A record with an invalid timestamp string must not be dropped."""
+        run_jobs = _import_run_jobs()
+        plugin_cls = _make_hours_plugin(
+            [
+                _make_hours_record(
+                    "stub_hours",
+                    1,
+                    posted_at="not-a-date",
+                )
+            ]
+        )
+        result = run_jobs(
+            plugin_classes={plugin_cls.SOURCE: plugin_cls},
+            credentials={},
+            format="json",
+            hours=24,
+            generated_at="2026-01-01T00:00:00Z",
+        )
+        data = json.loads(result)
+        assert len(data["jobs"]) == 1
+
+    def test_empty_string_posted_at_is_kept(self) -> None:
+        """A record with posted_at='' must not be dropped by the filter."""
+        run_jobs = _import_run_jobs()
+        plugin_cls = _make_hours_plugin([_make_hours_record("stub_hours", 1, posted_at="")])
+        result = run_jobs(
+            plugin_classes={plugin_cls.SOURCE: plugin_cls},
+            credentials={},
+            format="json",
+            hours=24,
+            generated_at="2026-01-01T00:00:00Z",
+        )
+        data = json.loads(result)
+        assert len(data["jobs"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# request_summary.records_filtered_by_hours
+# ---------------------------------------------------------------------------
+
+
+class TestRecordsFilteredByHoursSummary:
+    """request_summary must include records_filtered_by_hours count."""
+
+    def test_summary_field_zero_when_nothing_filtered(self) -> None:
+        """records_filtered_by_hours must be 0 when all records are recent."""
+        run_jobs = _import_run_jobs()
+        now = _utc_now()
+        recent = _iso(now - timedelta(hours=1))
+        plugin_cls = _make_hours_plugin([_make_hours_record("stub_hours", 1, posted_at=recent)])
+        result = run_jobs(
+            plugin_classes={plugin_cls.SOURCE: plugin_cls},
+            credentials={},
+            format="json",
+            hours=24,
+            generated_at="2026-01-01T00:00:00Z",
+        )
+        data = json.loads(result)
+        assert data["request_summary"]["records_filtered_by_hours"] == 0
+
+    def test_summary_field_counts_dropped_records(self) -> None:
+        """records_filtered_by_hours must count the dropped past-cutoff records."""
+        run_jobs = _import_run_jobs()
+        now = _utc_now()
+        old = _iso(now - timedelta(hours=50))
+        recent = _iso(now - timedelta(hours=1))
+        plugin_cls = _make_hours_plugin(
+            [
+                _make_hours_record("stub_hours", 1, posted_at=old),
+                _make_hours_record("stub_hours", 2, posted_at=old),
+                _make_hours_record("stub_hours", 3, posted_at=recent),
+            ]
+        )
+        result = run_jobs(
+            plugin_classes={plugin_cls.SOURCE: plugin_cls},
+            credentials={},
+            format="json",
+            hours=24,
+            generated_at="2026-01-01T00:00:00Z",
+        )
+        data = json.loads(result)
+        assert data["request_summary"]["records_filtered_by_hours"] == 2
+        assert len(data["jobs"]) == 1
+
+    def test_summary_field_present_in_jsonl_envelope(self) -> None:
+        """records_filtered_by_hours must also appear in the JSONL envelope."""
+        run_jobs = _import_run_jobs()
+        now = _utc_now()
+        old = _iso(now - timedelta(hours=50))
+        plugin_cls = _make_hours_plugin([_make_hours_record("stub_hours", 1, posted_at=old)])
+        result = run_jobs(
+            plugin_classes={plugin_cls.SOURCE: plugin_cls},
+            credentials={},
+            format="jsonl",
+            hours=24,
+            generated_at="2026-01-01T00:00:00Z",
+        )
+        envelope = json.loads(result.strip().splitlines()[0])
+        assert "records_filtered_by_hours" in envelope["request_summary"]
+        assert envelope["request_summary"]["records_filtered_by_hours"] == 1
+
+    def test_null_records_not_counted_in_filtered(self) -> None:
+        """Kept null-posted_at records must not increment the filter count."""
+        run_jobs = _import_run_jobs()
+        plugin_cls = _make_hours_plugin([_make_hours_record("stub_hours", 1, posted_at=None)])
+        result = run_jobs(
+            plugin_classes={plugin_cls.SOURCE: plugin_cls},
+            credentials={},
+            format="json",
+            hours=24,
+            generated_at="2026-01-01T00:00:00Z",
+        )
+        data = json.loads(result)
+        assert data["request_summary"]["records_filtered_by_hours"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration test: mocked plugin spanning the cutoff boundary
+# ---------------------------------------------------------------------------
+
+
+class TestHoursFilterIntegration:
+    """End-to-end orchestrator run with records spanning the cutoff."""
+
+    def test_mixed_records_only_recent_emitted(self) -> None:
+        """Only records within the hours window are emitted end-to-end.
+
+        3 records: 1 recent, 1 old, 1 null posted_at.
+        Expected outcome: 2 emitted (recent + null), 1 filtered.
+        """
+        run_jobs = _import_run_jobs()
+        now = _utc_now()
+        recent_ts = _iso(now - timedelta(hours=2))
+        old_ts = _iso(now - timedelta(hours=48))
+
+        plugin_cls = _make_hours_plugin(
+            [
+                _make_hours_record("stub_hours", 1, posted_at=recent_ts),
+                _make_hours_record("stub_hours", 2, posted_at=old_ts),
+                _make_hours_record("stub_hours", 3, posted_at=None),
+            ]
+        )
+        result = run_jobs(
+            plugin_classes={plugin_cls.SOURCE: plugin_cls},
+            credentials={},
+            format="json",
+            hours=24,
+        )
+        data = json.loads(result)
+        assert len(data["jobs"]) == 2
+        assert data["request_summary"]["records_filtered_by_hours"] == 1
+        emitted_ids = {j["source_id"] for j in data["jobs"]}
+        assert "stub_hours-1" in emitted_ids  # recent → kept
+        assert "stub_hours-2" not in emitted_ids  # old → dropped
+        assert "stub_hours-3" in emitted_ids  # null → kept
+
+    def test_all_recent_no_records_dropped(self) -> None:
+        """All-recent input: zero records filtered, all jobs emitted."""
+        run_jobs = _import_run_jobs()
+        now = _utc_now()
+        plugin_cls = _make_hours_plugin(
+            [
+                _make_hours_record("stub_hours", i, posted_at=_iso(now - timedelta(hours=i)))
+                for i in range(1, 5)
+            ]
+        )
+        result = run_jobs(
+            plugin_classes={plugin_cls.SOURCE: plugin_cls},
+            credentials={},
+            format="json",
+            hours=168,
+        )
+        data = json.loads(result)
+        assert len(data["jobs"]) == 4
+        assert data["request_summary"]["records_filtered_by_hours"] == 0
+
+    def test_all_old_records_none_emitted(self) -> None:
+        """All-old input: all records filtered, jobs array is empty."""
+        run_jobs = _import_run_jobs()
+        now = _utc_now()
+        old_ts = _iso(now - timedelta(hours=200))
+        plugin_cls = _make_hours_plugin(
+            [
+                _make_hours_record("stub_hours", 1, posted_at=old_ts),
+                _make_hours_record("stub_hours", 2, posted_at=old_ts),
+            ]
+        )
+        result = run_jobs(
+            plugin_classes={plugin_cls.SOURCE: plugin_cls},
+            credentials={},
+            format="json",
+            hours=24,
+        )
+        data = json.loads(result)
+        assert len(data["jobs"]) == 0
+        assert data["request_summary"]["records_filtered_by_hours"] == 2
+
+    @pytest.mark.parametrize("fmt", ["json", "jsonl"])
+    def test_filter_count_consistent_across_formats(self, fmt: str) -> None:
+        """records_filtered_by_hours must match for both output formats."""
+        run_jobs = _import_run_jobs()
+        now = _utc_now()
+        old_ts = _iso(now - timedelta(hours=50))
+        recent_ts = _iso(now - timedelta(hours=1))
+        plugin_cls = _make_hours_plugin(
+            [
+                _make_hours_record("stub_hours", 1, posted_at=old_ts),
+                _make_hours_record("stub_hours", 2, posted_at=recent_ts),
+            ]
+        )
+        result = run_jobs(
+            plugin_classes={plugin_cls.SOURCE: plugin_cls},
+            credentials={},
+            format=fmt,
+            hours=24,
+        )
+        if fmt == "json":
+            data = json.loads(result)
+            summary = data["request_summary"]
+        else:
+            summary = json.loads(result.strip().splitlines()[0])["request_summary"]
+        assert summary["records_filtered_by_hours"] == 1


### PR DESCRIPTION
## Summary

- Implements the `--hours` lookback window in the orchestrator (post-fetch filter): records with `posted_at` older than `now_utc - hours` are dropped; records with parseable `posted_at` within the window are kept; records with null/unparseable `posted_at` are kept (soft-filter default).
- Adds `request_summary.records_filtered_by_hours` for observability.
- Documents filter semantics + null-retention policy in `docs/output_schema.md`.

Fixes #54.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy src/ tests/ scripts/` clean
- [x] `pytest`: 855 passed, 6 skipped (baseline 840 → +15 new tests in `tests/test_hours_filter.py`; same 6 credential-gated skips as main)
- [ ] Post-merge wheel smoke: `--hours 1` returns strictly fewer records than `--hours 168` against live APIs (per issue AC)

## Notes

- Soft-filter null policy selected per issue body recommendation; a future `--hours-strict` toggle remains out of scope.
- Plugin-specific push-down (JSearch `date_posted`, Adzuna `max_days_old`) is out of scope per issue.

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*