### PR TITLE
chore: drop misleading 'scraping' keyword from pyproject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Dropped `scraping` from PyPI keywords — `job-api-aggregator` aggregates job *APIs*, not scrapes; the keyword was misleading. (#62)
+
 ### Deprecated
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
 keywords = [
     "jobs",
     "job-aggregation",
-    "scraping",
     "cli",
     "plugins",
 ]


### PR DESCRIPTION
## Summary

Drop `scraping` from `[project] keywords` in `pyproject.toml`. The keyword was misleading — `job-api-aggregator` aggregates job APIs (Adzuna, Jooble, JSearch, USAJOBS, etc.) and does not scrape job boards.

Refs #62. The full keyword/classifier refresh proposed in #62 is held for the next feature release per user decision; this PR ships only the scraping removal because the misleading tag actively misdirected PyPI search.

## Changes

- `pyproject.toml`: remove `"scraping"` from `keywords`
- `CHANGELOG.md`: entry under `[Unreleased] ### Changed`

## Companion change (already applied)

13 GitHub repo topics set via API: `python`, `python-package`, `jobs`, `job-search`, `job-board`, `job-aggregator`, `api`, `api-aggregator`, `cli`, `plugins`, `pluggable`, `careers`, `recruiting`. See `gh api repos/glitchwerks/job-api-aggregator/topics`.

## Test plan

- [ ] CI green (no code changes; metadata only)

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*