### PR TITLE
chore: sweep cbeaulieu-gt/ → glitchwerks/ refs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 # Trusted publishing via OIDC — no API tokens stored anywhere.
 # Prerequisites:
 #   1. Register the project on PyPI + TestPyPI with trusted publisher:
-#      repo = cbeaulieu-gt/job-api-aggregator, workflow = publish.yml
+#      repo = glitchwerks/job-api-aggregator, workflow = publish.yml
 #   2. Create GitHub environments "testpypi" and "pypi" (optional but
 #      strongly recommended — adds manual approval gate for production).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ source plugins, normalized output, no scoring or DB dependencies.
 ### Changed
 
 - Renamed project: distribution `job-aggregator` → `job-api-aggregator`; module `job_aggregator` → `job_api_aggregator`; repo `cbeaulieu-gt/job-aggregator` → `cbeaulieu-gt/job-api-aggregator`. (#59)
+- Transferred repo ownership: `cbeaulieu-gt/job-api-aggregator` → `glitchwerks/job-api-aggregator`. (#60)
 - Dropped `--ignore-vuln CVE-2026-3219` workaround from the `pip-audit` CI step; pip 26.1 (pypa/pip PR #13870, merged 2026-04-19) ships the fix, so the suppression is no longer needed. (#48)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Reusable job aggregation library: pluggable source plugins, normalized output, no scoring or DB dependencies.
 
 [![PyPI version](https://img.shields.io/pypi/v/job-api-aggregator)](https://pypi.org/project/job-api-aggregator/)
-[![CI](https://github.com/cbeaulieu-gt/job-api-aggregator/actions/workflows/ci.yml/badge.svg)](https://github.com/cbeaulieu-gt/job-api-aggregator/actions/workflows/ci.yml)
+[![CI](https://github.com/glitchwerks/job-api-aggregator/actions/workflows/ci.yml/badge.svg)](https://github.com/glitchwerks/job-api-aggregator/actions/workflows/ci.yml)
 [![Python versions](https://img.shields.io/pypi/pyversions/job-api-aggregator)](https://pypi.org/project/job-api-aggregator/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Please **do not** open a public GitHub issue for security vulnerabilities.
 
 Use GitHub's private vulnerability reporting instead:
 
-**[Report a vulnerability](https://github.com/cbeaulieu-gt/job-aggregator/security/advisories/new)**
+**[Report a vulnerability](https://github.com/glitchwerks/job-api-aggregator/security/advisories/new)**
 
 GitHub Security Advisories allow you to describe the issue privately. The maintainer
 will acknowledge receipt and work with you on a fix before any public disclosure.

--- a/docs/superpowers/plans/2026-04-23-job-aggregator-v1-execution-plan.md
+++ b/docs/superpowers/plans/2026-04-23-job-aggregator-v1-execution-plan.md
@@ -60,7 +60,7 @@ Resolve before Issue A is opened.
 - [x] **Adopt uv for Python tooling** — all venv management, installs, and tool invocation use `uv` (not `pip` / `venv` / `virtualenv`). Lock file `uv.lock` committed; `.python-version` committed; CI uses `astral-sh/setup-uv@v3`.
 - [x] **Decide LICENSE** — **Resolved: MIT.** `pyproject.toml` sets `license = "MIT"` (SPDX); `LICENSE` file holds standard MIT text (© 2026 Christopher Beaulieu).
 - [ ] **Decide GitHub repo visibility** (affects PyPI trusted-publishing OIDC trust setup and whether external consumers can `pip install git+…`).
-- [ ] **Configure PyPI trusted publishing** (pending LICENSE/name decisions above) — register the project on PyPI and TestPyPI with the `cbeaulieu-gt/job-api-aggregator` repo + `publish.yml` workflow as the trusted publisher. No API tokens stored anywhere.
+- [ ] **Configure PyPI trusted publishing** (pending LICENSE/name decisions above) — register the project on PyPI and TestPyPI with the `glitchwerks/job-api-aggregator` repo + `publish.yml` workflow as the trusted publisher. No API tokens stored anywhere.
 - [ ] **Reserve the GitHub Milestone** `job-api-aggregator v1` before opening any issues.
 - [ ] **All 10 plugins' credentials are on hand.** (User confirmed: yes.) Cassettes will be recorded for all 10 plugins — including those with no credential requirement, to capture real HTTP shape.
 
@@ -305,7 +305,7 @@ Issue A's final commit must produce an all-green CI run on an empty skeleton (no
 ## 9. Milestone scaffolding (copy-ready for issue creation)
 
 **Milestone:** `job-api-aggregator v1`
-**Repo:** `cbeaulieu-gt/job-api-aggregator`
+**Repo:** `glitchwerks/job-api-aggregator`
 **Description:** "Phase 1: ship standalone job-api-aggregator package v1.0 (per design spec 2026-04-23) through Code-complete gate + Ship gate. Phase 2 migration of job-matcher-pr is tracked separately."
 
 Target: **19 issues.** Create in this order (parents before children) so GitHub renders the dependency graph correctly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,11 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/cbeaulieu-gt/job-api-aggregator"
-Repository = "https://github.com/cbeaulieu-gt/job-api-aggregator"
-Issues = "https://github.com/cbeaulieu-gt/job-api-aggregator/issues"
-Changelog = "https://github.com/cbeaulieu-gt/job-api-aggregator/blob/main/CHANGELOG.md"
-Documentation = "https://github.com/cbeaulieu-gt/job-api-aggregator"
+Homepage = "https://github.com/glitchwerks/job-api-aggregator"
+Repository = "https://github.com/glitchwerks/job-api-aggregator"
+Issues = "https://github.com/glitchwerks/job-api-aggregator/issues"
+Changelog = "https://github.com/glitchwerks/job-api-aggregator/blob/main/CHANGELOG.md"
+Documentation = "https://github.com/glitchwerks/job-api-aggregator"
 
 [project.scripts]
 job-api-aggregator = "job_api_aggregator.cli.__main__:main"


### PR DESCRIPTION
## Summary

Repo was transferred from `cbeaulieu-gt` to `glitchwerks` after v1.0.0 was tagged. Updates every URL / repo-path reference to the new owner. Personal attribution (`@cbeaulieu-gt`, author name, email) is preserved.

Closes #60.

## Sweep

| File | Change |
|---|---|
| `pyproject.toml` | 5 `[project.urls]` values |
| `README.md` | CI badge URL (src + href) |
| `SECURITY.md` | Private advisory URL (also fixed stale `job-aggregator` path) |
| `.github/workflows/publish.yml` | Trusted-publisher comment block |
| `CHANGELOG.md` | New `### Changed` entry under [1.0.0] noting the transfer |
| `docs/superpowers/plans/2026-04-23-job-aggregator-v1-execution-plan.md` | 2 references |

## After merge

User chose to **retag v1.0.0 in place** (v1.0.0 never published to PyPI, so retag is non-breaking). Flow:

1. PyPI: register trusted publisher under `glitchwerks/job-api-aggregator` + `publish.yml` + `pypi` environment
2. Delete old `v1.0.0` tag (local + remote)
3. Retag `v1.0.0` on the merge commit
4. Push tag → `publish.yml` re-fires under the new owner

## Test plan

- [ ] CI green (no code changes; expect identical 855/6 result)
- [ ] No `cbeaulieu-gt` URL/path references remain (only `@cbeaulieu-gt` attribution + historical CHANGELOG entries)

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*